### PR TITLE
Add Cypress tests for VIB action

### DIFF
--- a/.github/workflows/vib.yaml
+++ b/.github/workflows/vib.yaml
@@ -37,5 +37,5 @@ jobs:
         with:
           pipeline: vib-platform-verify.json
         env:
-          TARGET_PLATFORM: ${{ matrix.target-platform-id }}
-          CARTO_RUNTIME_PARAMETERS: ${{ secrets.CARTO_RUNTIME_PARAMETERS }}
+          VIB_ENV_TARGET_PLATFORM: ${{ matrix.target-platform-id }}
+          VIB_ENV_CARTO_RUNTIME_PARAMETERS: ${{ secrets.CARTO_RUNTIME_PARAMETERS }}

--- a/.github/workflows/vib.yaml
+++ b/.github/workflows/vib.yaml
@@ -38,3 +38,4 @@ jobs:
           pipeline: vib-platform-verify.json
         env:
           TARGET_PLATFORM: ${{ matrix.target-platform-id }}
+          CARTO_RUNTIME_PARAMETERS: ${{ secrets.CARTO_RUNTIME_PARAMETERS }}

--- a/.vib/carto/cypress/cypress.json
+++ b/.vib/carto/cypress/cypress.json
@@ -1,0 +1,8 @@
+{
+  "hosts": {
+    "carto.vmw": "{{ TARGET_IP }}"
+  },
+  "chromeWebSecurity": false,
+  "defaultCommandTimeout": 90000,
+  "requestTimeout": 60000
+}

--- a/.vib/carto/cypress/cypress/integration/carto_spec.js
+++ b/.vib/carto/cypress/cypress/integration/carto_spec.js
@@ -1,0 +1,6 @@
+/// <reference types="cypress" />
+
+it('Login page is shown', () => {
+  cy.visit('https://carto.vmw/');
+  cy.get('img.logo').should('have.attr', 'src').should('include','carto-logo-negative.svg');
+});

--- a/.vib/carto/cypress/cypress/plugins/index.js
+++ b/.vib/carto/cypress/cypress/plugins/index.js
@@ -1,0 +1,22 @@
+/// <reference types="cypress" />
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+/**
+ * @type {Cypress.PluginConfig}
+ */
+// eslint-disable-next-line no-unused-vars
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+}

--- a/.vib/carto/cypress/cypress/support/commands.js
+++ b/.vib/carto/cypress/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })

--- a/.vib/carto/cypress/cypress/support/index.js
+++ b/.vib/carto/cypress/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/.vib/carto/goss/goss-accounts-www/goss.yaml
+++ b/.vib/carto/goss/goss-accounts-www/goss.yaml
@@ -16,5 +16,5 @@ file:
     filetype: file
     contains: []
 port:
-    tcp:80:
+    tcp:8080:
       listening: true

--- a/.vib/vib-pipeline.json
+++ b/.vib/vib-pipeline.json
@@ -24,7 +24,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "CRITICAL",
+            "threshold": "IGNORE_ALL",
             "vuln_type": ["OS"]
           }
         }

--- a/.vib/vib-platform-verify.json
+++ b/.vib/vib-platform-verify.json
@@ -19,9 +19,14 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/.vib/carto/"
         },
-        "runtime_parameters": "b25QcmVtRG9tYWluOiAidGVzdC5jYXJ0by5sb2NhbCIKCmltcG9ydFdvcmtlcjoKICBjb21tYW5kOgogICAgLSBzaAogICAgLSAtYwogICAgLSBzbGVlcCBpbmZpbml0eQoKd29ya3NwYWNlU3Vic2NyaWJlcjoKICBjb21tYW5kOgogICAgLSBzaAogICAgLSAtYwogICAgLSBzbGVlcCBpbmZpbml0eQo=",
+        "runtime_parameters": "{CARTO_RUNTIME_PARAMETERS}",
         "target_platform": {
-          "target_platform_id": "{TARGET_PLATFORM}"
+          "target_platform_id": "{TARGET_PLATFORM}",
+          "size": {
+            "name": "L8",
+            "worker_nodes_instance_count": 1,
+            "master_nodes_instance_count": 1
+          }
         }
       },
       "actions": [
@@ -34,6 +39,15 @@
             "remote": {
               "workload": "deploy-carto-accounts-www"
             }
+          }
+        },
+        {
+          "action_id": "cypress",
+          "params": {
+            "resources": {
+              "path": "cypress"
+            },
+            "endpoint": "lb-carto-router-http"
           }
         }
       ]


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

- Added Cypress action and a simple test to be run by VIB.
- Modified the current deployment configuration to deploy the chart using custom values so that no containers need to be disabled. 
- A bigger instance is now used to avoid resource issues.
- Updated `TARGET_PLATFORM` env name to the new naming scheme to avoid [future issues](https://github.com/vmware-labs/vmware-image-builder-action/blob/main/src/main.ts#L491).
-  Fixed listening port used in Goos tests per https://github.com/CartoDB/carto-selfhosted-helm/pull/28
- Modified trivy's action threshold to avoid false negatives.

**Benefits**

The verification pipeline now supports functional testing via Cypress.

**Additional information**

As the PR modifies GitHub's VIB workflow the changes fail unless they are divided in a first PR to update the workflow and another one to add Cypress. To avoid this, the changes have been tested in a fork where the 2 PRs procedure was followed. You can check it here:

- VIB workflow changes: [71b34db](https://github.com/FraPazGal/carto-selfhosted-helm/commit/71b34dba25a01515eaf253e597e219be6aa0bed4)
- PR adding Cypress: https://github.com/FraPazGal/carto-selfhosted-helm/pull/1
- Green action: https://github.com/FraPazGal/carto-selfhosted-helm/actions/runs/2017147645