### PR TITLE
Exclude Markdown files to not trigger VIB

### DIFF
--- a/.github/workflows/vib.yaml
+++ b/.github/workflows/vib.yaml
@@ -3,6 +3,8 @@ on: # rebuild any PRs and main branch changes
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
 env:
   CSP_API_URL: https://console.cloud.vmware.com
   CSP_API_TOKEN: ${{ secrets.CSP_API_TOKEN }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

Excludes Markdown `*.md` files for them not to trigger the VIB action.

**Benefits**

Avoid unnecessary Infrastructure resources and achieves shorter testing times for those PRs only modifying `*.md` files.

**Additional Information**

Workflow change tested in https://github.com/FraPazGal/carto-selfhosted-helm/pull/3