### PR TITLE
Update to `1.20.3-2022.04.01.01` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.13.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.12
+  version: 11.1.13
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.7.0
-digest: sha256:55af71220be8f7ce54fee199209be05579c472d89e703eb26314408b66df4ba7
-generated: "2022-03-30T10:11:17.087017455Z"
+  version: 16.8.0
+digest: sha256:7bd87c42f33eab12648b975751a7c2c03e0a366efef8fff6cd1b99c6d06fedd1
+generated: "2022-04-01T10:28:16.548032632Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.03.30.1
+appVersion: 2022.04.01.01
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -28,4 +28,4 @@ keywords:
 name: carto
 sources:
   - https://carto.com/
-version: 1.20.1
+version: 1.20.3


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/2144ea4bfecd943f72682cf270e8f96a01431361