### PR TITLE
revert scale 0 some components if depend

### DIFF
--- a/chart/templates/import-worker/deployment.yaml
+++ b/chart/templates/import-worker/deployment.yaml
@@ -13,11 +13,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.cartoConfigValues.selfHostedTenantId }}
   replicas: {{ .Values.importWorker.replicaCount }}
-  {{- else }}
-  replicas: 0
-  {{- end }}
   {{- if .Values.importWorker.updateStrategy }}
   strategy: {{- toYaml .Values.importWorker.updateStrategy | nindent 4 }}
   {{- end }}

--- a/chart/templates/workspace-subscriber/deployment.yaml
+++ b/chart/templates/workspace-subscriber/deployment.yaml
@@ -13,11 +13,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.cartoConfigValues.selfHostedTenantId }}
   replicas: {{ .Values.workspaceSubscriber.replicaCount }}
-  {{- else }}
-  replicas: 0
-  {{- end }}
   {{- if .Values.workspaceSubscriber.updateStrategy }}
   strategy: {{- toYaml .Values.workspaceSubscriber.updateStrategy | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

There are two components that have this approach, `import-worker` and `workspace-subscriber`,  this change was introduced by us in order to only start this components if some parameters were defined in customer package config file, when this file was very young and not well structured. 

The idea was that if you execute `helm install carto` from the official helm repo (without any customer file) all pods were able to run without restarts, `import-worker` and `wrk-subscriber` needs these params, in other case they will be restarting continually, and the rests of the components do not need this params to stay in running state.


**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->