### PR TITLE
Multiple fixes from RT review

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -134,10 +134,14 @@ Generate the secret def to be used in pods definitions
 {{- end -}}
 
 {{/*
-Create gcpBucketsProjectId using the gcpBucketsProjectId config or, if not defined, selfHostedGcpProjectId.
+Return true if a `appSecrets.gcpBucketsServiceAccountKey` is specified in any way
 */}}
-{{- define "carto.gcpBucketsProjectId" -}}
-{{ default .Values.cartoConfigValues.selfHostedGcpProjectId .Values.appConfigValues.gcpBucketsProjectId }}
+{{- define "carto.gcpBucketsServiceAccountKey.used" -}}
+{{- if .Values.appSecrets.gcpBucketsServiceAccountKey.existingSecret.name }}
+true
+{{- else if .Values.appSecrets.gcpBucketsServiceAccountKey.value -}}
+true
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -137,9 +137,7 @@ Generate the secret def to be used in pods definitions
 Return true if a `appSecrets.gcpBucketsServiceAccountKey` is specified in any way
 */}}
 {{- define "carto.gcpBucketsServiceAccountKey.used" -}}
-{{- if .Values.appSecrets.gcpBucketsServiceAccountKey.existingSecret.name }}
-true
-{{- else if .Values.appSecrets.gcpBucketsServiceAccountKey.value -}}
+{{- if or (.Values.appSecrets.gcpBucketsServiceAccountKey.existingSecret.name) (.Values.appSecrets.gcpBucketsServiceAccountKey.value) }}
 true
 {{- end -}}
 {{- end -}}

--- a/chart/templates/cdn-invalidator-sub/deployment.yaml
+++ b/chart/templates/cdn-invalidator-sub/deployment.yaml
@@ -94,7 +94,7 @@ spec:
           args:
             - -ec
             - |
-              npm run start
+              npm run start:built
           {{- end }}
           env:
             - name: WORKSPACE_POSTGRES_PASSWORD
@@ -160,9 +160,9 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.cdnInvalidatorSub.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: google-secret
-              mountPath: /usr/src/certs/key.json
-              subPath: {{ template "carto.google.secretKey" . }}
+            - name: gcp-default-service-account-key
+              mountPath: {{ include "carto.google.secretMountDir" . }}
+              readOnly: true
           {{- if .Values.cdnInvalidatorSub.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.cdnInvalidatorSub.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -170,9 +170,12 @@ spec:
         {{- include "common.tplvalues.render" ( dict "value" .Values.cdnInvalidatorSub.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
-        - name: google-secret
+        - name: gcp-default-service-account-key
           secret:
             secretName: {{ include "carto.google.secretName" . }}
+            items:
+              - key: {{ include "carto.google.secretKey" . }}
+                path: {{ include "carto.google.secretMountFilename" . }}
         {{- if .Values.cdnInvalidatorSub.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.cdnInvalidatorSub.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/chart/templates/import-api/configmap.yaml
+++ b/chart/templates/import-api/configmap.yaml
@@ -46,8 +46,12 @@ data:
   IMPORT_PROVIDER: {{ .Values.appConfigValues.storageProvider | quote }}
   IMPORT_BUCKET: {{ .Values.appConfigValues.importBucket | quote }}
   {{- if eq .Values.appConfigValues.storageProvider "gcp" }}
-  IMPORT_PROJECTID: {{ include "carto.gcpBucketsProjectId" . | quote }}
+    {{- if .Values.appConfigValues.gcpBucketsProjectId }}
+  IMPORT_PROJECTID: {{ .Values.appConfigValues.gcpBucketsProjectId | quote }}
+    {{- end }}
+    {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
   IMPORT_KEYFILENAME: {{ include "carto.gcpBucketsServiceAccountKey.secretMountAbsolutePath" . }}
+    {{- end }}
   {{- end }}
   {{- if eq .Values.appConfigValues.storageProvider "s3" }}
   IMPORT_REGION: {{ .Values.appConfigValues.awsS3Region | quote }}

--- a/chart/templates/import-api/configmap.yaml
+++ b/chart/templates/import-api/configmap.yaml
@@ -46,12 +46,12 @@ data:
   IMPORT_PROVIDER: {{ .Values.appConfigValues.storageProvider | quote }}
   IMPORT_BUCKET: {{ .Values.appConfigValues.importBucket | quote }}
   {{- if eq .Values.appConfigValues.storageProvider "gcp" }}
-    {{- if .Values.appConfigValues.gcpBucketsProjectId }}
+  {{- if .Values.appConfigValues.gcpBucketsProjectId }}
   IMPORT_PROJECTID: {{ .Values.appConfigValues.gcpBucketsProjectId | quote }}
-    {{- end }}
-    {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
+  {{- end }}
+  {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
   IMPORT_KEYFILENAME: {{ include "carto.gcpBucketsServiceAccountKey.secretMountAbsolutePath" . }}
-    {{- end }}
+  {{- end }}
   {{- end }}
   {{- if eq .Values.appConfigValues.storageProvider "s3" }}
   IMPORT_REGION: {{ .Values.appConfigValues.awsS3Region | quote }}

--- a/chart/templates/import-api/deployment.yaml
+++ b/chart/templates/import-api/deployment.yaml
@@ -181,9 +181,11 @@ spec:
             - name: gcp-default-service-account-key
               mountPath: {{ include "carto.google.secretMountDir" . }}
               readOnly: true
+            {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
             - name: gcp-buckets-service-account-key
               mountPath: {{ include "carto.gcpBucketsServiceAccountKey.secretMountDir" . }}
               readOnly: true
+            {{- end }}
           {{- if .Values.importApi.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.importApi.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -197,12 +199,14 @@ spec:
             items:
               - key: {{ include "carto.google.secretKey" . }}
                 path: {{ include "carto.google.secretMountFilename" . }}
+        {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
         - name: gcp-buckets-service-account-key
           secret:
             secretName: {{ include "carto.gcpBucketsServiceAccountKey.secretName" . }}
             items:
               - key: {{ include "carto.gcpBucketsServiceAccountKey.secretKey" . }}
                 path: {{ include "carto.gcpBucketsServiceAccountKey.secretMountFilename" . }}
+        {{- end }}
         {{- if .Values.importApi.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.importApi.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -35,12 +35,12 @@ data:
   IMPORT_PROVIDER: {{ .Values.appConfigValues.storageProvider | quote }}
   IMPORT_BUCKET: {{ .Values.appConfigValues.importBucket | quote }}
   {{- if eq .Values.appConfigValues.storageProvider "gcp" }}
-    {{- if .Values.appConfigValues.gcpBucketsProjectId }}
+  {{- if .Values.appConfigValues.gcpBucketsProjectId }}
   IMPORT_PROJECTID: {{ .Values.appConfigValues.gcpBucketsProjectId | quote }}
-    {{- end }}
-    {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
+  {{- end }}
+  {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
   IMPORT_KEYFILENAME: {{ include "carto.gcpBucketsServiceAccountKey.secretMountAbsolutePath" . }}
-    {{- end }}
+  {{- end }}
   {{- end }}
   {{- if eq .Values.appConfigValues.storageProvider "s3" }}
   IMPORT_REGION: {{ .Values.appConfigValues.awsS3Region | quote }}

--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -35,8 +35,12 @@ data:
   IMPORT_PROVIDER: {{ .Values.appConfigValues.storageProvider | quote }}
   IMPORT_BUCKET: {{ .Values.appConfigValues.importBucket | quote }}
   {{- if eq .Values.appConfigValues.storageProvider "gcp" }}
-  IMPORT_PROJECTID: {{ include "carto.gcpBucketsProjectId" . | quote }}
+    {{- if .Values.appConfigValues.gcpBucketsProjectId }}
+  IMPORT_PROJECTID: {{ .Values.appConfigValues.gcpBucketsProjectId | quote }}
+    {{- end }}
+    {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
   IMPORT_KEYFILENAME: {{ include "carto.gcpBucketsServiceAccountKey.secretMountAbsolutePath" . }}
+    {{- end }}
   {{- end }}
   {{- if eq .Values.appConfigValues.storageProvider "s3" }}
   IMPORT_REGION: {{ .Values.appConfigValues.awsS3Region | quote }}

--- a/chart/templates/import-worker/deployment.yaml
+++ b/chart/templates/import-worker/deployment.yaml
@@ -159,9 +159,11 @@ spec:
             - name: gcp-default-service-account-key
               mountPath: {{ include "carto.google.secretMountDir" . }}
               readOnly: true
+            {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
             - name: gcp-buckets-service-account-key
               mountPath: {{ include "carto.gcpBucketsServiceAccountKey.secretMountDir" . }}
               readOnly: true
+            {{- end }}
           {{- if .Values.importWorker.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.importWorker.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -175,12 +177,14 @@ spec:
             items:
               - key: {{ include "carto.google.secretKey" . }}
                 path: {{ include "carto.google.secretMountFilename" . }}
+        {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
         - name: gcp-buckets-service-account-key
           secret:
             secretName: {{ include "carto.gcpBucketsServiceAccountKey.secretName" . }}
             items:
               - key: {{ include "carto.gcpBucketsServiceAccountKey.secretKey" . }}
                 path: {{ include "carto.gcpBucketsServiceAccountKey.secretMountFilename" . }}
+        {{- end }}
         {{- if .Values.importWorker.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.importWorker.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/chart/templates/lds-api/deployment.yaml
+++ b/chart/templates/lds-api/deployment.yaml
@@ -168,9 +168,9 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.ldsApi.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: google-secret
-              mountPath: /usr/src/certs/key.json
-              subPath: {{ template "carto.google.secretKey" . }}
+            - name: gcp-default-service-account-key
+              mountPath: {{ include "carto.google.secretMountDir" . }}
+              readOnly: true
           {{- if .Values.ldsApi.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.ldsApi.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -178,9 +178,12 @@ spec:
         {{- include "common.tplvalues.render" ( dict "value" .Values.ldsApi.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
-        - name: google-secret
+        - name: gcp-default-service-account-key
           secret:
             secretName: {{ include "carto.google.secretName" . }}
+            items:
+              - key: {{ include "carto.google.secretKey" . }}
+                path: {{ include "carto.google.secretMountFilename" . }}
         {{- if .Values.ldsApi.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.ldsApi.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/chart/templates/workspace-api/configmap.yaml
+++ b/chart/templates/workspace-api/configmap.yaml
@@ -57,10 +57,14 @@ data:
   WORKSPACE_THUMBNAILS_PUBLIC: {{ .Values.appConfigValues.workspaceThumbnailsPublic | quote }}
   WORKSPACE_THUMBNAILS_PROVIDER: {{ .Values.appConfigValues.storageProvider | quote }}
   {{- if eq .Values.appConfigValues.storageProvider "gcp" }}
-  WORKSPACE_IMPORTS_PROJECTID: {{ include "carto.gcpBucketsProjectId" . | quote }}
+    {{- if .Values.appConfigValues.gcpBucketsProjectId }}
+  WORKSPACE_IMPORTS_PROJECTID: {{ .Values.appConfigValues.gcpBucketsProjectId | quote }}
+  WORKSPACE_THUMBNAILS_PROJECTID: {{ .Values.appConfigValues.gcpBucketsProjectId | quote }}
+    {{- end }}
+    {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
   WORKSPACE_IMPORTS_KEYFILENAME: {{ include "carto.gcpBucketsServiceAccountKey.secretMountAbsolutePath" . }}
-  WORKSPACE_THUMBNAILS_PROJECTID: {{ include "carto.gcpBucketsProjectId" . | quote }}
   WORKSPACE_THUMBNAILS_KEYFILENAME: {{ include "carto.gcpBucketsServiceAccountKey.secretMountAbsolutePath" . }}
+    {{- end }}
   {{- end }}
   {{- if eq .Values.appConfigValues.storageProvider "s3" }}
   WORKSPACE_THUMBNAILS_REGION: {{ .Values.appConfigValues.awsS3Region | quote }}

--- a/chart/templates/workspace-api/configmap.yaml
+++ b/chart/templates/workspace-api/configmap.yaml
@@ -57,14 +57,14 @@ data:
   WORKSPACE_THUMBNAILS_PUBLIC: {{ .Values.appConfigValues.workspaceThumbnailsPublic | quote }}
   WORKSPACE_THUMBNAILS_PROVIDER: {{ .Values.appConfigValues.storageProvider | quote }}
   {{- if eq .Values.appConfigValues.storageProvider "gcp" }}
-    {{- if .Values.appConfigValues.gcpBucketsProjectId }}
+  {{- if .Values.appConfigValues.gcpBucketsProjectId }}
   WORKSPACE_IMPORTS_PROJECTID: {{ .Values.appConfigValues.gcpBucketsProjectId | quote }}
   WORKSPACE_THUMBNAILS_PROJECTID: {{ .Values.appConfigValues.gcpBucketsProjectId | quote }}
-    {{- end }}
-    {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
+  {{- end }}
+  {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
   WORKSPACE_IMPORTS_KEYFILENAME: {{ include "carto.gcpBucketsServiceAccountKey.secretMountAbsolutePath" . }}
   WORKSPACE_THUMBNAILS_KEYFILENAME: {{ include "carto.gcpBucketsServiceAccountKey.secretMountAbsolutePath" . }}
-    {{- end }}
+  {{- end }}
   {{- end }}
   {{- if eq .Values.appConfigValues.storageProvider "s3" }}
   WORKSPACE_THUMBNAILS_REGION: {{ .Values.appConfigValues.awsS3Region | quote }}

--- a/chart/templates/workspace-api/deployment.yaml
+++ b/chart/templates/workspace-api/deployment.yaml
@@ -238,9 +238,11 @@ spec:
             - name: gcp-default-service-account-key
               mountPath: {{ include "carto.google.secretMountDir" . }}
               readOnly: true
+            {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
             - name: gcp-buckets-service-account-key
               mountPath: {{ include "carto.gcpBucketsServiceAccountKey.secretMountDir" . }}
               readOnly: true
+            {{- end }}
           {{- if .Values.workspaceApi.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.workspaceApi.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -254,12 +256,14 @@ spec:
             items:
               - key: {{ include "carto.google.secretKey" . }}
                 path: {{ include "carto.google.secretMountFilename" . }}
+        {{- if ( include "carto.gcpBucketsServiceAccountKey.used" . ) }}
         - name: gcp-buckets-service-account-key
           secret:
             secretName: {{ include "carto.gcpBucketsServiceAccountKey.secretName" . }}
             items:
               - key: {{ include "carto.gcpBucketsServiceAccountKey.secretKey" . }}
                 path: {{ include "carto.gcpBucketsServiceAccountKey.secretMountFilename" . }}
+        {{- end }}
         {{- if .Values.workspaceApi.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.workspaceApi.extraVolumes "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
- Fix command cdn-invalidator-sub
- Fix gcp-secrets mounted in cdn-invalidator-sub
- [x] Solve problem with `WORKSPACE_IMPORTS_PROJECTID`, `WORKSPACE_IMPORTS_KEYFILENAME` && same for  `WORKSPACE_THUMBNAILS_*` . That variables should be mounted only when a secret is passed and the projectid is defined.
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->