### PR TITLE
Fix Redis credentials secret

### DIFF
--- a/chart/templates/externalredis-secret.yaml
+++ b/chart/templates/externalredis-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "carto.postgresql.secretName" . }}
+  name: {{ include "carto.redis.secretName" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
       {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -13,5 +13,5 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  db-password: {{ .Values.externalRedis.password | b64enc | quote }}
+  redis-password: {{ .Values.externalRedis.password | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

Redis secret template has a typo

**Benefits**

APIs cannot connect to Redis because of this

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

None