### PR TITLE
Refactor Docker images templating

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -123,74 +123,75 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 ### accounts-www Deployment Parameters
 
-| Name                                                     | Description                                                                                           | Value                                        |
-| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| `accountsWww.image.name`                                 | accounts-www image registry and repository                                                            | `gcr.io/carto-onprem-artifacts/accounts-www` |
-| `accountsWww.image.tag`                                  | accounts-www image tag (immutable tags are recommended)                                               | `""`                                         |
-| `accountsWww.image.pullPolicy`                           | accounts-www image pull policy                                                                        | `IfNotPresent`                               |
-| `accountsWww.image.pullSecrets`                          | accounts-www image pull secrets                                                                       | `[]`                                         |
-| `accountsWww.replicaCount`                               | Number of accounts-www replicas to deploy                                                             | `1`                                          |
-| `accountsWww.containerPorts.http`                        | accounts-www HTTP container port                                                                      | `8080`                                       |
-| `accountsWww.livenessProbe.enabled`                      | Enable livenessProbe on accounts-www containers                                                       | `true`                                       |
-| `accountsWww.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                                               | `10`                                         |
-| `accountsWww.livenessProbe.periodSeconds`                | Period seconds for livenessProbe                                                                      | `30`                                         |
-| `accountsWww.livenessProbe.timeoutSeconds`               | Timeout seconds for livenessProbe                                                                     | `5`                                          |
-| `accountsWww.livenessProbe.failureThreshold`             | Failure threshold for livenessProbe                                                                   | `5`                                          |
-| `accountsWww.livenessProbe.successThreshold`             | Success threshold for livenessProbe                                                                   | `1`                                          |
-| `accountsWww.readinessProbe.enabled`                     | Enable readinessProbe on accounts-www containers                                                      | `true`                                       |
-| `accountsWww.readinessProbe.initialDelaySeconds`         | Initial delay seconds for readinessProbe                                                              | `10`                                         |
-| `accountsWww.readinessProbe.periodSeconds`               | Period seconds for readinessProbe                                                                     | `30`                                         |
-| `accountsWww.readinessProbe.timeoutSeconds`              | Timeout seconds for readinessProbe                                                                    | `5`                                          |
-| `accountsWww.readinessProbe.failureThreshold`            | Failure threshold for readinessProbe                                                                  | `5`                                          |
-| `accountsWww.readinessProbe.successThreshold`            | Success threshold for readinessProbe                                                                  | `1`                                          |
-| `accountsWww.startupProbe.enabled`                       | Enable startupProbe on accounts-www containers                                                        | `false`                                      |
-| `accountsWww.startupProbe.initialDelaySeconds`           | Initial delay seconds for startupProbe                                                                | `10`                                         |
-| `accountsWww.startupProbe.periodSeconds`                 | Period seconds for startupProbe                                                                       | `30`                                         |
-| `accountsWww.startupProbe.timeoutSeconds`                | Timeout seconds for startupProbe                                                                      | `5`                                          |
-| `accountsWww.startupProbe.failureThreshold`              | Failure threshold for startupProbe                                                                    | `5`                                          |
-| `accountsWww.startupProbe.successThreshold`              | Success threshold for startupProbe                                                                    | `1`                                          |
-| `accountsWww.customLivenessProbe`                        | Custom livenessProbe that overrides the default one                                                   | `{}`                                         |
-| `accountsWww.customReadinessProbe`                       | Custom readinessProbe that overrides the default one                                                  | `{}`                                         |
-| `accountsWww.customStartupProbe`                         | Custom startupProbe that overrides the default one                                                    | `{}`                                         |
-| `accountsWww.autoscaling.enabled`                        | Enable autoscaling for the accounts-www containers                                                    | `false`                                      |
-| `accountsWww.autoscaling.minReplicas`                    | The minimal number of containters for the accounts-www deployment                                     | `1`                                          |
-| `accountsWww.autoscaling.maxReplicas`                    | The maximum number of containers for the accounts-www deployment                                      | `2`                                          |
-| `accountsWww.autoscaling.targetCPUUtilizationPercentage` | The CPU utilization percentage used for scale up containers in accounts-www deployment                | `75`                                         |
-| `accountsWww.resources.limits`                           | The resources limits for the accounts-www containers                                                  | `{}`                                         |
-| `accountsWww.resources.requests`                         | The requested resources for the accounts-www containers                                               | `{}`                                         |
-| `accountsWww.podSecurityContext.enabled`                 | Enabled accounts-www pods' Security Context                                                           | `true`                                       |
-| `accountsWww.podSecurityContext.fsGroup`                 | Set accounts-www pod's Security Context fsGroup                                                       | `0`                                          |
-| `accountsWww.containerSecurityContext.enabled`           | Enabled accounts-www containers' Security Context                                                     | `true`                                       |
-| `accountsWww.containerSecurityContext.runAsUser`         | Set accounts-www containers' Security Context runAsUser                                               | `0`                                          |
-| `accountsWww.containerSecurityContext.runAsNonRoot`      | Set accounts-www containers' Security Context runAsNonRoot                                            | `false`                                      |
-| `accountsWww.configuration`                              | Configuration settings (env vars) for accounts-www                                                    | `{}`                                         |
-| `accountsWww.secretConfiguration`                        | Configuration settings (env vars) for accounts-www                                                    | `""`                                         |
-| `accountsWww.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for accounts-www                     | `""`                                         |
-| `accountsWww.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for accounts-www                     | `""`                                         |
-| `accountsWww.command`                                    | Override default container command (useful when using custom images)                                  | `[]`                                         |
-| `accountsWww.args`                                       | Override default container args (useful when using custom images)                                     | `[]`                                         |
-| `accountsWww.hostAliases`                                | accounts-www pods host aliases                                                                        | `[]`                                         |
-| `accountsWww.podLabels`                                  | Extra labels for accounts-www pods                                                                    | `{}`                                         |
-| `accountsWww.podAnnotations`                             | Annotations for accounts-www pods                                                                     | `{}`                                         |
-| `accountsWww.podAffinityPreset`                          | Pod affinity preset. Ignored if `accountsWww.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                         |
-| `accountsWww.podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `accountsWww.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                       |
-| `accountsWww.nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `accountsWww.affinity` is set. Allowed values: `soft` or `hard` | `""`                                         |
-| `accountsWww.nodeAffinityPreset.key`                     | Node label key to match. Ignored if `accountsWww.affinity` is set                                     | `""`                                         |
-| `accountsWww.nodeAffinityPreset.values`                  | Node label values to match. Ignored if `accountsWww.affinity` is set                                  | `[]`                                         |
-| `accountsWww.affinity`                                   | Affinity for accounts-www pods assignment                                                             | `{}`                                         |
-| `accountsWww.nodeSelector`                               | Node labels for accounts-www pods assignment                                                          | `{}`                                         |
-| `accountsWww.tolerations`                                | Tolerations for accounts-www pods assignment                                                          | `[]`                                         |
-| `accountsWww.updateStrategy.type`                        | accounts-www statefulset strategy type                                                                | `RollingUpdate`                              |
-| `accountsWww.priorityClassName`                          | accounts-www pods' priorityClassName                                                                  | `""`                                         |
-| `accountsWww.schedulerName`                              | Name of the k8s scheduler (other than default) for accounts-www pods                                  | `""`                                         |
-| `accountsWww.lifecycleHooks`                             | for the accounts-www container(s) to automate configuration before or after startup                   | `{}`                                         |
-| `accountsWww.extraEnvVars`                               | Array with extra environment variables to add to accounts-www nodes                                   | `[]`                                         |
-| `accountsWww.extraEnvVarsCM`                             | Name of existing ConfigMap containing extra env vars for accounts-www nodes                           | `""`                                         |
-| `accountsWww.extraEnvVarsSecret`                         | Name of existing Secret containing extra env vars for accounts-www nodes                              | `""`                                         |
-| `accountsWww.extraVolumes`                               | Optionally specify extra list of additional volumes for the accounts-www pod(s)                       | `[]`                                         |
-| `accountsWww.extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts for the accounts-www container(s)            | `[]`                                         |
-| `accountsWww.sidecars`                                   | Add additional sidecar containers to the accounts-www pod(s)                                          | `{}`                                         |
-| `accountsWww.initContainers`                             | Add additional init containers to the accounts-www pod(s)                                             | `{}`                                         |
+| Name                                                     | Description                                                                                           | Value                           |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `accountsWww.image.registry`                             | accounts-www image registry                                                                           | `gcr.io/carto-onprem-artifacts` |
+| `accountsWww.image.repository`                           | accounts-www image repository                                                                         | `accounts-www`                  |
+| `accountsWww.image.tag`                                  | accounts-www image tag (immutable tags are recommended)                                               | `""`                            |
+| `accountsWww.image.pullPolicy`                           | accounts-www image pull policy                                                                        | `IfNotPresent`                  |
+| `accountsWww.image.pullSecrets`                          | accounts-www image pull secrets                                                                       | `[]`                            |
+| `accountsWww.replicaCount`                               | Number of accounts-www replicas to deploy                                                             | `1`                             |
+| `accountsWww.containerPorts.http`                        | accounts-www HTTP container port                                                                      | `8080`                          |
+| `accountsWww.livenessProbe.enabled`                      | Enable livenessProbe on accounts-www containers                                                       | `true`                          |
+| `accountsWww.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                                               | `10`                            |
+| `accountsWww.livenessProbe.periodSeconds`                | Period seconds for livenessProbe                                                                      | `30`                            |
+| `accountsWww.livenessProbe.timeoutSeconds`               | Timeout seconds for livenessProbe                                                                     | `5`                             |
+| `accountsWww.livenessProbe.failureThreshold`             | Failure threshold for livenessProbe                                                                   | `5`                             |
+| `accountsWww.livenessProbe.successThreshold`             | Success threshold for livenessProbe                                                                   | `1`                             |
+| `accountsWww.readinessProbe.enabled`                     | Enable readinessProbe on accounts-www containers                                                      | `true`                          |
+| `accountsWww.readinessProbe.initialDelaySeconds`         | Initial delay seconds for readinessProbe                                                              | `10`                            |
+| `accountsWww.readinessProbe.periodSeconds`               | Period seconds for readinessProbe                                                                     | `30`                            |
+| `accountsWww.readinessProbe.timeoutSeconds`              | Timeout seconds for readinessProbe                                                                    | `5`                             |
+| `accountsWww.readinessProbe.failureThreshold`            | Failure threshold for readinessProbe                                                                  | `5`                             |
+| `accountsWww.readinessProbe.successThreshold`            | Success threshold for readinessProbe                                                                  | `1`                             |
+| `accountsWww.startupProbe.enabled`                       | Enable startupProbe on accounts-www containers                                                        | `false`                         |
+| `accountsWww.startupProbe.initialDelaySeconds`           | Initial delay seconds for startupProbe                                                                | `10`                            |
+| `accountsWww.startupProbe.periodSeconds`                 | Period seconds for startupProbe                                                                       | `30`                            |
+| `accountsWww.startupProbe.timeoutSeconds`                | Timeout seconds for startupProbe                                                                      | `5`                             |
+| `accountsWww.startupProbe.failureThreshold`              | Failure threshold for startupProbe                                                                    | `5`                             |
+| `accountsWww.startupProbe.successThreshold`              | Success threshold for startupProbe                                                                    | `1`                             |
+| `accountsWww.customLivenessProbe`                        | Custom livenessProbe that overrides the default one                                                   | `{}`                            |
+| `accountsWww.customReadinessProbe`                       | Custom readinessProbe that overrides the default one                                                  | `{}`                            |
+| `accountsWww.customStartupProbe`                         | Custom startupProbe that overrides the default one                                                    | `{}`                            |
+| `accountsWww.autoscaling.enabled`                        | Enable autoscaling for the accounts-www containers                                                    | `false`                         |
+| `accountsWww.autoscaling.minReplicas`                    | The minimal number of containters for the accounts-www deployment                                     | `1`                             |
+| `accountsWww.autoscaling.maxReplicas`                    | The maximum number of containers for the accounts-www deployment                                      | `2`                             |
+| `accountsWww.autoscaling.targetCPUUtilizationPercentage` | The CPU utilization percentage used for scale up containers in accounts-www deployment                | `75`                            |
+| `accountsWww.resources.limits`                           | The resources limits for the accounts-www containers                                                  | `{}`                            |
+| `accountsWww.resources.requests`                         | The requested resources for the accounts-www containers                                               | `{}`                            |
+| `accountsWww.podSecurityContext.enabled`                 | Enabled accounts-www pods' Security Context                                                           | `true`                          |
+| `accountsWww.podSecurityContext.fsGroup`                 | Set accounts-www pod's Security Context fsGroup                                                       | `0`                             |
+| `accountsWww.containerSecurityContext.enabled`           | Enabled accounts-www containers' Security Context                                                     | `true`                          |
+| `accountsWww.containerSecurityContext.runAsUser`         | Set accounts-www containers' Security Context runAsUser                                               | `0`                             |
+| `accountsWww.containerSecurityContext.runAsNonRoot`      | Set accounts-www containers' Security Context runAsNonRoot                                            | `false`                         |
+| `accountsWww.configuration`                              | Configuration settings (env vars) for accounts-www                                                    | `{}`                            |
+| `accountsWww.secretConfiguration`                        | Configuration settings (env vars) for accounts-www                                                    | `""`                            |
+| `accountsWww.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for accounts-www                     | `""`                            |
+| `accountsWww.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for accounts-www                     | `""`                            |
+| `accountsWww.command`                                    | Override default container command (useful when using custom images)                                  | `[]`                            |
+| `accountsWww.args`                                       | Override default container args (useful when using custom images)                                     | `[]`                            |
+| `accountsWww.hostAliases`                                | accounts-www pods host aliases                                                                        | `[]`                            |
+| `accountsWww.podLabels`                                  | Extra labels for accounts-www pods                                                                    | `{}`                            |
+| `accountsWww.podAnnotations`                             | Annotations for accounts-www pods                                                                     | `{}`                            |
+| `accountsWww.podAffinityPreset`                          | Pod affinity preset. Ignored if `accountsWww.affinity` is set. Allowed values: `soft` or `hard`       | `""`                            |
+| `accountsWww.podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `accountsWww.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                          |
+| `accountsWww.nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `accountsWww.affinity` is set. Allowed values: `soft` or `hard` | `""`                            |
+| `accountsWww.nodeAffinityPreset.key`                     | Node label key to match. Ignored if `accountsWww.affinity` is set                                     | `""`                            |
+| `accountsWww.nodeAffinityPreset.values`                  | Node label values to match. Ignored if `accountsWww.affinity` is set                                  | `[]`                            |
+| `accountsWww.affinity`                                   | Affinity for accounts-www pods assignment                                                             | `{}`                            |
+| `accountsWww.nodeSelector`                               | Node labels for accounts-www pods assignment                                                          | `{}`                            |
+| `accountsWww.tolerations`                                | Tolerations for accounts-www pods assignment                                                          | `[]`                            |
+| `accountsWww.updateStrategy.type`                        | accounts-www statefulset strategy type                                                                | `RollingUpdate`                 |
+| `accountsWww.priorityClassName`                          | accounts-www pods' priorityClassName                                                                  | `""`                            |
+| `accountsWww.schedulerName`                              | Name of the k8s scheduler (other than default) for accounts-www pods                                  | `""`                            |
+| `accountsWww.lifecycleHooks`                             | for the accounts-www container(s) to automate configuration before or after startup                   | `{}`                            |
+| `accountsWww.extraEnvVars`                               | Array with extra environment variables to add to accounts-www nodes                                   | `[]`                            |
+| `accountsWww.extraEnvVarsCM`                             | Name of existing ConfigMap containing extra env vars for accounts-www nodes                           | `""`                            |
+| `accountsWww.extraEnvVarsSecret`                         | Name of existing Secret containing extra env vars for accounts-www nodes                              | `""`                            |
+| `accountsWww.extraVolumes`                               | Optionally specify extra list of additional volumes for the accounts-www pod(s)                       | `[]`                            |
+| `accountsWww.extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts for the accounts-www container(s)            | `[]`                            |
+| `accountsWww.sidecars`                                   | Add additional sidecar containers to the accounts-www pod(s)                                          | `{}`                            |
+| `accountsWww.initContainers`                             | Add additional init containers to the accounts-www pod(s)                                             | `{}`                            |
 
 
 ### accounts-www Service Parameters
@@ -220,74 +221,75 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 ### import-api Deployment Parameters
 
-| Name                                                   | Description                                                                                         | Value                                      |
-| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| `importApi.image.name`                                 | import-api image registry and repository                                                            | `gcr.io/carto-onprem-artifacts/import-api` |
-| `importApi.image.tag`                                  | import-api image tag (immutable tags are recommended)                                               | `""`                                       |
-| `importApi.image.pullPolicy`                           | import-api image pull policy                                                                        | `IfNotPresent`                             |
-| `importApi.image.pullSecrets`                          | import-api image pull secrets                                                                       | `[]`                                       |
-| `importApi.replicaCount`                               | Number of import-api replicas to deploy                                                             | `1`                                        |
-| `importApi.containerPorts.http`                        | import-api HTTP container port                                                                      | `8003`                                     |
-| `importApi.livenessProbe.enabled`                      | Enable livenessProbe on import-api containers                                                       | `true`                                     |
-| `importApi.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                                             | `10`                                       |
-| `importApi.livenessProbe.periodSeconds`                | Period seconds for livenessProbe                                                                    | `30`                                       |
-| `importApi.livenessProbe.timeoutSeconds`               | Timeout seconds for livenessProbe                                                                   | `5`                                        |
-| `importApi.livenessProbe.failureThreshold`             | Failure threshold for livenessProbe                                                                 | `5`                                        |
-| `importApi.livenessProbe.successThreshold`             | Success threshold for livenessProbe                                                                 | `1`                                        |
-| `importApi.readinessProbe.enabled`                     | Enable readinessProbe on import-api containers                                                      | `true`                                     |
-| `importApi.readinessProbe.initialDelaySeconds`         | Initial delay seconds for readinessProbe                                                            | `10`                                       |
-| `importApi.readinessProbe.periodSeconds`               | Period seconds for readinessProbe                                                                   | `30`                                       |
-| `importApi.readinessProbe.timeoutSeconds`              | Timeout seconds for readinessProbe                                                                  | `5`                                        |
-| `importApi.readinessProbe.failureThreshold`            | Failure threshold for readinessProbe                                                                | `5`                                        |
-| `importApi.readinessProbe.successThreshold`            | Success threshold for readinessProbe                                                                | `1`                                        |
-| `importApi.startupProbe.enabled`                       | Enable startupProbe on import-api containers                                                        | `false`                                    |
-| `importApi.startupProbe.initialDelaySeconds`           | Initial delay seconds for startupProbe                                                              | `10`                                       |
-| `importApi.startupProbe.periodSeconds`                 | Period seconds for startupProbe                                                                     | `30`                                       |
-| `importApi.startupProbe.timeoutSeconds`                | Timeout seconds for startupProbe                                                                    | `5`                                        |
-| `importApi.startupProbe.failureThreshold`              | Failure threshold for startupProbe                                                                  | `5`                                        |
-| `importApi.startupProbe.successThreshold`              | Success threshold for startupProbe                                                                  | `1`                                        |
-| `importApi.customLivenessProbe`                        | Custom livenessProbe that overrides the default one                                                 | `{}`                                       |
-| `importApi.customReadinessProbe`                       | Custom readinessProbe that overrides the default one                                                | `{}`                                       |
-| `importApi.customStartupProbe`                         | Custom startupProbe that overrides the default one                                                  | `{}`                                       |
-| `importApi.autoscaling.enabled`                        | Enable autoscaling for the import-api containers                                                    | `false`                                    |
-| `importApi.autoscaling.minReplicas`                    | The minimal number of containters for the import-api deployment                                     | `1`                                        |
-| `importApi.autoscaling.maxReplicas`                    | The maximum number of containers for the import-api deployment                                      | `2`                                        |
-| `importApi.autoscaling.targetCPUUtilizationPercentage` | The CPU utilization percentage used for scale up containers in import-api deployment                | `75`                                       |
-| `importApi.resources.limits`                           | The resources limits for the import-api containers                                                  | `{}`                                       |
-| `importApi.resources.requests`                         | The requested resources for the import-api containers                                               | `{}`                                       |
-| `importApi.podSecurityContext.enabled`                 | Enabled import-api pods' Security Context                                                           | `true`                                     |
-| `importApi.podSecurityContext.fsGroup`                 | Set import-api pod's Security Context fsGroup                                                       | `0`                                        |
-| `importApi.containerSecurityContext.enabled`           | Enabled import-api containers' Security Context                                                     | `true`                                     |
-| `importApi.containerSecurityContext.runAsUser`         | Set import-api containers' Security Context runAsUser                                               | `0`                                        |
-| `importApi.containerSecurityContext.runAsNonRoot`      | Set import-api containers' Security Context runAsNonRoot                                            | `false`                                    |
-| `importApi.configuration`                              | Configuration settings (env vars) for import-api                                                    | `{}`                                       |
-| `importApi.secretConfiguration`                        | Configuration settings (env vars) for import-api                                                    | `""`                                       |
-| `importApi.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for import-api                     | `""`                                       |
-| `importApi.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for import-api                     | `""`                                       |
-| `importApi.command`                                    | Override default container command (useful when using custom images)                                | `[]`                                       |
-| `importApi.args`                                       | Override default container args (useful when using custom images)                                   | `[]`                                       |
-| `importApi.hostAliases`                                | import-api pods host aliases                                                                        | `[]`                                       |
-| `importApi.podLabels`                                  | Extra labels for import-api pods                                                                    | `{}`                                       |
-| `importApi.podAnnotations`                             | Annotations for import-api pods                                                                     | `{}`                                       |
-| `importApi.podAffinityPreset`                          | Pod affinity preset. Ignored if `importApi.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                       |
-| `importApi.podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `importApi.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                     |
-| `importApi.nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `importApi.affinity` is set. Allowed values: `soft` or `hard` | `""`                                       |
-| `importApi.nodeAffinityPreset.key`                     | Node label key to match. Ignored if `importApi.affinity` is set                                     | `""`                                       |
-| `importApi.nodeAffinityPreset.values`                  | Node label values to match. Ignored if `importApi.affinity` is set                                  | `[]`                                       |
-| `importApi.affinity`                                   | Affinity for import-api pods assignment                                                             | `{}`                                       |
-| `importApi.nodeSelector`                               | Node labels for import-api pods assignment                                                          | `{}`                                       |
-| `importApi.tolerations`                                | Tolerations for import-api pods assignment                                                          | `[]`                                       |
-| `importApi.updateStrategy.type`                        | import-api statefulset strategy type                                                                | `RollingUpdate`                            |
-| `importApi.priorityClassName`                          | import-api pods' priorityClassName                                                                  | `""`                                       |
-| `importApi.schedulerName`                              | Name of the k8s scheduler (other than default) for import-api pods                                  | `""`                                       |
-| `importApi.lifecycleHooks`                             | for the import-api container(s) to automate configuration before or after startup                   | `{}`                                       |
-| `importApi.extraEnvVars`                               | Array with extra environment variables to add to import-api nodes                                   | `[]`                                       |
-| `importApi.extraEnvVarsCM`                             | Name of existing ConfigMap containing extra env vars for import-api nodes                           | `""`                                       |
-| `importApi.extraEnvVarsSecret`                         | Name of existing Secret containing extra env vars for import-api nodes                              | `""`                                       |
-| `importApi.extraVolumes`                               | Optionally specify extra list of additional volumes for the import-api pod(s)                       | `[]`                                       |
-| `importApi.extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts for the import-api container(s)            | `[]`                                       |
-| `importApi.sidecars`                                   | Add additional sidecar containers to the import-api pod(s)                                          | `{}`                                       |
-| `importApi.initContainers`                             | Add additional init containers to the import-api pod(s)                                             | `{}`                                       |
+| Name                                                   | Description                                                                                         | Value                           |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `importApi.image.registry`                             | import-api image registry                                                                           | `gcr.io/carto-onprem-artifacts` |
+| `importApi.image.repository`                           | import-api image repository                                                                         | `import-api`                    |
+| `importApi.image.tag`                                  | import-api image tag (immutable tags are recommended)                                               | `""`                            |
+| `importApi.image.pullPolicy`                           | import-api image pull policy                                                                        | `IfNotPresent`                  |
+| `importApi.image.pullSecrets`                          | import-api image pull secrets                                                                       | `[]`                            |
+| `importApi.replicaCount`                               | Number of import-api replicas to deploy                                                             | `1`                             |
+| `importApi.containerPorts.http`                        | import-api HTTP container port                                                                      | `8003`                          |
+| `importApi.livenessProbe.enabled`                      | Enable livenessProbe on import-api containers                                                       | `true`                          |
+| `importApi.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                                             | `10`                            |
+| `importApi.livenessProbe.periodSeconds`                | Period seconds for livenessProbe                                                                    | `30`                            |
+| `importApi.livenessProbe.timeoutSeconds`               | Timeout seconds for livenessProbe                                                                   | `5`                             |
+| `importApi.livenessProbe.failureThreshold`             | Failure threshold for livenessProbe                                                                 | `5`                             |
+| `importApi.livenessProbe.successThreshold`             | Success threshold for livenessProbe                                                                 | `1`                             |
+| `importApi.readinessProbe.enabled`                     | Enable readinessProbe on import-api containers                                                      | `true`                          |
+| `importApi.readinessProbe.initialDelaySeconds`         | Initial delay seconds for readinessProbe                                                            | `10`                            |
+| `importApi.readinessProbe.periodSeconds`               | Period seconds for readinessProbe                                                                   | `30`                            |
+| `importApi.readinessProbe.timeoutSeconds`              | Timeout seconds for readinessProbe                                                                  | `5`                             |
+| `importApi.readinessProbe.failureThreshold`            | Failure threshold for readinessProbe                                                                | `5`                             |
+| `importApi.readinessProbe.successThreshold`            | Success threshold for readinessProbe                                                                | `1`                             |
+| `importApi.startupProbe.enabled`                       | Enable startupProbe on import-api containers                                                        | `false`                         |
+| `importApi.startupProbe.initialDelaySeconds`           | Initial delay seconds for startupProbe                                                              | `10`                            |
+| `importApi.startupProbe.periodSeconds`                 | Period seconds for startupProbe                                                                     | `30`                            |
+| `importApi.startupProbe.timeoutSeconds`                | Timeout seconds for startupProbe                                                                    | `5`                             |
+| `importApi.startupProbe.failureThreshold`              | Failure threshold for startupProbe                                                                  | `5`                             |
+| `importApi.startupProbe.successThreshold`              | Success threshold for startupProbe                                                                  | `1`                             |
+| `importApi.customLivenessProbe`                        | Custom livenessProbe that overrides the default one                                                 | `{}`                            |
+| `importApi.customReadinessProbe`                       | Custom readinessProbe that overrides the default one                                                | `{}`                            |
+| `importApi.customStartupProbe`                         | Custom startupProbe that overrides the default one                                                  | `{}`                            |
+| `importApi.autoscaling.enabled`                        | Enable autoscaling for the import-api containers                                                    | `false`                         |
+| `importApi.autoscaling.minReplicas`                    | The minimal number of containters for the import-api deployment                                     | `1`                             |
+| `importApi.autoscaling.maxReplicas`                    | The maximum number of containers for the import-api deployment                                      | `2`                             |
+| `importApi.autoscaling.targetCPUUtilizationPercentage` | The CPU utilization percentage used for scale up containers in import-api deployment                | `75`                            |
+| `importApi.resources.limits`                           | The resources limits for the import-api containers                                                  | `{}`                            |
+| `importApi.resources.requests`                         | The requested resources for the import-api containers                                               | `{}`                            |
+| `importApi.podSecurityContext.enabled`                 | Enabled import-api pods' Security Context                                                           | `true`                          |
+| `importApi.podSecurityContext.fsGroup`                 | Set import-api pod's Security Context fsGroup                                                       | `0`                             |
+| `importApi.containerSecurityContext.enabled`           | Enabled import-api containers' Security Context                                                     | `true`                          |
+| `importApi.containerSecurityContext.runAsUser`         | Set import-api containers' Security Context runAsUser                                               | `0`                             |
+| `importApi.containerSecurityContext.runAsNonRoot`      | Set import-api containers' Security Context runAsNonRoot                                            | `false`                         |
+| `importApi.configuration`                              | Configuration settings (env vars) for import-api                                                    | `{}`                            |
+| `importApi.secretConfiguration`                        | Configuration settings (env vars) for import-api                                                    | `""`                            |
+| `importApi.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for import-api                     | `""`                            |
+| `importApi.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for import-api                     | `""`                            |
+| `importApi.command`                                    | Override default container command (useful when using custom images)                                | `[]`                            |
+| `importApi.args`                                       | Override default container args (useful when using custom images)                                   | `[]`                            |
+| `importApi.hostAliases`                                | import-api pods host aliases                                                                        | `[]`                            |
+| `importApi.podLabels`                                  | Extra labels for import-api pods                                                                    | `{}`                            |
+| `importApi.podAnnotations`                             | Annotations for import-api pods                                                                     | `{}`                            |
+| `importApi.podAffinityPreset`                          | Pod affinity preset. Ignored if `importApi.affinity` is set. Allowed values: `soft` or `hard`       | `""`                            |
+| `importApi.podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `importApi.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                          |
+| `importApi.nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `importApi.affinity` is set. Allowed values: `soft` or `hard` | `""`                            |
+| `importApi.nodeAffinityPreset.key`                     | Node label key to match. Ignored if `importApi.affinity` is set                                     | `""`                            |
+| `importApi.nodeAffinityPreset.values`                  | Node label values to match. Ignored if `importApi.affinity` is set                                  | `[]`                            |
+| `importApi.affinity`                                   | Affinity for import-api pods assignment                                                             | `{}`                            |
+| `importApi.nodeSelector`                               | Node labels for import-api pods assignment                                                          | `{}`                            |
+| `importApi.tolerations`                                | Tolerations for import-api pods assignment                                                          | `[]`                            |
+| `importApi.updateStrategy.type`                        | import-api statefulset strategy type                                                                | `RollingUpdate`                 |
+| `importApi.priorityClassName`                          | import-api pods' priorityClassName                                                                  | `""`                            |
+| `importApi.schedulerName`                              | Name of the k8s scheduler (other than default) for import-api pods                                  | `""`                            |
+| `importApi.lifecycleHooks`                             | for the import-api container(s) to automate configuration before or after startup                   | `{}`                            |
+| `importApi.extraEnvVars`                               | Array with extra environment variables to add to import-api nodes                                   | `[]`                            |
+| `importApi.extraEnvVarsCM`                             | Name of existing ConfigMap containing extra env vars for import-api nodes                           | `""`                            |
+| `importApi.extraEnvVarsSecret`                         | Name of existing Secret containing extra env vars for import-api nodes                              | `""`                            |
+| `importApi.extraVolumes`                               | Optionally specify extra list of additional volumes for the import-api pod(s)                       | `[]`                            |
+| `importApi.extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts for the import-api container(s)            | `[]`                            |
+| `importApi.sidecars`                                   | Add additional sidecar containers to the import-api pod(s)                                          | `{}`                            |
+| `importApi.initContainers`                             | Add additional init containers to the import-api pod(s)                                             | `{}`                            |
 
 
 ### import-api Service Parameters
@@ -317,51 +319,52 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 ### import-worker Deployment Parameters
 
-| Name                                                 | Description                                                                                            | Value                                      |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
-| `importWorker.image.name`                            | import-worker image registry and repository                                                            | `gcr.io/carto-onprem-artifacts/import-api` |
-| `importWorker.image.tag`                             | import-worker image tag (immutable tags are recommended)                                               | `""`                                       |
-| `importWorker.image.pullPolicy`                      | import-worker image pull policy                                                                        | `IfNotPresent`                             |
-| `importWorker.image.pullSecrets`                     | import-worker image pull secrets                                                                       | `[]`                                       |
-| `importWorker.replicaCount`                          | Number of import-worker replicas to deploy                                                             | `1`                                        |
-| `importWorker.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                    | `{}`                                       |
-| `importWorker.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                   | `{}`                                       |
-| `importWorker.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                     | `{}`                                       |
-| `importWorker.resources.limits`                      | The resources limits for the import-worker containers                                                  | `{}`                                       |
-| `importWorker.resources.requests`                    | The requested resources for the import-worker containers                                               | `{}`                                       |
-| `importWorker.podSecurityContext.enabled`            | Enabled import-worker pods' Security Context                                                           | `true`                                     |
-| `importWorker.podSecurityContext.fsGroup`            | Set import-worker pod's Security Context fsGroup                                                       | `0`                                        |
-| `importWorker.containerSecurityContext.enabled`      | Enabled import-worker containers' Security Context                                                     | `true`                                     |
-| `importWorker.containerSecurityContext.runAsUser`    | Set import-worker containers' Security Context runAsUser                                               | `0`                                        |
-| `importWorker.containerSecurityContext.runAsNonRoot` | Set import-worker containers' Security Context runAsNonRoot                                            | `false`                                    |
-| `importWorker.configuration`                         | Configuration settings (env vars) for import-worker                                                    | `{}`                                       |
-| `importWorker.secretConfiguration`                   | Configuration settings (env vars) for import-worker                                                    | `""`                                       |
-| `importWorker.existingConfigMap`                     | The name of an existing ConfigMap with your custom configuration for import-worker                     | `""`                                       |
-| `importWorker.existingSecret`                        | The name of an existing ConfigMap with your custom configuration for import-worker                     | `""`                                       |
-| `importWorker.command`                               | Override default container command (useful when using custom images)                                   | `[]`                                       |
-| `importWorker.args`                                  | Override default container args (useful when using custom images)                                      | `[]`                                       |
-| `importWorker.hostAliases`                           | import-worker pods host aliases                                                                        | `[]`                                       |
-| `importWorker.podLabels`                             | Extra labels for import-worker pods                                                                    | `{}`                                       |
-| `importWorker.podAnnotations`                        | Annotations for import-worker pods                                                                     | `{}`                                       |
-| `importWorker.podAffinityPreset`                     | Pod affinity preset. Ignored if `importWorker.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                       |
-| `importWorker.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `importWorker.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                     |
-| `importWorker.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `importWorker.affinity` is set. Allowed values: `soft` or `hard` | `""`                                       |
-| `importWorker.nodeAffinityPreset.key`                | Node label key to match. Ignored if `importWorker.affinity` is set                                     | `""`                                       |
-| `importWorker.nodeAffinityPreset.values`             | Node label values to match. Ignored if `importWorker.affinity` is set                                  | `[]`                                       |
-| `importWorker.affinity`                              | Affinity for import-worker pods assignment                                                             | `{}`                                       |
-| `importWorker.nodeSelector`                          | Node labels for import-worker pods assignment                                                          | `{}`                                       |
-| `importWorker.tolerations`                           | Tolerations for import-worker pods assignment                                                          | `[]`                                       |
-| `importWorker.updateStrategy.type`                   | import-worker statefulset strategy type                                                                | `RollingUpdate`                            |
-| `importWorker.priorityClassName`                     | import-worker pods' priorityClassName                                                                  | `""`                                       |
-| `importWorker.schedulerName`                         | Name of the k8s scheduler (other than default) for import-worker pods                                  | `""`                                       |
-| `importWorker.lifecycleHooks`                        | for the import-worker container(s) to automate configuration before or after startup                   | `{}`                                       |
-| `importWorker.extraEnvVars`                          | Array with extra environment variables to add to import-worker nodes                                   | `[]`                                       |
-| `importWorker.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for import-worker nodes                           | `""`                                       |
-| `importWorker.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for import-worker nodes                              | `""`                                       |
-| `importWorker.extraVolumes`                          | Optionally specify extra list of additional volumes for the import-worker pod(s)                       | `[]`                                       |
-| `importWorker.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the import-worker container(s)            | `[]`                                       |
-| `importWorker.sidecars`                              | Add additional sidecar containers to the import-worker pod(s)                                          | `{}`                                       |
-| `importWorker.initContainers`                        | Add additional init containers to the import-worker pod(s)                                             | `{}`                                       |
+| Name                                                 | Description                                                                                            | Value                           |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------- |
+| `importWorker.image.registry`                        | import-worker image registry                                                                           | `gcr.io/carto-onprem-artifacts` |
+| `importWorker.image.repository`                      | import-worker image repository                                                                         | `import-api`                    |
+| `importWorker.image.tag`                             | import-worker image tag (immutable tags are recommended)                                               | `""`                            |
+| `importWorker.image.pullPolicy`                      | import-worker image pull policy                                                                        | `IfNotPresent`                  |
+| `importWorker.image.pullSecrets`                     | import-worker image pull secrets                                                                       | `[]`                            |
+| `importWorker.replicaCount`                          | Number of import-worker replicas to deploy                                                             | `1`                             |
+| `importWorker.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                    | `{}`                            |
+| `importWorker.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                   | `{}`                            |
+| `importWorker.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                     | `{}`                            |
+| `importWorker.resources.limits`                      | The resources limits for the import-worker containers                                                  | `{}`                            |
+| `importWorker.resources.requests`                    | The requested resources for the import-worker containers                                               | `{}`                            |
+| `importWorker.podSecurityContext.enabled`            | Enabled import-worker pods' Security Context                                                           | `true`                          |
+| `importWorker.podSecurityContext.fsGroup`            | Set import-worker pod's Security Context fsGroup                                                       | `0`                             |
+| `importWorker.containerSecurityContext.enabled`      | Enabled import-worker containers' Security Context                                                     | `true`                          |
+| `importWorker.containerSecurityContext.runAsUser`    | Set import-worker containers' Security Context runAsUser                                               | `0`                             |
+| `importWorker.containerSecurityContext.runAsNonRoot` | Set import-worker containers' Security Context runAsNonRoot                                            | `false`                         |
+| `importWorker.configuration`                         | Configuration settings (env vars) for import-worker                                                    | `{}`                            |
+| `importWorker.secretConfiguration`                   | Configuration settings (env vars) for import-worker                                                    | `""`                            |
+| `importWorker.existingConfigMap`                     | The name of an existing ConfigMap with your custom configuration for import-worker                     | `""`                            |
+| `importWorker.existingSecret`                        | The name of an existing ConfigMap with your custom configuration for import-worker                     | `""`                            |
+| `importWorker.command`                               | Override default container command (useful when using custom images)                                   | `[]`                            |
+| `importWorker.args`                                  | Override default container args (useful when using custom images)                                      | `[]`                            |
+| `importWorker.hostAliases`                           | import-worker pods host aliases                                                                        | `[]`                            |
+| `importWorker.podLabels`                             | Extra labels for import-worker pods                                                                    | `{}`                            |
+| `importWorker.podAnnotations`                        | Annotations for import-worker pods                                                                     | `{}`                            |
+| `importWorker.podAffinityPreset`                     | Pod affinity preset. Ignored if `importWorker.affinity` is set. Allowed values: `soft` or `hard`       | `""`                            |
+| `importWorker.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `importWorker.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                          |
+| `importWorker.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `importWorker.affinity` is set. Allowed values: `soft` or `hard` | `""`                            |
+| `importWorker.nodeAffinityPreset.key`                | Node label key to match. Ignored if `importWorker.affinity` is set                                     | `""`                            |
+| `importWorker.nodeAffinityPreset.values`             | Node label values to match. Ignored if `importWorker.affinity` is set                                  | `[]`                            |
+| `importWorker.affinity`                              | Affinity for import-worker pods assignment                                                             | `{}`                            |
+| `importWorker.nodeSelector`                          | Node labels for import-worker pods assignment                                                          | `{}`                            |
+| `importWorker.tolerations`                           | Tolerations for import-worker pods assignment                                                          | `[]`                            |
+| `importWorker.updateStrategy.type`                   | import-worker statefulset strategy type                                                                | `RollingUpdate`                 |
+| `importWorker.priorityClassName`                     | import-worker pods' priorityClassName                                                                  | `""`                            |
+| `importWorker.schedulerName`                         | Name of the k8s scheduler (other than default) for import-worker pods                                  | `""`                            |
+| `importWorker.lifecycleHooks`                        | for the import-worker container(s) to automate configuration before or after startup                   | `{}`                            |
+| `importWorker.extraEnvVars`                          | Array with extra environment variables to add to import-worker nodes                                   | `[]`                            |
+| `importWorker.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for import-worker nodes                           | `""`                            |
+| `importWorker.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for import-worker nodes                              | `""`                            |
+| `importWorker.extraVolumes`                          | Optionally specify extra list of additional volumes for the import-worker pod(s)                       | `[]`                            |
+| `importWorker.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the import-worker container(s)            | `[]`                            |
+| `importWorker.sidecars`                              | Add additional sidecar containers to the import-worker pod(s)                                          | `{}`                            |
+| `importWorker.initContainers`                        | Add additional init containers to the import-worker pod(s)                                             | `{}`                            |
 
 
 ### import-worker ServiceAccount configuration
@@ -375,74 +378,75 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 ### lds-api Deployment Parameters
 
-| Name                                                | Description                                                                                      | Value                                   |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------- |
-| `ldsApi.image.name`                                 | lds-api image registry and repository                                                            | `gcr.io/carto-onprem-artifacts/lds-api` |
-| `ldsApi.image.tag`                                  | lds-api image tag (immutable tags are recommended)                                               | `""`                                    |
-| `ldsApi.image.pullPolicy`                           | lds-api image pull policy                                                                        | `IfNotPresent`                          |
-| `ldsApi.image.pullSecrets`                          | lds-api image pull secrets                                                                       | `[]`                                    |
-| `ldsApi.replicaCount`                               | Number of lds-api replicas to deploy                                                             | `1`                                     |
-| `ldsApi.containerPorts.http`                        | lds-api HTTP container port                                                                      | `8004`                                  |
-| `ldsApi.livenessProbe.enabled`                      | Enable livenessProbe on lds-api containers                                                       | `true`                                  |
-| `ldsApi.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                                          | `10`                                    |
-| `ldsApi.livenessProbe.periodSeconds`                | Period seconds for livenessProbe                                                                 | `30`                                    |
-| `ldsApi.livenessProbe.timeoutSeconds`               | Timeout seconds for livenessProbe                                                                | `5`                                     |
-| `ldsApi.livenessProbe.failureThreshold`             | Failure threshold for livenessProbe                                                              | `5`                                     |
-| `ldsApi.livenessProbe.successThreshold`             | Success threshold for livenessProbe                                                              | `1`                                     |
-| `ldsApi.readinessProbe.enabled`                     | Enable readinessProbe on lds-api containers                                                      | `true`                                  |
-| `ldsApi.readinessProbe.initialDelaySeconds`         | Initial delay seconds for readinessProbe                                                         | `10`                                    |
-| `ldsApi.readinessProbe.periodSeconds`               | Period seconds for readinessProbe                                                                | `30`                                    |
-| `ldsApi.readinessProbe.timeoutSeconds`              | Timeout seconds for readinessProbe                                                               | `5`                                     |
-| `ldsApi.readinessProbe.failureThreshold`            | Failure threshold for readinessProbe                                                             | `5`                                     |
-| `ldsApi.readinessProbe.successThreshold`            | Success threshold for readinessProbe                                                             | `1`                                     |
-| `ldsApi.startupProbe.enabled`                       | Enable startupProbe on lds-api containers                                                        | `false`                                 |
-| `ldsApi.startupProbe.initialDelaySeconds`           | Initial delay seconds for startupProbe                                                           | `10`                                    |
-| `ldsApi.startupProbe.periodSeconds`                 | Period seconds for startupProbe                                                                  | `30`                                    |
-| `ldsApi.startupProbe.timeoutSeconds`                | Timeout seconds for startupProbe                                                                 | `5`                                     |
-| `ldsApi.startupProbe.failureThreshold`              | Failure threshold for startupProbe                                                               | `5`                                     |
-| `ldsApi.startupProbe.successThreshold`              | Success threshold for startupProbe                                                               | `1`                                     |
-| `ldsApi.customLivenessProbe`                        | Custom livenessProbe that overrides the default one                                              | `{}`                                    |
-| `ldsApi.customReadinessProbe`                       | Custom readinessProbe that overrides the default one                                             | `{}`                                    |
-| `ldsApi.customStartupProbe`                         | Custom startupProbe that overrides the default one                                               | `{}`                                    |
-| `ldsApi.autoscaling.enabled`                        | Enable autoscaling for the lds-api containers                                                    | `false`                                 |
-| `ldsApi.autoscaling.minReplicas`                    | The minimal number of containters for the workspldsace-api deployment                            | `1`                                     |
-| `ldsApi.autoscaling.maxReplicas`                    | The maximum number of containers for the lds-api deployment                                      | `2`                                     |
-| `ldsApi.autoscaling.targetCPUUtilizationPercentage` | The CPU utilization percentage used for scale up containers in lds-api deployment                | `75`                                    |
-| `ldsApi.resources.limits`                           | The resources limits for the lds-api containers                                                  | `{}`                                    |
-| `ldsApi.resources.requests`                         | The requested resources for the lds-api containers                                               | `{}`                                    |
-| `ldsApi.podSecurityContext.enabled`                 | Enabled lds-api pods' Security Context                                                           | `true`                                  |
-| `ldsApi.podSecurityContext.fsGroup`                 | Set lds-api pod's Security Context fsGroup                                                       | `0`                                     |
-| `ldsApi.containerSecurityContext.enabled`           | Enabled lds-api containers' Security Context                                                     | `true`                                  |
-| `ldsApi.containerSecurityContext.runAsUser`         | Set lds-api containers' Security Context runAsUser                                               | `0`                                     |
-| `ldsApi.containerSecurityContext.runAsNonRoot`      | Set lds-api containers' Security Context runAsNonRoot                                            | `false`                                 |
-| `ldsApi.configuration`                              | Configuration settings (env vars) for lds-api                                                    | `{}`                                    |
-| `ldsApi.secretConfiguration`                        | Configuration settings (env vars) for lds-api                                                    | `""`                                    |
-| `ldsApi.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for lds-api                     | `""`                                    |
-| `ldsApi.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for lds-api                     | `""`                                    |
-| `ldsApi.command`                                    | Override default container command (useful when using custom images)                             | `[]`                                    |
-| `ldsApi.args`                                       | Override default container args (useful when using custom images)                                | `[]`                                    |
-| `ldsApi.hostAliases`                                | lds-api pods host aliases                                                                        | `[]`                                    |
-| `ldsApi.podLabels`                                  | Extra labels for lds-api pods                                                                    | `{}`                                    |
-| `ldsApi.podAnnotations`                             | Annotations for lds-api pods                                                                     | `{}`                                    |
-| `ldsApi.podAffinityPreset`                          | Pod affinity preset. Ignored if `ldsApi.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                    |
-| `ldsApi.podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `ldsApi.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                  |
-| `ldsApi.nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `ldsApi.affinity` is set. Allowed values: `soft` or `hard` | `""`                                    |
-| `ldsApi.nodeAffinityPreset.key`                     | Node label key to match. Ignored if `ldsApi.affinity` is set                                     | `""`                                    |
-| `ldsApi.nodeAffinityPreset.values`                  | Node label values to match. Ignored if `ldsApi.affinity` is set                                  | `[]`                                    |
-| `ldsApi.affinity`                                   | Affinity for lds-api pods assignment                                                             | `{}`                                    |
-| `ldsApi.nodeSelector`                               | Node labels for lds-api pods assignment                                                          | `{}`                                    |
-| `ldsApi.tolerations`                                | Tolerations for lds-api pods assignment                                                          | `[]`                                    |
-| `ldsApi.updateStrategy.type`                        | lds-api statefulset strategy type                                                                | `RollingUpdate`                         |
-| `ldsApi.priorityClassName`                          | lds-api pods' priorityClassName                                                                  | `""`                                    |
-| `ldsApi.schedulerName`                              | Name of the k8s scheduler (other than default) for lds-api pods                                  | `""`                                    |
-| `ldsApi.lifecycleHooks`                             | for the lds-api container(s) to automate configuration before or after startup                   | `{}`                                    |
-| `ldsApi.extraEnvVars`                               | Array with extra environment variables to add to lds-api nodes                                   | `[]`                                    |
-| `ldsApi.extraEnvVarsCM`                             | Name of existing ConfigMap containing extra env vars for lds-api nodes                           | `""`                                    |
-| `ldsApi.extraEnvVarsSecret`                         | Name of existing Secret containing extra env vars for lds-api nodes                              | `""`                                    |
-| `ldsApi.extraVolumes`                               | Optionally specify extra list of additional volumes for the lds-api pod(s)                       | `[]`                                    |
-| `ldsApi.extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts for the lds-api container(s)            | `[]`                                    |
-| `ldsApi.sidecars`                                   | Add additional sidecar containers to the lds-api pod(s)                                          | `{}`                                    |
-| `ldsApi.initContainers`                             | Add additional init containers to the lds-api pod(s)                                             | `{}`                                    |
+| Name                                                | Description                                                                                      | Value                           |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------- |
+| `ldsApi.image.registry`                             | lds-api image registry                                                                           | `gcr.io/carto-onprem-artifacts` |
+| `ldsApi.image.repository`                           | lds-api image repository                                                                         | `lds-api`                       |
+| `ldsApi.image.tag`                                  | lds-api image tag (immutable tags are recommended)                                               | `""`                            |
+| `ldsApi.image.pullPolicy`                           | lds-api image pull policy                                                                        | `IfNotPresent`                  |
+| `ldsApi.image.pullSecrets`                          | lds-api image pull secrets                                                                       | `[]`                            |
+| `ldsApi.replicaCount`                               | Number of lds-api replicas to deploy                                                             | `1`                             |
+| `ldsApi.containerPorts.http`                        | lds-api HTTP container port                                                                      | `8004`                          |
+| `ldsApi.livenessProbe.enabled`                      | Enable livenessProbe on lds-api containers                                                       | `true`                          |
+| `ldsApi.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                                          | `10`                            |
+| `ldsApi.livenessProbe.periodSeconds`                | Period seconds for livenessProbe                                                                 | `30`                            |
+| `ldsApi.livenessProbe.timeoutSeconds`               | Timeout seconds for livenessProbe                                                                | `5`                             |
+| `ldsApi.livenessProbe.failureThreshold`             | Failure threshold for livenessProbe                                                              | `5`                             |
+| `ldsApi.livenessProbe.successThreshold`             | Success threshold for livenessProbe                                                              | `1`                             |
+| `ldsApi.readinessProbe.enabled`                     | Enable readinessProbe on lds-api containers                                                      | `true`                          |
+| `ldsApi.readinessProbe.initialDelaySeconds`         | Initial delay seconds for readinessProbe                                                         | `10`                            |
+| `ldsApi.readinessProbe.periodSeconds`               | Period seconds for readinessProbe                                                                | `30`                            |
+| `ldsApi.readinessProbe.timeoutSeconds`              | Timeout seconds for readinessProbe                                                               | `5`                             |
+| `ldsApi.readinessProbe.failureThreshold`            | Failure threshold for readinessProbe                                                             | `5`                             |
+| `ldsApi.readinessProbe.successThreshold`            | Success threshold for readinessProbe                                                             | `1`                             |
+| `ldsApi.startupProbe.enabled`                       | Enable startupProbe on lds-api containers                                                        | `false`                         |
+| `ldsApi.startupProbe.initialDelaySeconds`           | Initial delay seconds for startupProbe                                                           | `10`                            |
+| `ldsApi.startupProbe.periodSeconds`                 | Period seconds for startupProbe                                                                  | `30`                            |
+| `ldsApi.startupProbe.timeoutSeconds`                | Timeout seconds for startupProbe                                                                 | `5`                             |
+| `ldsApi.startupProbe.failureThreshold`              | Failure threshold for startupProbe                                                               | `5`                             |
+| `ldsApi.startupProbe.successThreshold`              | Success threshold for startupProbe                                                               | `1`                             |
+| `ldsApi.customLivenessProbe`                        | Custom livenessProbe that overrides the default one                                              | `{}`                            |
+| `ldsApi.customReadinessProbe`                       | Custom readinessProbe that overrides the default one                                             | `{}`                            |
+| `ldsApi.customStartupProbe`                         | Custom startupProbe that overrides the default one                                               | `{}`                            |
+| `ldsApi.autoscaling.enabled`                        | Enable autoscaling for the lds-api containers                                                    | `false`                         |
+| `ldsApi.autoscaling.minReplicas`                    | The minimal number of containters for the workspldsace-api deployment                            | `1`                             |
+| `ldsApi.autoscaling.maxReplicas`                    | The maximum number of containers for the lds-api deployment                                      | `2`                             |
+| `ldsApi.autoscaling.targetCPUUtilizationPercentage` | The CPU utilization percentage used for scale up containers in lds-api deployment                | `75`                            |
+| `ldsApi.resources.limits`                           | The resources limits for the lds-api containers                                                  | `{}`                            |
+| `ldsApi.resources.requests`                         | The requested resources for the lds-api containers                                               | `{}`                            |
+| `ldsApi.podSecurityContext.enabled`                 | Enabled lds-api pods' Security Context                                                           | `true`                          |
+| `ldsApi.podSecurityContext.fsGroup`                 | Set lds-api pod's Security Context fsGroup                                                       | `0`                             |
+| `ldsApi.containerSecurityContext.enabled`           | Enabled lds-api containers' Security Context                                                     | `true`                          |
+| `ldsApi.containerSecurityContext.runAsUser`         | Set lds-api containers' Security Context runAsUser                                               | `0`                             |
+| `ldsApi.containerSecurityContext.runAsNonRoot`      | Set lds-api containers' Security Context runAsNonRoot                                            | `false`                         |
+| `ldsApi.configuration`                              | Configuration settings (env vars) for lds-api                                                    | `{}`                            |
+| `ldsApi.secretConfiguration`                        | Configuration settings (env vars) for lds-api                                                    | `""`                            |
+| `ldsApi.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for lds-api                     | `""`                            |
+| `ldsApi.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for lds-api                     | `""`                            |
+| `ldsApi.command`                                    | Override default container command (useful when using custom images)                             | `[]`                            |
+| `ldsApi.args`                                       | Override default container args (useful when using custom images)                                | `[]`                            |
+| `ldsApi.hostAliases`                                | lds-api pods host aliases                                                                        | `[]`                            |
+| `ldsApi.podLabels`                                  | Extra labels for lds-api pods                                                                    | `{}`                            |
+| `ldsApi.podAnnotations`                             | Annotations for lds-api pods                                                                     | `{}`                            |
+| `ldsApi.podAffinityPreset`                          | Pod affinity preset. Ignored if `ldsApi.affinity` is set. Allowed values: `soft` or `hard`       | `""`                            |
+| `ldsApi.podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `ldsApi.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                          |
+| `ldsApi.nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `ldsApi.affinity` is set. Allowed values: `soft` or `hard` | `""`                            |
+| `ldsApi.nodeAffinityPreset.key`                     | Node label key to match. Ignored if `ldsApi.affinity` is set                                     | `""`                            |
+| `ldsApi.nodeAffinityPreset.values`                  | Node label values to match. Ignored if `ldsApi.affinity` is set                                  | `[]`                            |
+| `ldsApi.affinity`                                   | Affinity for lds-api pods assignment                                                             | `{}`                            |
+| `ldsApi.nodeSelector`                               | Node labels for lds-api pods assignment                                                          | `{}`                            |
+| `ldsApi.tolerations`                                | Tolerations for lds-api pods assignment                                                          | `[]`                            |
+| `ldsApi.updateStrategy.type`                        | lds-api statefulset strategy type                                                                | `RollingUpdate`                 |
+| `ldsApi.priorityClassName`                          | lds-api pods' priorityClassName                                                                  | `""`                            |
+| `ldsApi.schedulerName`                              | Name of the k8s scheduler (other than default) for lds-api pods                                  | `""`                            |
+| `ldsApi.lifecycleHooks`                             | for the lds-api container(s) to automate configuration before or after startup                   | `{}`                            |
+| `ldsApi.extraEnvVars`                               | Array with extra environment variables to add to lds-api nodes                                   | `[]`                            |
+| `ldsApi.extraEnvVarsCM`                             | Name of existing ConfigMap containing extra env vars for lds-api nodes                           | `""`                            |
+| `ldsApi.extraEnvVarsSecret`                         | Name of existing Secret containing extra env vars for lds-api nodes                              | `""`                            |
+| `ldsApi.extraVolumes`                               | Optionally specify extra list of additional volumes for the lds-api pod(s)                       | `[]`                            |
+| `ldsApi.extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts for the lds-api container(s)            | `[]`                            |
+| `ldsApi.sidecars`                                   | Add additional sidecar containers to the lds-api pod(s)                                          | `{}`                            |
+| `ldsApi.initContainers`                             | Add additional init containers to the lds-api pod(s)                                             | `{}`                            |
 
 
 ### lds-api Service Parameters
@@ -472,74 +476,75 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 ### maps-api Deployment Parameters
 
-| Name                                                 | Description                                                                                       | Value                                    |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| `mapsApi.image.name`                                 | maps-api image registry and repository                                                            | `gcr.io/carto-onprem-artifacts/maps-api` |
-| `mapsApi.image.tag`                                  | maps-api image tag (immutable tags are recommended)                                               | `""`                                     |
-| `mapsApi.image.pullPolicy`                           | maps-api image pull policy                                                                        | `IfNotPresent`                           |
-| `mapsApi.image.pullSecrets`                          | maps-api image pull secrets                                                                       | `[]`                                     |
-| `mapsApi.replicaCount`                               | Number of maps-api replicas to deploy                                                             | `1`                                      |
-| `mapsApi.containerPorts.http`                        | maps-api HTTP container port                                                                      | `8002`                                   |
-| `mapsApi.livenessProbe.enabled`                      | Enable livenessProbe on maps-api containers                                                       | `true`                                   |
-| `mapsApi.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                                           | `10`                                     |
-| `mapsApi.livenessProbe.periodSeconds`                | Period seconds for livenessProbe                                                                  | `30`                                     |
-| `mapsApi.livenessProbe.timeoutSeconds`               | Timeout seconds for livenessProbe                                                                 | `5`                                      |
-| `mapsApi.livenessProbe.failureThreshold`             | Failure threshold for livenessProbe                                                               | `5`                                      |
-| `mapsApi.livenessProbe.successThreshold`             | Success threshold for livenessProbe                                                               | `1`                                      |
-| `mapsApi.readinessProbe.enabled`                     | Enable readinessProbe on maps-api containers                                                      | `true`                                   |
-| `mapsApi.readinessProbe.initialDelaySeconds`         | Initial delay seconds for readinessProbe                                                          | `10`                                     |
-| `mapsApi.readinessProbe.periodSeconds`               | Period seconds for readinessProbe                                                                 | `30`                                     |
-| `mapsApi.readinessProbe.timeoutSeconds`              | Timeout seconds for readinessProbe                                                                | `5`                                      |
-| `mapsApi.readinessProbe.failureThreshold`            | Failure threshold for readinessProbe                                                              | `5`                                      |
-| `mapsApi.readinessProbe.successThreshold`            | Success threshold for readinessProbe                                                              | `1`                                      |
-| `mapsApi.startupProbe.enabled`                       | Enable startupProbe on maps-api containers                                                        | `false`                                  |
-| `mapsApi.startupProbe.initialDelaySeconds`           | Initial delay seconds for startupProbe                                                            | `10`                                     |
-| `mapsApi.startupProbe.periodSeconds`                 | Period seconds for startupProbe                                                                   | `30`                                     |
-| `mapsApi.startupProbe.timeoutSeconds`                | Timeout seconds for startupProbe                                                                  | `5`                                      |
-| `mapsApi.startupProbe.failureThreshold`              | Failure threshold for startupProbe                                                                | `5`                                      |
-| `mapsApi.startupProbe.successThreshold`              | Success threshold for startupProbe                                                                | `1`                                      |
-| `mapsApi.customLivenessProbe`                        | Custom livenessProbe that overrides the default one                                               | `{}`                                     |
-| `mapsApi.customReadinessProbe`                       | Custom readinessProbe that overrides the default one                                              | `{}`                                     |
-| `mapsApi.customStartupProbe`                         | Custom startupProbe that overrides the default one                                                | `{}`                                     |
-| `mapsApi.autoscaling.enabled`                        | Enable autoscaling for the maps-api containers                                                    | `false`                                  |
-| `mapsApi.autoscaling.minReplicas`                    | The minimal number of containters for the maps-api deployment                                     | `2`                                      |
-| `mapsApi.autoscaling.maxReplicas`                    | The maximum number of containers for the maps-api deployment                                      | `3`                                      |
-| `mapsApi.autoscaling.targetCPUUtilizationPercentage` | The CPU utilization percentage used for scale up containers in maps-api deployment                | `75`                                     |
-| `mapsApi.resources.limits`                           | The resources limits for the maps-api containers                                                  | `{}`                                     |
-| `mapsApi.resources.requests`                         | The requested resources for the maps-api containers                                               | `{}`                                     |
-| `mapsApi.podSecurityContext.enabled`                 | Enabled maps-api pods' Security Context                                                           | `true`                                   |
-| `mapsApi.podSecurityContext.fsGroup`                 | Set maps-api pod's Security Context fsGroup                                                       | `0`                                      |
-| `mapsApi.containerSecurityContext.enabled`           | Enabled maps-api containers' Security Context                                                     | `true`                                   |
-| `mapsApi.containerSecurityContext.runAsUser`         | Set maps-api containers' Security Context runAsUser                                               | `0`                                      |
-| `mapsApi.containerSecurityContext.runAsNonRoot`      | Set maps-api containers' Security Context runAsNonRoot                                            | `false`                                  |
-| `mapsApi.configuration`                              | Configuration settings (env vars) for maps-api                                                    | `{}`                                     |
-| `mapsApi.secretConfiguration`                        | Configuration settings (env vars) for maps-api                                                    | `""`                                     |
-| `mapsApi.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for maps-api                     | `""`                                     |
-| `mapsApi.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for maps-api                     | `""`                                     |
-| `mapsApi.command`                                    | Override default container command (useful when using custom images)                              | `[]`                                     |
-| `mapsApi.args`                                       | Override default container args (useful when using custom images)                                 | `[]`                                     |
-| `mapsApi.hostAliases`                                | maps-api pods host aliases                                                                        | `[]`                                     |
-| `mapsApi.podLabels`                                  | Extra labels for maps-api pods                                                                    | `{}`                                     |
-| `mapsApi.podAnnotations`                             | Annotations for maps-api pods                                                                     | `{}`                                     |
-| `mapsApi.podAffinityPreset`                          | Pod affinity preset. Ignored if `mapsApi.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                     |
-| `mapsApi.podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `mapsApi.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                   |
-| `mapsApi.nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `mapsApi.affinity` is set. Allowed values: `soft` or `hard` | `""`                                     |
-| `mapsApi.nodeAffinityPreset.key`                     | Node label key to match. Ignored if `mapsApi.affinity` is set                                     | `""`                                     |
-| `mapsApi.nodeAffinityPreset.values`                  | Node label values to match. Ignored if `mapsApi.affinity` is set                                  | `[]`                                     |
-| `mapsApi.affinity`                                   | Affinity for maps-api pods assignment                                                             | `{}`                                     |
-| `mapsApi.nodeSelector`                               | Node labels for maps-api pods assignment                                                          | `{}`                                     |
-| `mapsApi.tolerations`                                | Tolerations for maps-api pods assignment                                                          | `[]`                                     |
-| `mapsApi.updateStrategy.type`                        | maps-api statefulset strategy type                                                                | `RollingUpdate`                          |
-| `mapsApi.priorityClassName`                          | maps-api pods' priorityClassName                                                                  | `""`                                     |
-| `mapsApi.schedulerName`                              | Name of the k8s scheduler (other than default) for maps-api pods                                  | `""`                                     |
-| `mapsApi.lifecycleHooks`                             | for the maps-api container(s) to automate configuration before or after startup                   | `{}`                                     |
-| `mapsApi.extraEnvVars`                               | Array with extra environment variables to add to maps-api nodes                                   | `[]`                                     |
-| `mapsApi.extraEnvVarsCM`                             | Name of existing ConfigMap containing extra env vars for maps-api nodes                           | `""`                                     |
-| `mapsApi.extraEnvVarsSecret`                         | Name of existing Secret containing extra env vars for maps-api nodes                              | `""`                                     |
-| `mapsApi.extraVolumes`                               | Optionally specify extra list of additional volumes for the maps-api pod(s)                       | `[]`                                     |
-| `mapsApi.extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts for the maps-api container(s)            | `[]`                                     |
-| `mapsApi.sidecars`                                   | Add additional sidecar containers to the maps-api pod(s)                                          | `{}`                                     |
-| `mapsApi.initContainers`                             | Add additional init containers to the maps-api pod(s)                                             | `{}`                                     |
+| Name                                                 | Description                                                                                       | Value                           |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `mapsApi.image.registry`                             | maps-api image registry                                                                           | `gcr.io/carto-onprem-artifacts` |
+| `mapsApi.image.repository`                           | maps-api image repository                                                                         | `maps-api`                      |
+| `mapsApi.image.tag`                                  | maps-api image tag (immutable tags are recommended)                                               | `""`                            |
+| `mapsApi.image.pullPolicy`                           | maps-api image pull policy                                                                        | `IfNotPresent`                  |
+| `mapsApi.image.pullSecrets`                          | maps-api image pull secrets                                                                       | `[]`                            |
+| `mapsApi.replicaCount`                               | Number of maps-api replicas to deploy                                                             | `1`                             |
+| `mapsApi.containerPorts.http`                        | maps-api HTTP container port                                                                      | `8002`                          |
+| `mapsApi.livenessProbe.enabled`                      | Enable livenessProbe on maps-api containers                                                       | `true`                          |
+| `mapsApi.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                                           | `10`                            |
+| `mapsApi.livenessProbe.periodSeconds`                | Period seconds for livenessProbe                                                                  | `30`                            |
+| `mapsApi.livenessProbe.timeoutSeconds`               | Timeout seconds for livenessProbe                                                                 | `5`                             |
+| `mapsApi.livenessProbe.failureThreshold`             | Failure threshold for livenessProbe                                                               | `5`                             |
+| `mapsApi.livenessProbe.successThreshold`             | Success threshold for livenessProbe                                                               | `1`                             |
+| `mapsApi.readinessProbe.enabled`                     | Enable readinessProbe on maps-api containers                                                      | `true`                          |
+| `mapsApi.readinessProbe.initialDelaySeconds`         | Initial delay seconds for readinessProbe                                                          | `10`                            |
+| `mapsApi.readinessProbe.periodSeconds`               | Period seconds for readinessProbe                                                                 | `30`                            |
+| `mapsApi.readinessProbe.timeoutSeconds`              | Timeout seconds for readinessProbe                                                                | `5`                             |
+| `mapsApi.readinessProbe.failureThreshold`            | Failure threshold for readinessProbe                                                              | `5`                             |
+| `mapsApi.readinessProbe.successThreshold`            | Success threshold for readinessProbe                                                              | `1`                             |
+| `mapsApi.startupProbe.enabled`                       | Enable startupProbe on maps-api containers                                                        | `false`                         |
+| `mapsApi.startupProbe.initialDelaySeconds`           | Initial delay seconds for startupProbe                                                            | `10`                            |
+| `mapsApi.startupProbe.periodSeconds`                 | Period seconds for startupProbe                                                                   | `30`                            |
+| `mapsApi.startupProbe.timeoutSeconds`                | Timeout seconds for startupProbe                                                                  | `5`                             |
+| `mapsApi.startupProbe.failureThreshold`              | Failure threshold for startupProbe                                                                | `5`                             |
+| `mapsApi.startupProbe.successThreshold`              | Success threshold for startupProbe                                                                | `1`                             |
+| `mapsApi.customLivenessProbe`                        | Custom livenessProbe that overrides the default one                                               | `{}`                            |
+| `mapsApi.customReadinessProbe`                       | Custom readinessProbe that overrides the default one                                              | `{}`                            |
+| `mapsApi.customStartupProbe`                         | Custom startupProbe that overrides the default one                                                | `{}`                            |
+| `mapsApi.autoscaling.enabled`                        | Enable autoscaling for the maps-api containers                                                    | `false`                         |
+| `mapsApi.autoscaling.minReplicas`                    | The minimal number of containters for the maps-api deployment                                     | `2`                             |
+| `mapsApi.autoscaling.maxReplicas`                    | The maximum number of containers for the maps-api deployment                                      | `3`                             |
+| `mapsApi.autoscaling.targetCPUUtilizationPercentage` | The CPU utilization percentage used for scale up containers in maps-api deployment                | `75`                            |
+| `mapsApi.resources.limits`                           | The resources limits for the maps-api containers                                                  | `{}`                            |
+| `mapsApi.resources.requests`                         | The requested resources for the maps-api containers                                               | `{}`                            |
+| `mapsApi.podSecurityContext.enabled`                 | Enabled maps-api pods' Security Context                                                           | `true`                          |
+| `mapsApi.podSecurityContext.fsGroup`                 | Set maps-api pod's Security Context fsGroup                                                       | `0`                             |
+| `mapsApi.containerSecurityContext.enabled`           | Enabled maps-api containers' Security Context                                                     | `true`                          |
+| `mapsApi.containerSecurityContext.runAsUser`         | Set maps-api containers' Security Context runAsUser                                               | `0`                             |
+| `mapsApi.containerSecurityContext.runAsNonRoot`      | Set maps-api containers' Security Context runAsNonRoot                                            | `false`                         |
+| `mapsApi.configuration`                              | Configuration settings (env vars) for maps-api                                                    | `{}`                            |
+| `mapsApi.secretConfiguration`                        | Configuration settings (env vars) for maps-api                                                    | `""`                            |
+| `mapsApi.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for maps-api                     | `""`                            |
+| `mapsApi.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for maps-api                     | `""`                            |
+| `mapsApi.command`                                    | Override default container command (useful when using custom images)                              | `[]`                            |
+| `mapsApi.args`                                       | Override default container args (useful when using custom images)                                 | `[]`                            |
+| `mapsApi.hostAliases`                                | maps-api pods host aliases                                                                        | `[]`                            |
+| `mapsApi.podLabels`                                  | Extra labels for maps-api pods                                                                    | `{}`                            |
+| `mapsApi.podAnnotations`                             | Annotations for maps-api pods                                                                     | `{}`                            |
+| `mapsApi.podAffinityPreset`                          | Pod affinity preset. Ignored if `mapsApi.affinity` is set. Allowed values: `soft` or `hard`       | `""`                            |
+| `mapsApi.podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `mapsApi.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                          |
+| `mapsApi.nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `mapsApi.affinity` is set. Allowed values: `soft` or `hard` | `""`                            |
+| `mapsApi.nodeAffinityPreset.key`                     | Node label key to match. Ignored if `mapsApi.affinity` is set                                     | `""`                            |
+| `mapsApi.nodeAffinityPreset.values`                  | Node label values to match. Ignored if `mapsApi.affinity` is set                                  | `[]`                            |
+| `mapsApi.affinity`                                   | Affinity for maps-api pods assignment                                                             | `{}`                            |
+| `mapsApi.nodeSelector`                               | Node labels for maps-api pods assignment                                                          | `{}`                            |
+| `mapsApi.tolerations`                                | Tolerations for maps-api pods assignment                                                          | `[]`                            |
+| `mapsApi.updateStrategy.type`                        | maps-api statefulset strategy type                                                                | `RollingUpdate`                 |
+| `mapsApi.priorityClassName`                          | maps-api pods' priorityClassName                                                                  | `""`                            |
+| `mapsApi.schedulerName`                              | Name of the k8s scheduler (other than default) for maps-api pods                                  | `""`                            |
+| `mapsApi.lifecycleHooks`                             | for the maps-api container(s) to automate configuration before or after startup                   | `{}`                            |
+| `mapsApi.extraEnvVars`                               | Array with extra environment variables to add to maps-api nodes                                   | `[]`                            |
+| `mapsApi.extraEnvVarsCM`                             | Name of existing ConfigMap containing extra env vars for maps-api nodes                           | `""`                            |
+| `mapsApi.extraEnvVarsSecret`                         | Name of existing Secret containing extra env vars for maps-api nodes                              | `""`                            |
+| `mapsApi.extraVolumes`                               | Optionally specify extra list of additional volumes for the maps-api pod(s)                       | `[]`                            |
+| `mapsApi.extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts for the maps-api container(s)            | `[]`                            |
+| `mapsApi.sidecars`                                   | Add additional sidecar containers to the maps-api pod(s)                                          | `{}`                            |
+| `mapsApi.initContainers`                             | Add additional init containers to the maps-api pod(s)                                             | `{}`                            |
 
 
 ### maps-api Service Parameters
@@ -569,75 +574,76 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 ### router Deployment Parameters
 
-| Name                                                | Description                                                                                      | Value                                  |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------- |
-| `router.image.name`                                 | router image registry and repository                                                             | `gcr.io/carto-onprem-artifacts/router` |
-| `router.image.tag`                                  | router image tag (immutable tags are recommended)                                                | `""`                                   |
-| `router.image.pullPolicy`                           | router image pull policy                                                                         | `IfNotPresent`                         |
-| `router.image.pullSecrets`                          | router image pull secrets                                                                        | `[]`                                   |
-| `router.replicaCount`                               | Number of router replicas to deploy                                                              | `1`                                    |
-| `router.containerPorts.http`                        | router HTTP container port                                                                       | `8080`                                 |
-| `router.containerPorts.https`                       | router HTTPS container port                                                                      | `8443`                                 |
-| `router.livenessProbe.enabled`                      | Enable livenessProbe on router containers                                                        | `true`                                 |
-| `router.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                                          | `10`                                   |
-| `router.livenessProbe.periodSeconds`                | Period seconds for livenessProbe                                                                 | `30`                                   |
-| `router.livenessProbe.timeoutSeconds`               | Timeout seconds for livenessProbe                                                                | `5`                                    |
-| `router.livenessProbe.failureThreshold`             | Failure threshold for livenessProbe                                                              | `5`                                    |
-| `router.livenessProbe.successThreshold`             | Success threshold for livenessProbe                                                              | `1`                                    |
-| `router.readinessProbe.enabled`                     | Enable readinessProbe on router containers                                                       | `true`                                 |
-| `router.readinessProbe.initialDelaySeconds`         | Initial delay seconds for readinessProbe                                                         | `10`                                   |
-| `router.readinessProbe.periodSeconds`               | Period seconds for readinessProbe                                                                | `30`                                   |
-| `router.readinessProbe.timeoutSeconds`              | Timeout seconds for readinessProbe                                                               | `5`                                    |
-| `router.readinessProbe.failureThreshold`            | Failure threshold for readinessProbe                                                             | `5`                                    |
-| `router.readinessProbe.successThreshold`            | Success threshold for readinessProbe                                                             | `1`                                    |
-| `router.startupProbe.enabled`                       | Enable startupProbe on router containers                                                         | `false`                                |
-| `router.startupProbe.initialDelaySeconds`           | Initial delay seconds for startupProbe                                                           | `10`                                   |
-| `router.startupProbe.periodSeconds`                 | Period seconds for startupProbe                                                                  | `30`                                   |
-| `router.startupProbe.timeoutSeconds`                | Timeout seconds for startupProbe                                                                 | `5`                                    |
-| `router.startupProbe.failureThreshold`              | Failure threshold for startupProbe                                                               | `5`                                    |
-| `router.startupProbe.successThreshold`              | Success threshold for startupProbe                                                               | `1`                                    |
-| `router.customLivenessProbe`                        | Custom livenessProbe that overrides the default one                                              | `{}`                                   |
-| `router.customReadinessProbe`                       | Custom readinessProbe that overrides the default one                                             | `{}`                                   |
-| `router.customStartupProbe`                         | Custom startupProbe that overrides the default one                                               | `{}`                                   |
-| `router.autoscaling.enabled`                        | Enable autoscaling for the router containers                                                     | `false`                                |
-| `router.autoscaling.minReplicas`                    | The minimal number of containters for the router deployment                                      | `1`                                    |
-| `router.autoscaling.maxReplicas`                    | The maximum number of containers for the router deployment                                       | `2`                                    |
-| `router.autoscaling.targetCPUUtilizationPercentage` | The CPU utilization percentage used for scale up containers in router deployment                 | `75`                                   |
-| `router.resources.limits`                           | The resources limits for the router containers                                                   | `{}`                                   |
-| `router.resources.requests`                         | The requested resources for the router containers                                                | `{}`                                   |
-| `router.podSecurityContext.enabled`                 | Enabled router pods' Security Context                                                            | `true`                                 |
-| `router.podSecurityContext.fsGroup`                 | Set router pod's Security Context fsGroup                                                        | `0`                                    |
-| `router.containerSecurityContext.enabled`           | Enabled router containers' Security Context                                                      | `true`                                 |
-| `router.containerSecurityContext.runAsUser`         | Set router containers' Security Context runAsUser                                                | `0`                                    |
-| `router.containerSecurityContext.runAsNonRoot`      | Set router containers' Security Context runAsNonRoot                                             | `false`                                |
-| `router.configuration`                              | Configuration settings (env vars) for router                                                     | `{}`                                   |
-| `router.secretConfiguration`                        | Configuration settings (env vars) for router                                                     | `""`                                   |
-| `router.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for router                      | `""`                                   |
-| `router.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for router                      | `""`                                   |
-| `router.command`                                    | Override default container command (useful when using custom images)                             | `[]`                                   |
-| `router.args`                                       | Override default container args (useful when using custom images)                                | `[]`                                   |
-| `router.hostAliases`                                | router pods host aliases                                                                         | `[]`                                   |
-| `router.podLabels`                                  | Extra labels for router pods                                                                     | `{}`                                   |
-| `router.podAnnotations`                             | Annotations for router pods                                                                      | `{}`                                   |
-| `router.podAffinityPreset`                          | Pod affinity preset. Ignored if `router.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                   |
-| `router.podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `router.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                 |
-| `router.nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `router.affinity` is set. Allowed values: `soft` or `hard` | `""`                                   |
-| `router.nodeAffinityPreset.key`                     | Node label key to match. Ignored if `router.affinity` is set                                     | `""`                                   |
-| `router.nodeAffinityPreset.values`                  | Node label values to match. Ignored if `router.affinity` is set                                  | `[]`                                   |
-| `router.affinity`                                   | Affinity for router pods assignment                                                              | `{}`                                   |
-| `router.nodeSelector`                               | Node labels for router pods assignment                                                           | `{}`                                   |
-| `router.tolerations`                                | Tolerations for router pods assignment                                                           | `[]`                                   |
-| `router.updateStrategy.type`                        | router statefulset strategy type                                                                 | `RollingUpdate`                        |
-| `router.priorityClassName`                          | router pods' priorityClassName                                                                   | `""`                                   |
-| `router.schedulerName`                              | Name of the k8s scheduler (other than default) for router pods                                   | `""`                                   |
-| `router.lifecycleHooks`                             | for the router container(s) to automate configuration before or after startup                    | `{}`                                   |
-| `router.extraEnvVars`                               | Array with extra environment variables to add to router nodes                                    | `[]`                                   |
-| `router.extraEnvVarsCM`                             | Name of existing ConfigMap containing extra env vars for router nodes                            | `""`                                   |
-| `router.extraEnvVarsSecret`                         | Name of existing Secret containing extra env vars for router nodes                               | `""`                                   |
-| `router.extraVolumes`                               | Optionally specify extra list of additional volumes for the router pod(s)                        | `[]`                                   |
-| `router.extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts for the router container(s)             | `[]`                                   |
-| `router.sidecars`                                   | Add additional sidecar containers to the router pod(s)                                           | `{}`                                   |
-| `router.initContainers`                             | Add additional init containers to the router pod(s)                                              | `{}`                                   |
+| Name                                                | Description                                                                                      | Value                           |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------- |
+| `router.image.registry`                             | router image registry                                                                            | `gcr.io/carto-onprem-artifacts` |
+| `router.image.repository`                           | router image repository                                                                          | `router`                        |
+| `router.image.tag`                                  | router image tag (immutable tags are recommended)                                                | `""`                            |
+| `router.image.pullPolicy`                           | router image pull policy                                                                         | `IfNotPresent`                  |
+| `router.image.pullSecrets`                          | router image pull secrets                                                                        | `[]`                            |
+| `router.replicaCount`                               | Number of router replicas to deploy                                                              | `1`                             |
+| `router.containerPorts.http`                        | router HTTP container port                                                                       | `8080`                          |
+| `router.containerPorts.https`                       | router HTTPS container port                                                                      | `8443`                          |
+| `router.livenessProbe.enabled`                      | Enable livenessProbe on router containers                                                        | `true`                          |
+| `router.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                                          | `10`                            |
+| `router.livenessProbe.periodSeconds`                | Period seconds for livenessProbe                                                                 | `30`                            |
+| `router.livenessProbe.timeoutSeconds`               | Timeout seconds for livenessProbe                                                                | `5`                             |
+| `router.livenessProbe.failureThreshold`             | Failure threshold for livenessProbe                                                              | `5`                             |
+| `router.livenessProbe.successThreshold`             | Success threshold for livenessProbe                                                              | `1`                             |
+| `router.readinessProbe.enabled`                     | Enable readinessProbe on router containers                                                       | `true`                          |
+| `router.readinessProbe.initialDelaySeconds`         | Initial delay seconds for readinessProbe                                                         | `10`                            |
+| `router.readinessProbe.periodSeconds`               | Period seconds for readinessProbe                                                                | `30`                            |
+| `router.readinessProbe.timeoutSeconds`              | Timeout seconds for readinessProbe                                                               | `5`                             |
+| `router.readinessProbe.failureThreshold`            | Failure threshold for readinessProbe                                                             | `5`                             |
+| `router.readinessProbe.successThreshold`            | Success threshold for readinessProbe                                                             | `1`                             |
+| `router.startupProbe.enabled`                       | Enable startupProbe on router containers                                                         | `false`                         |
+| `router.startupProbe.initialDelaySeconds`           | Initial delay seconds for startupProbe                                                           | `10`                            |
+| `router.startupProbe.periodSeconds`                 | Period seconds for startupProbe                                                                  | `30`                            |
+| `router.startupProbe.timeoutSeconds`                | Timeout seconds for startupProbe                                                                 | `5`                             |
+| `router.startupProbe.failureThreshold`              | Failure threshold for startupProbe                                                               | `5`                             |
+| `router.startupProbe.successThreshold`              | Success threshold for startupProbe                                                               | `1`                             |
+| `router.customLivenessProbe`                        | Custom livenessProbe that overrides the default one                                              | `{}`                            |
+| `router.customReadinessProbe`                       | Custom readinessProbe that overrides the default one                                             | `{}`                            |
+| `router.customStartupProbe`                         | Custom startupProbe that overrides the default one                                               | `{}`                            |
+| `router.autoscaling.enabled`                        | Enable autoscaling for the router containers                                                     | `false`                         |
+| `router.autoscaling.minReplicas`                    | The minimal number of containters for the router deployment                                      | `1`                             |
+| `router.autoscaling.maxReplicas`                    | The maximum number of containers for the router deployment                                       | `2`                             |
+| `router.autoscaling.targetCPUUtilizationPercentage` | The CPU utilization percentage used for scale up containers in router deployment                 | `75`                            |
+| `router.resources.limits`                           | The resources limits for the router containers                                                   | `{}`                            |
+| `router.resources.requests`                         | The requested resources for the router containers                                                | `{}`                            |
+| `router.podSecurityContext.enabled`                 | Enabled router pods' Security Context                                                            | `true`                          |
+| `router.podSecurityContext.fsGroup`                 | Set router pod's Security Context fsGroup                                                        | `0`                             |
+| `router.containerSecurityContext.enabled`           | Enabled router containers' Security Context                                                      | `true`                          |
+| `router.containerSecurityContext.runAsUser`         | Set router containers' Security Context runAsUser                                                | `0`                             |
+| `router.containerSecurityContext.runAsNonRoot`      | Set router containers' Security Context runAsNonRoot                                             | `false`                         |
+| `router.configuration`                              | Configuration settings (env vars) for router                                                     | `{}`                            |
+| `router.secretConfiguration`                        | Configuration settings (env vars) for router                                                     | `""`                            |
+| `router.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for router                      | `""`                            |
+| `router.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for router                      | `""`                            |
+| `router.command`                                    | Override default container command (useful when using custom images)                             | `[]`                            |
+| `router.args`                                       | Override default container args (useful when using custom images)                                | `[]`                            |
+| `router.hostAliases`                                | router pods host aliases                                                                         | `[]`                            |
+| `router.podLabels`                                  | Extra labels for router pods                                                                     | `{}`                            |
+| `router.podAnnotations`                             | Annotations for router pods                                                                      | `{}`                            |
+| `router.podAffinityPreset`                          | Pod affinity preset. Ignored if `router.affinity` is set. Allowed values: `soft` or `hard`       | `""`                            |
+| `router.podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `router.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                          |
+| `router.nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `router.affinity` is set. Allowed values: `soft` or `hard` | `""`                            |
+| `router.nodeAffinityPreset.key`                     | Node label key to match. Ignored if `router.affinity` is set                                     | `""`                            |
+| `router.nodeAffinityPreset.values`                  | Node label values to match. Ignored if `router.affinity` is set                                  | `[]`                            |
+| `router.affinity`                                   | Affinity for router pods assignment                                                              | `{}`                            |
+| `router.nodeSelector`                               | Node labels for router pods assignment                                                           | `{}`                            |
+| `router.tolerations`                                | Tolerations for router pods assignment                                                           | `[]`                            |
+| `router.updateStrategy.type`                        | router statefulset strategy type                                                                 | `RollingUpdate`                 |
+| `router.priorityClassName`                          | router pods' priorityClassName                                                                   | `""`                            |
+| `router.schedulerName`                              | Name of the k8s scheduler (other than default) for router pods                                   | `""`                            |
+| `router.lifecycleHooks`                             | for the router container(s) to automate configuration before or after startup                    | `{}`                            |
+| `router.extraEnvVars`                               | Array with extra environment variables to add to router nodes                                    | `[]`                            |
+| `router.extraEnvVarsCM`                             | Name of existing ConfigMap containing extra env vars for router nodes                            | `""`                            |
+| `router.extraEnvVarsSecret`                         | Name of existing Secret containing extra env vars for router nodes                               | `""`                            |
+| `router.extraVolumes`                               | Optionally specify extra list of additional volumes for the router pod(s)                        | `[]`                            |
+| `router.extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts for the router container(s)             | `[]`                            |
+| `router.sidecars`                                   | Add additional sidecar containers to the router pod(s)                                           | `{}`                            |
+| `router.initContainers`                             | Add additional init containers to the router pod(s)                                              | `{}`                            |
 
 
 ### router Service Parameters
@@ -669,70 +675,71 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 ### httpCache Deployment Parameters
 
-| Name                                              | Description                                                                                         | Value                                      |
-| ------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| `httpCache.image.name`                            | http-cache image registry and repository                                                            | `gcr.io/carto-onprem-artifacts/http-cache` |
-| `httpCache.image.tag`                             | http-cache image tag (immutable tags are recommended)                                               | `""`                                       |
-| `httpCache.image.pullPolicy`                      | http-cache image pull policy                                                                        | `IfNotPresent`                             |
-| `httpCache.image.pullSecrets`                     | http-cache image pull secrets                                                                       | `[]`                                       |
-| `httpCache.replicaCount`                          | Number of http-cache replicas to deploy                                                             | `1`                                        |
-| `httpCache.containerPorts.http`                   | http-cache HTTP container port                                                                      | `6081`                                     |
-| `httpCache.livenessProbe.enabled`                 | Enable livenessProbe on http-cache containers                                                       | `true`                                     |
-| `httpCache.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                             | `10`                                       |
-| `httpCache.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                    | `30`                                       |
-| `httpCache.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                   | `5`                                        |
-| `httpCache.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                 | `5`                                        |
-| `httpCache.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                 | `1`                                        |
-| `httpCache.readinessProbe.enabled`                | Enable readinessProbe on http-cache containers                                                      | `true`                                     |
-| `httpCache.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                            | `10`                                       |
-| `httpCache.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                   | `30`                                       |
-| `httpCache.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                  | `5`                                        |
-| `httpCache.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                | `5`                                        |
-| `httpCache.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                | `1`                                        |
-| `httpCache.startupProbe.enabled`                  | Enable startupProbe on http-cache containers                                                        | `false`                                    |
-| `httpCache.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                              | `10`                                       |
-| `httpCache.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                     | `30`                                       |
-| `httpCache.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                    | `5`                                        |
-| `httpCache.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                  | `5`                                        |
-| `httpCache.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                  | `1`                                        |
-| `httpCache.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                 | `{}`                                       |
-| `httpCache.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                | `{}`                                       |
-| `httpCache.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                  | `{}`                                       |
-| `httpCache.resources.limits`                      | The resources limits for the http-cache containers                                                  | `{}`                                       |
-| `httpCache.resources.requests`                    | The requested resources for the http-cache containers                                               | `{}`                                       |
-| `httpCache.podSecurityContext.enabled`            | Enabled http-cache pods' Security Context                                                           | `true`                                     |
-| `httpCache.podSecurityContext.fsGroup`            | Set http-cache pod's Security Context fsGroup                                                       | `0`                                        |
-| `httpCache.containerSecurityContext.enabled`      | Enabled http-cache containers' Security Context                                                     | `true`                                     |
-| `httpCache.containerSecurityContext.runAsUser`    | Set http-cache containers' Security Context runAsUser                                               | `0`                                        |
-| `httpCache.containerSecurityContext.runAsNonRoot` | Set http-cache containers' Security Context runAsNonRoot                                            | `false`                                    |
-| `httpCache.configuration`                         | Configuration settings (env vars) for http-cache                                                    | `{}`                                       |
-| `httpCache.secretConfiguration`                   | Configuration settings (env vars) for http-cache                                                    | `""`                                       |
-| `httpCache.existingConfigMap`                     | The name of an existing ConfigMap with your custom configuration for http-cache                     | `""`                                       |
-| `httpCache.existingSecret`                        | The name of an existing ConfigMap with your custom configuration for http-cache                     | `""`                                       |
-| `httpCache.command`                               | Override default container command (useful when using custom images)                                | `[]`                                       |
-| `httpCache.args`                                  | Override default container args (useful when using custom images)                                   | `[]`                                       |
-| `httpCache.hostAliases`                           | http-cache pods host aliases                                                                        | `[]`                                       |
-| `httpCache.podLabels`                             | Extra labels for http-cache pods                                                                    | `{}`                                       |
-| `httpCache.podAnnotations`                        | Annotations for http-cache pods                                                                     | `{}`                                       |
-| `httpCache.podAffinityPreset`                     | Pod affinity preset. Ignored if `httpCache.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                       |
-| `httpCache.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `httpCache.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                     |
-| `httpCache.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `httpCache.affinity` is set. Allowed values: `soft` or `hard` | `""`                                       |
-| `httpCache.nodeAffinityPreset.key`                | Node label key to match. Ignored if `httpCache.affinity` is set                                     | `""`                                       |
-| `httpCache.nodeAffinityPreset.values`             | Node label values to match. Ignored if `httpCache.affinity` is set                                  | `[]`                                       |
-| `httpCache.affinity`                              | Affinity for http-cache pods assignment                                                             | `{}`                                       |
-| `httpCache.nodeSelector`                          | Node labels for http-cache pods assignment                                                          | `{}`                                       |
-| `httpCache.tolerations`                           | Tolerations for http-cache pods assignment                                                          | `[]`                                       |
-| `httpCache.updateStrategy.type`                   | http-cache statefulset strategy type                                                                | `RollingUpdate`                            |
-| `httpCache.priorityClassName`                     | http-cache pods' priorityClassName                                                                  | `""`                                       |
-| `httpCache.schedulerName`                         | Name of the k8s scheduler (other than default) for http-cache pods                                  | `""`                                       |
-| `httpCache.lifecycleHooks`                        | for the http-cache container(s) to automate configuration before or after startup                   | `{}`                                       |
-| `httpCache.extraEnvVars`                          | Array with extra environment variables to add to http-cache nodes                                   | `[]`                                       |
-| `httpCache.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for http-cache nodes                           | `""`                                       |
-| `httpCache.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for http-cache nodes                              | `""`                                       |
-| `httpCache.extraVolumes`                          | Optionally specify extra list of additional volumes for the http-cache pod(s)                       | `[]`                                       |
-| `httpCache.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the http-cache container(s)            | `[]`                                       |
-| `httpCache.sidecars`                              | Add additional sidecar containers to the http-cache pod(s)                                          | `{}`                                       |
-| `httpCache.initContainers`                        | Add additional init containers to the http-cache pod(s)                                             | `{}`                                       |
+| Name                                              | Description                                                                                         | Value                           |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `httpCache.image.registry`                        | http-cache image registry                                                                           | `gcr.io/carto-onprem-artifacts` |
+| `httpCache.image.repository`                      | http-cache image repository                                                                         | `http-cache`                    |
+| `httpCache.image.tag`                             | http-cache image tag (immutable tags are recommended)                                               | `""`                            |
+| `httpCache.image.pullPolicy`                      | http-cache image pull policy                                                                        | `IfNotPresent`                  |
+| `httpCache.image.pullSecrets`                     | http-cache image pull secrets                                                                       | `[]`                            |
+| `httpCache.replicaCount`                          | Number of http-cache replicas to deploy                                                             | `1`                             |
+| `httpCache.containerPorts.http`                   | http-cache HTTP container port                                                                      | `6081`                          |
+| `httpCache.livenessProbe.enabled`                 | Enable livenessProbe on http-cache containers                                                       | `true`                          |
+| `httpCache.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                             | `10`                            |
+| `httpCache.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                    | `30`                            |
+| `httpCache.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                   | `5`                             |
+| `httpCache.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                 | `5`                             |
+| `httpCache.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                 | `1`                             |
+| `httpCache.readinessProbe.enabled`                | Enable readinessProbe on http-cache containers                                                      | `true`                          |
+| `httpCache.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                            | `10`                            |
+| `httpCache.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                   | `30`                            |
+| `httpCache.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                  | `5`                             |
+| `httpCache.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                | `5`                             |
+| `httpCache.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                | `1`                             |
+| `httpCache.startupProbe.enabled`                  | Enable startupProbe on http-cache containers                                                        | `false`                         |
+| `httpCache.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                              | `10`                            |
+| `httpCache.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                     | `30`                            |
+| `httpCache.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                    | `5`                             |
+| `httpCache.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                  | `5`                             |
+| `httpCache.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                  | `1`                             |
+| `httpCache.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                 | `{}`                            |
+| `httpCache.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                | `{}`                            |
+| `httpCache.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                  | `{}`                            |
+| `httpCache.resources.limits`                      | The resources limits for the http-cache containers                                                  | `{}`                            |
+| `httpCache.resources.requests`                    | The requested resources for the http-cache containers                                               | `{}`                            |
+| `httpCache.podSecurityContext.enabled`            | Enabled http-cache pods' Security Context                                                           | `true`                          |
+| `httpCache.podSecurityContext.fsGroup`            | Set http-cache pod's Security Context fsGroup                                                       | `0`                             |
+| `httpCache.containerSecurityContext.enabled`      | Enabled http-cache containers' Security Context                                                     | `true`                          |
+| `httpCache.containerSecurityContext.runAsUser`    | Set http-cache containers' Security Context runAsUser                                               | `0`                             |
+| `httpCache.containerSecurityContext.runAsNonRoot` | Set http-cache containers' Security Context runAsNonRoot                                            | `false`                         |
+| `httpCache.configuration`                         | Configuration settings (env vars) for http-cache                                                    | `{}`                            |
+| `httpCache.secretConfiguration`                   | Configuration settings (env vars) for http-cache                                                    | `""`                            |
+| `httpCache.existingConfigMap`                     | The name of an existing ConfigMap with your custom configuration for http-cache                     | `""`                            |
+| `httpCache.existingSecret`                        | The name of an existing ConfigMap with your custom configuration for http-cache                     | `""`                            |
+| `httpCache.command`                               | Override default container command (useful when using custom images)                                | `[]`                            |
+| `httpCache.args`                                  | Override default container args (useful when using custom images)                                   | `[]`                            |
+| `httpCache.hostAliases`                           | http-cache pods host aliases                                                                        | `[]`                            |
+| `httpCache.podLabels`                             | Extra labels for http-cache pods                                                                    | `{}`                            |
+| `httpCache.podAnnotations`                        | Annotations for http-cache pods                                                                     | `{}`                            |
+| `httpCache.podAffinityPreset`                     | Pod affinity preset. Ignored if `httpCache.affinity` is set. Allowed values: `soft` or `hard`       | `""`                            |
+| `httpCache.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `httpCache.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                          |
+| `httpCache.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `httpCache.affinity` is set. Allowed values: `soft` or `hard` | `""`                            |
+| `httpCache.nodeAffinityPreset.key`                | Node label key to match. Ignored if `httpCache.affinity` is set                                     | `""`                            |
+| `httpCache.nodeAffinityPreset.values`             | Node label values to match. Ignored if `httpCache.affinity` is set                                  | `[]`                            |
+| `httpCache.affinity`                              | Affinity for http-cache pods assignment                                                             | `{}`                            |
+| `httpCache.nodeSelector`                          | Node labels for http-cache pods assignment                                                          | `{}`                            |
+| `httpCache.tolerations`                           | Tolerations for http-cache pods assignment                                                          | `[]`                            |
+| `httpCache.updateStrategy.type`                   | http-cache statefulset strategy type                                                                | `RollingUpdate`                 |
+| `httpCache.priorityClassName`                     | http-cache pods' priorityClassName                                                                  | `""`                            |
+| `httpCache.schedulerName`                         | Name of the k8s scheduler (other than default) for http-cache pods                                  | `""`                            |
+| `httpCache.lifecycleHooks`                        | for the http-cache container(s) to automate configuration before or after startup                   | `{}`                            |
+| `httpCache.extraEnvVars`                          | Array with extra environment variables to add to http-cache nodes                                   | `[]`                            |
+| `httpCache.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for http-cache nodes                           | `""`                            |
+| `httpCache.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for http-cache nodes                              | `""`                            |
+| `httpCache.extraVolumes`                          | Optionally specify extra list of additional volumes for the http-cache pod(s)                       | `[]`                            |
+| `httpCache.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the http-cache container(s)            | `[]`                            |
+| `httpCache.sidecars`                              | Add additional sidecar containers to the http-cache pod(s)                                          | `{}`                            |
+| `httpCache.initContainers`                        | Add additional init containers to the http-cache pod(s)                                             | `{}`                            |
 
 
 ### http-cache Service Parameters
@@ -762,70 +769,71 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 ### cdnInvalidatorSub Deployment Parameters
 
-| Name                                                      | Description                                                                                                 | Value                                                         |
-| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `cdnInvalidatorSub.image.name`                            | cdnInvalidatorSub image registry and repository                                                             | `gcr.io/carto-onprem-artifacts/consumers/cdn-invalidator-sub` |
-| `cdnInvalidatorSub.image.tag`                             | cdnInvalidatorSub image tag (immutable tags are recommended)                                                | `""`                                                          |
-| `cdnInvalidatorSub.image.pullPolicy`                      | cdnInvalidatorSub image pull policy                                                                         | `IfNotPresent`                                                |
-| `cdnInvalidatorSub.image.pullSecrets`                     | cdnInvalidatorSub image pull secrets                                                                        | `[]`                                                          |
-| `cdnInvalidatorSub.replicaCount`                          | Number of cdnInvalidatorSub replicas to deploy                                                              | `1`                                                           |
-| `cdnInvalidatorSub.containerPorts.http`                   | cdnInvalidatorSub HTTP container port                                                                       | `3000`                                                        |
-| `cdnInvalidatorSub.livenessProbe.enabled`                 | Enable livenessProbe on cdnInvalidatorSub containers                                                        | `false`                                                       |
-| `cdnInvalidatorSub.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                     | `10`                                                          |
-| `cdnInvalidatorSub.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                            | `30`                                                          |
-| `cdnInvalidatorSub.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                           | `5`                                                           |
-| `cdnInvalidatorSub.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                         | `5`                                                           |
-| `cdnInvalidatorSub.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                         | `1`                                                           |
-| `cdnInvalidatorSub.readinessProbe.enabled`                | Enable readinessProbe on cdnInvalidatorSub containers                                                       | `false`                                                       |
-| `cdnInvalidatorSub.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                    | `10`                                                          |
-| `cdnInvalidatorSub.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                           | `30`                                                          |
-| `cdnInvalidatorSub.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                          | `5`                                                           |
-| `cdnInvalidatorSub.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                        | `5`                                                           |
-| `cdnInvalidatorSub.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                        | `1`                                                           |
-| `cdnInvalidatorSub.startupProbe.enabled`                  | Enable startupProbe on cdnInvalidatorSub containers                                                         | `false`                                                       |
-| `cdnInvalidatorSub.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                      | `10`                                                          |
-| `cdnInvalidatorSub.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                             | `30`                                                          |
-| `cdnInvalidatorSub.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                            | `5`                                                           |
-| `cdnInvalidatorSub.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                          | `5`                                                           |
-| `cdnInvalidatorSub.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                          | `1`                                                           |
-| `cdnInvalidatorSub.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                         | `{}`                                                          |
-| `cdnInvalidatorSub.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                        | `{}`                                                          |
-| `cdnInvalidatorSub.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                          | `{}`                                                          |
-| `cdnInvalidatorSub.resources.limits`                      | The resources limits for the cdnInvalidatorSub containers                                                   | `{}`                                                          |
-| `cdnInvalidatorSub.resources.requests`                    | The requested resources for the cdnInvalidatorSub containers                                                | `{}`                                                          |
-| `cdnInvalidatorSub.podSecurityContext.enabled`            | Enabled cdnInvalidatorSub pods' Security Context                                                            | `true`                                                        |
-| `cdnInvalidatorSub.podSecurityContext.fsGroup`            | Set cdnInvalidatorSub pod's Security Context fsGroup                                                        | `0`                                                           |
-| `cdnInvalidatorSub.containerSecurityContext.enabled`      | Enabled cdnInvalidatorSub containers' Security Context                                                      | `true`                                                        |
-| `cdnInvalidatorSub.containerSecurityContext.runAsUser`    | Set cdnInvalidatorSub containers' Security Context runAsUser                                                | `0`                                                           |
-| `cdnInvalidatorSub.containerSecurityContext.runAsNonRoot` | Set cdnInvalidatorSub containers' Security Context runAsNonRoot                                             | `false`                                                       |
-| `cdnInvalidatorSub.configuration`                         | Configuration settings (env vars) for cdnInvalidatorSub                                                     | `{}`                                                          |
-| `cdnInvalidatorSub.secretConfiguration`                   | Configuration settings (env vars) for cdnInvalidatorSub                                                     | `""`                                                          |
-| `cdnInvalidatorSub.existingConfigMap`                     | The name of an existing ConfigMap with your custom configuration for cdnInvalidatorSub                      | `""`                                                          |
-| `cdnInvalidatorSub.existingSecret`                        | The name of an existing ConfigMap with your custom configuration for cdnInvalidatorSub                      | `""`                                                          |
-| `cdnInvalidatorSub.command`                               | Override default container command (useful when using custom images)                                        | `[]`                                                          |
-| `cdnInvalidatorSub.args`                                  | Override default container args (useful when using custom images)                                           | `[]`                                                          |
-| `cdnInvalidatorSub.hostAliases`                           | cdnInvalidatorSub pods host aliases                                                                         | `[]`                                                          |
-| `cdnInvalidatorSub.podLabels`                             | Extra labels for cdnInvalidatorSub pods                                                                     | `{}`                                                          |
-| `cdnInvalidatorSub.podAnnotations`                        | Annotations for cdnInvalidatorSub pods                                                                      | `{}`                                                          |
-| `cdnInvalidatorSub.podAffinityPreset`                     | Pod affinity preset. Ignored if `cdnInvalidatorSub.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                                          |
-| `cdnInvalidatorSub.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `cdnInvalidatorSub.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                                        |
-| `cdnInvalidatorSub.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `cdnInvalidatorSub.affinity` is set. Allowed values: `soft` or `hard` | `""`                                                          |
-| `cdnInvalidatorSub.nodeAffinityPreset.key`                | Node label key to match. Ignored if `cdnInvalidatorSub.affinity` is set                                     | `""`                                                          |
-| `cdnInvalidatorSub.nodeAffinityPreset.values`             | Node label values to match. Ignored if `cdnInvalidatorSub.affinity` is set                                  | `[]`                                                          |
-| `cdnInvalidatorSub.affinity`                              | Affinity for cdnInvalidatorSub pods assignment                                                              | `{}`                                                          |
-| `cdnInvalidatorSub.nodeSelector`                          | Node labels for cdnInvalidatorSub pods assignment                                                           | `{}`                                                          |
-| `cdnInvalidatorSub.tolerations`                           | Tolerations for cdnInvalidatorSub pods assignment                                                           | `[]`                                                          |
-| `cdnInvalidatorSub.updateStrategy.type`                   | cdnInvalidatorSub statefulset strategy type                                                                 | `RollingUpdate`                                               |
-| `cdnInvalidatorSub.priorityClassName`                     | cdnInvalidatorSub pods' priorityClassName                                                                   | `""`                                                          |
-| `cdnInvalidatorSub.schedulerName`                         | Name of the k8s scheduler (other than default) for cdnInvalidatorSub pods                                   | `""`                                                          |
-| `cdnInvalidatorSub.lifecycleHooks`                        | for the cdnInvalidatorSub container(s) to automate configuration before or after startup                    | `{}`                                                          |
-| `cdnInvalidatorSub.extraEnvVars`                          | Array with extra environment variables to add to cdnInvalidatorSub nodes                                    | `[]`                                                          |
-| `cdnInvalidatorSub.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for cdnInvalidatorSub nodes                            | `""`                                                          |
-| `cdnInvalidatorSub.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for cdnInvalidatorSub nodes                               | `""`                                                          |
-| `cdnInvalidatorSub.extraVolumes`                          | Optionally specify extra list of additional volumes for the cdnInvalidatorSub pod(s)                        | `[]`                                                          |
-| `cdnInvalidatorSub.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the cdnInvalidatorSub container(s)             | `[]`                                                          |
-| `cdnInvalidatorSub.sidecars`                              | Add additional sidecar containers to the cdnInvalidatorSub pod(s)                                           | `{}`                                                          |
-| `cdnInvalidatorSub.initContainers`                        | Add additional init containers to the cdnInvalidatorSub pod(s)                                              | `{}`                                                          |
+| Name                                                      | Description                                                                                                 | Value                           |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `cdnInvalidatorSub.image.registry`                        | cdn-invalidator-sub image registry                                                                          | `gcr.io/carto-onprem-artifacts` |
+| `cdnInvalidatorSub.image.repository`                      | cdn-invalidator-sub image repository                                                                        | `consumers/cdn-invalidator-sub` |
+| `cdnInvalidatorSub.image.tag`                             | cdn-invalidator-sub image tag (immutable tags are recommended)                                              | `""`                            |
+| `cdnInvalidatorSub.image.pullPolicy`                      | cdn-invalidator-sub image pull policy                                                                       | `IfNotPresent`                  |
+| `cdnInvalidatorSub.image.pullSecrets`                     | cdn-invalidator-sub image pull secrets                                                                      | `[]`                            |
+| `cdnInvalidatorSub.replicaCount`                          | Number of cdnInvalidatorSub replicas to deploy                                                              | `1`                             |
+| `cdnInvalidatorSub.containerPorts.http`                   | cdnInvalidatorSub HTTP container port                                                                       | `3000`                          |
+| `cdnInvalidatorSub.livenessProbe.enabled`                 | Enable livenessProbe on cdnInvalidatorSub containers                                                        | `false`                         |
+| `cdnInvalidatorSub.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                     | `10`                            |
+| `cdnInvalidatorSub.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                            | `30`                            |
+| `cdnInvalidatorSub.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                           | `5`                             |
+| `cdnInvalidatorSub.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                         | `5`                             |
+| `cdnInvalidatorSub.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                         | `1`                             |
+| `cdnInvalidatorSub.readinessProbe.enabled`                | Enable readinessProbe on cdnInvalidatorSub containers                                                       | `false`                         |
+| `cdnInvalidatorSub.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                    | `10`                            |
+| `cdnInvalidatorSub.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                           | `30`                            |
+| `cdnInvalidatorSub.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                          | `5`                             |
+| `cdnInvalidatorSub.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                        | `5`                             |
+| `cdnInvalidatorSub.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                        | `1`                             |
+| `cdnInvalidatorSub.startupProbe.enabled`                  | Enable startupProbe on cdnInvalidatorSub containers                                                         | `false`                         |
+| `cdnInvalidatorSub.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                      | `10`                            |
+| `cdnInvalidatorSub.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                             | `30`                            |
+| `cdnInvalidatorSub.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                            | `5`                             |
+| `cdnInvalidatorSub.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                          | `5`                             |
+| `cdnInvalidatorSub.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                          | `1`                             |
+| `cdnInvalidatorSub.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                         | `{}`                            |
+| `cdnInvalidatorSub.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                        | `{}`                            |
+| `cdnInvalidatorSub.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                          | `{}`                            |
+| `cdnInvalidatorSub.resources.limits`                      | The resources limits for the cdnInvalidatorSub containers                                                   | `{}`                            |
+| `cdnInvalidatorSub.resources.requests`                    | The requested resources for the cdnInvalidatorSub containers                                                | `{}`                            |
+| `cdnInvalidatorSub.podSecurityContext.enabled`            | Enabled cdnInvalidatorSub pods' Security Context                                                            | `true`                          |
+| `cdnInvalidatorSub.podSecurityContext.fsGroup`            | Set cdnInvalidatorSub pod's Security Context fsGroup                                                        | `0`                             |
+| `cdnInvalidatorSub.containerSecurityContext.enabled`      | Enabled cdnInvalidatorSub containers' Security Context                                                      | `true`                          |
+| `cdnInvalidatorSub.containerSecurityContext.runAsUser`    | Set cdnInvalidatorSub containers' Security Context runAsUser                                                | `0`                             |
+| `cdnInvalidatorSub.containerSecurityContext.runAsNonRoot` | Set cdnInvalidatorSub containers' Security Context runAsNonRoot                                             | `false`                         |
+| `cdnInvalidatorSub.configuration`                         | Configuration settings (env vars) for cdnInvalidatorSub                                                     | `{}`                            |
+| `cdnInvalidatorSub.secretConfiguration`                   | Configuration settings (env vars) for cdnInvalidatorSub                                                     | `""`                            |
+| `cdnInvalidatorSub.existingConfigMap`                     | The name of an existing ConfigMap with your custom configuration for cdnInvalidatorSub                      | `""`                            |
+| `cdnInvalidatorSub.existingSecret`                        | The name of an existing ConfigMap with your custom configuration for cdnInvalidatorSub                      | `""`                            |
+| `cdnInvalidatorSub.command`                               | Override default container command (useful when using custom images)                                        | `[]`                            |
+| `cdnInvalidatorSub.args`                                  | Override default container args (useful when using custom images)                                           | `[]`                            |
+| `cdnInvalidatorSub.hostAliases`                           | cdnInvalidatorSub pods host aliases                                                                         | `[]`                            |
+| `cdnInvalidatorSub.podLabels`                             | Extra labels for cdnInvalidatorSub pods                                                                     | `{}`                            |
+| `cdnInvalidatorSub.podAnnotations`                        | Annotations for cdnInvalidatorSub pods                                                                      | `{}`                            |
+| `cdnInvalidatorSub.podAffinityPreset`                     | Pod affinity preset. Ignored if `cdnInvalidatorSub.affinity` is set. Allowed values: `soft` or `hard`       | `""`                            |
+| `cdnInvalidatorSub.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `cdnInvalidatorSub.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                          |
+| `cdnInvalidatorSub.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `cdnInvalidatorSub.affinity` is set. Allowed values: `soft` or `hard` | `""`                            |
+| `cdnInvalidatorSub.nodeAffinityPreset.key`                | Node label key to match. Ignored if `cdnInvalidatorSub.affinity` is set                                     | `""`                            |
+| `cdnInvalidatorSub.nodeAffinityPreset.values`             | Node label values to match. Ignored if `cdnInvalidatorSub.affinity` is set                                  | `[]`                            |
+| `cdnInvalidatorSub.affinity`                              | Affinity for cdnInvalidatorSub pods assignment                                                              | `{}`                            |
+| `cdnInvalidatorSub.nodeSelector`                          | Node labels for cdnInvalidatorSub pods assignment                                                           | `{}`                            |
+| `cdnInvalidatorSub.tolerations`                           | Tolerations for cdnInvalidatorSub pods assignment                                                           | `[]`                            |
+| `cdnInvalidatorSub.updateStrategy.type`                   | cdnInvalidatorSub statefulset strategy type                                                                 | `RollingUpdate`                 |
+| `cdnInvalidatorSub.priorityClassName`                     | cdnInvalidatorSub pods' priorityClassName                                                                   | `""`                            |
+| `cdnInvalidatorSub.schedulerName`                         | Name of the k8s scheduler (other than default) for cdnInvalidatorSub pods                                   | `""`                            |
+| `cdnInvalidatorSub.lifecycleHooks`                        | for the cdnInvalidatorSub container(s) to automate configuration before or after startup                    | `{}`                            |
+| `cdnInvalidatorSub.extraEnvVars`                          | Array with extra environment variables to add to cdnInvalidatorSub nodes                                    | `[]`                            |
+| `cdnInvalidatorSub.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for cdnInvalidatorSub nodes                            | `""`                            |
+| `cdnInvalidatorSub.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for cdnInvalidatorSub nodes                               | `""`                            |
+| `cdnInvalidatorSub.extraVolumes`                          | Optionally specify extra list of additional volumes for the cdnInvalidatorSub pod(s)                        | `[]`                            |
+| `cdnInvalidatorSub.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the cdnInvalidatorSub container(s)             | `[]`                            |
+| `cdnInvalidatorSub.sidecars`                              | Add additional sidecar containers to the cdnInvalidatorSub pod(s)                                           | `{}`                            |
+| `cdnInvalidatorSub.initContainers`                        | Add additional init containers to the cdnInvalidatorSub pod(s)                                              | `{}`                            |
 
 
 ### cdnInvalidatorSub Service Parameters
@@ -856,74 +864,75 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 ### workspace-api Deployment Parameters
 
-| Name                                                      | Description                                                                                            | Value                                         |
-| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
-| `workspaceApi.image.name`                                 | workspace-api image registry and repository                                                            | `gcr.io/carto-onprem-artifacts/workspace-api` |
-| `workspaceApi.image.tag`                                  | workspace-api image tag (immutable tags are recommended)                                               | `""`                                          |
-| `workspaceApi.image.pullPolicy`                           | workspace-api image pull policy                                                                        | `IfNotPresent`                                |
-| `workspaceApi.image.pullSecrets`                          | workspace-api image pull secrets                                                                       | `[]`                                          |
-| `workspaceApi.replicaCount`                               | Number of workspace-api replicas to deploy                                                             | `1`                                           |
-| `workspaceApi.containerPorts.http`                        | workspace-api HTTP container port                                                                      | `8001`                                        |
-| `workspaceApi.livenessProbe.enabled`                      | Enable livenessProbe on workspace-api containers                                                       | `true`                                        |
-| `workspaceApi.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                                                | `10`                                          |
-| `workspaceApi.livenessProbe.periodSeconds`                | Period seconds for livenessProbe                                                                       | `30`                                          |
-| `workspaceApi.livenessProbe.timeoutSeconds`               | Timeout seconds for livenessProbe                                                                      | `5`                                           |
-| `workspaceApi.livenessProbe.failureThreshold`             | Failure threshold for livenessProbe                                                                    | `5`                                           |
-| `workspaceApi.livenessProbe.successThreshold`             | Success threshold for livenessProbe                                                                    | `1`                                           |
-| `workspaceApi.readinessProbe.enabled`                     | Enable readinessProbe on workspace-api containers                                                      | `true`                                        |
-| `workspaceApi.readinessProbe.initialDelaySeconds`         | Initial delay seconds for readinessProbe                                                               | `10`                                          |
-| `workspaceApi.readinessProbe.periodSeconds`               | Period seconds for readinessProbe                                                                      | `30`                                          |
-| `workspaceApi.readinessProbe.timeoutSeconds`              | Timeout seconds for readinessProbe                                                                     | `5`                                           |
-| `workspaceApi.readinessProbe.failureThreshold`            | Failure threshold for readinessProbe                                                                   | `5`                                           |
-| `workspaceApi.readinessProbe.successThreshold`            | Success threshold for readinessProbe                                                                   | `1`                                           |
-| `workspaceApi.startupProbe.enabled`                       | Enable startupProbe on workspace-api containers                                                        | `false`                                       |
-| `workspaceApi.startupProbe.initialDelaySeconds`           | Initial delay seconds for startupProbe                                                                 | `10`                                          |
-| `workspaceApi.startupProbe.periodSeconds`                 | Period seconds for startupProbe                                                                        | `30`                                          |
-| `workspaceApi.startupProbe.timeoutSeconds`                | Timeout seconds for startupProbe                                                                       | `5`                                           |
-| `workspaceApi.startupProbe.failureThreshold`              | Failure threshold for startupProbe                                                                     | `5`                                           |
-| `workspaceApi.startupProbe.successThreshold`              | Success threshold for startupProbe                                                                     | `1`                                           |
-| `workspaceApi.customLivenessProbe`                        | Custom livenessProbe that overrides the default one                                                    | `{}`                                          |
-| `workspaceApi.customReadinessProbe`                       | Custom readinessProbe that overrides the default one                                                   | `{}`                                          |
-| `workspaceApi.customStartupProbe`                         | Custom startupProbe that overrides the default one                                                     | `{}`                                          |
-| `workspaceApi.autoscaling.enabled`                        | Enable autoscaling for the workspace-api containers                                                    | `false`                                       |
-| `workspaceApi.autoscaling.minReplicas`                    | The minimal number of containters for the workspace-api deployment                                     | `2`                                           |
-| `workspaceApi.autoscaling.maxReplicas`                    | The maximum number of containers for the workspace-api deployment                                      | `3`                                           |
-| `workspaceApi.autoscaling.targetCPUUtilizationPercentage` | The CPU utilization percentage used for scale up containers in workspace-api deployment                | `75`                                          |
-| `workspaceApi.resources.limits`                           | The resources limits for the workspace-api containers                                                  | `{}`                                          |
-| `workspaceApi.resources.requests`                         | The requested resources for the workspace-api containers                                               | `{}`                                          |
-| `workspaceApi.podSecurityContext.enabled`                 | Enabled workspace-api pods' Security Context                                                           | `true`                                        |
-| `workspaceApi.podSecurityContext.fsGroup`                 | Set workspace-api pod's Security Context fsGroup                                                       | `0`                                           |
-| `workspaceApi.containerSecurityContext.enabled`           | Enabled workspace-api containers' Security Context                                                     | `true`                                        |
-| `workspaceApi.containerSecurityContext.runAsUser`         | Set workspace-api containers' Security Context runAsUser                                               | `0`                                           |
-| `workspaceApi.containerSecurityContext.runAsNonRoot`      | Set workspace-api containers' Security Context runAsNonRoot                                            | `false`                                       |
-| `workspaceApi.configuration`                              | Configuration settings (env vars) for workspace-api                                                    | `{}`                                          |
-| `workspaceApi.secretConfiguration`                        | Configuration settings (env vars) for workspace-api                                                    | `""`                                          |
-| `workspaceApi.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for workspace-api                     | `""`                                          |
-| `workspaceApi.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for workspace-api                     | `""`                                          |
-| `workspaceApi.command`                                    | Override default container command (useful when using custom images)                                   | `[]`                                          |
-| `workspaceApi.args`                                       | Override default container args (useful when using custom images)                                      | `[]`                                          |
-| `workspaceApi.hostAliases`                                | workspace-api pods host aliases                                                                        | `[]`                                          |
-| `workspaceApi.podLabels`                                  | Extra labels for workspace-api pods                                                                    | `{}`                                          |
-| `workspaceApi.podAnnotations`                             | Annotations for workspace-api pods                                                                     | `{}`                                          |
-| `workspaceApi.podAffinityPreset`                          | Pod affinity preset. Ignored if `workspaceApi.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                          |
-| `workspaceApi.podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `workspaceApi.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                        |
-| `workspaceApi.nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `workspaceApi.affinity` is set. Allowed values: `soft` or `hard` | `""`                                          |
-| `workspaceApi.nodeAffinityPreset.key`                     | Node label key to match. Ignored if `workspaceApi.affinity` is set                                     | `""`                                          |
-| `workspaceApi.nodeAffinityPreset.values`                  | Node label values to match. Ignored if `workspaceApi.affinity` is set                                  | `[]`                                          |
-| `workspaceApi.affinity`                                   | Affinity for workspace-api pods assignment                                                             | `{}`                                          |
-| `workspaceApi.nodeSelector`                               | Node labels for workspace-api pods assignment                                                          | `{}`                                          |
-| `workspaceApi.tolerations`                                | Tolerations for workspace-api pods assignment                                                          | `[]`                                          |
-| `workspaceApi.updateStrategy.type`                        | workspace-api statefulset strategy type                                                                | `RollingUpdate`                               |
-| `workspaceApi.priorityClassName`                          | workspace-api pods' priorityClassName                                                                  | `""`                                          |
-| `workspaceApi.schedulerName`                              | Name of the k8s scheduler (other than default) for workspace-api pods                                  | `""`                                          |
-| `workspaceApi.lifecycleHooks`                             | for the workspace-api container(s) to automate configuration before or after startup                   | `{}`                                          |
-| `workspaceApi.extraEnvVars`                               | Array with extra environment variables to add to workspace-api nodes                                   | `[]`                                          |
-| `workspaceApi.extraEnvVarsCM`                             | Name of existing ConfigMap containing extra env vars for workspace-api nodes                           | `""`                                          |
-| `workspaceApi.extraEnvVarsSecret`                         | Name of existing Secret containing extra env vars for workspace-api nodes                              | `""`                                          |
-| `workspaceApi.extraVolumes`                               | Optionally specify extra list of additional volumes for the workspace-api pod(s)                       | `[]`                                          |
-| `workspaceApi.extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts for the workspace-api container(s)            | `[]`                                          |
-| `workspaceApi.sidecars`                                   | Add additional sidecar containers to the workspace-api pod(s)                                          | `{}`                                          |
-| `workspaceApi.initContainers`                             | Add additional init containers to the workspace-api pod(s)                                             | `{}`                                          |
+| Name                                                      | Description                                                                                            | Value                           |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------- |
+| `workspaceApi.image.registry`                             | workspace-api image registry                                                                           | `gcr.io/carto-onprem-artifacts` |
+| `workspaceApi.image.repository`                           | workspace-api image repository                                                                         | `workspace-api`                 |
+| `workspaceApi.image.tag`                                  | workspace-api image tag (immutable tags are recommended)                                               | `""`                            |
+| `workspaceApi.image.pullPolicy`                           | workspace-api image pull policy                                                                        | `IfNotPresent`                  |
+| `workspaceApi.image.pullSecrets`                          | workspace-api image pull secrets                                                                       | `[]`                            |
+| `workspaceApi.replicaCount`                               | Number of workspace-api replicas to deploy                                                             | `1`                             |
+| `workspaceApi.containerPorts.http`                        | workspace-api HTTP container port                                                                      | `8001`                          |
+| `workspaceApi.livenessProbe.enabled`                      | Enable livenessProbe on workspace-api containers                                                       | `true`                          |
+| `workspaceApi.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                                                | `10`                            |
+| `workspaceApi.livenessProbe.periodSeconds`                | Period seconds for livenessProbe                                                                       | `30`                            |
+| `workspaceApi.livenessProbe.timeoutSeconds`               | Timeout seconds for livenessProbe                                                                      | `5`                             |
+| `workspaceApi.livenessProbe.failureThreshold`             | Failure threshold for livenessProbe                                                                    | `5`                             |
+| `workspaceApi.livenessProbe.successThreshold`             | Success threshold for livenessProbe                                                                    | `1`                             |
+| `workspaceApi.readinessProbe.enabled`                     | Enable readinessProbe on workspace-api containers                                                      | `true`                          |
+| `workspaceApi.readinessProbe.initialDelaySeconds`         | Initial delay seconds for readinessProbe                                                               | `10`                            |
+| `workspaceApi.readinessProbe.periodSeconds`               | Period seconds for readinessProbe                                                                      | `30`                            |
+| `workspaceApi.readinessProbe.timeoutSeconds`              | Timeout seconds for readinessProbe                                                                     | `5`                             |
+| `workspaceApi.readinessProbe.failureThreshold`            | Failure threshold for readinessProbe                                                                   | `5`                             |
+| `workspaceApi.readinessProbe.successThreshold`            | Success threshold for readinessProbe                                                                   | `1`                             |
+| `workspaceApi.startupProbe.enabled`                       | Enable startupProbe on workspace-api containers                                                        | `false`                         |
+| `workspaceApi.startupProbe.initialDelaySeconds`           | Initial delay seconds for startupProbe                                                                 | `10`                            |
+| `workspaceApi.startupProbe.periodSeconds`                 | Period seconds for startupProbe                                                                        | `30`                            |
+| `workspaceApi.startupProbe.timeoutSeconds`                | Timeout seconds for startupProbe                                                                       | `5`                             |
+| `workspaceApi.startupProbe.failureThreshold`              | Failure threshold for startupProbe                                                                     | `5`                             |
+| `workspaceApi.startupProbe.successThreshold`              | Success threshold for startupProbe                                                                     | `1`                             |
+| `workspaceApi.customLivenessProbe`                        | Custom livenessProbe that overrides the default one                                                    | `{}`                            |
+| `workspaceApi.customReadinessProbe`                       | Custom readinessProbe that overrides the default one                                                   | `{}`                            |
+| `workspaceApi.customStartupProbe`                         | Custom startupProbe that overrides the default one                                                     | `{}`                            |
+| `workspaceApi.autoscaling.enabled`                        | Enable autoscaling for the workspace-api containers                                                    | `false`                         |
+| `workspaceApi.autoscaling.minReplicas`                    | The minimal number of containters for the workspace-api deployment                                     | `2`                             |
+| `workspaceApi.autoscaling.maxReplicas`                    | The maximum number of containers for the workspace-api deployment                                      | `3`                             |
+| `workspaceApi.autoscaling.targetCPUUtilizationPercentage` | The CPU utilization percentage used for scale up containers in workspace-api deployment                | `75`                            |
+| `workspaceApi.resources.limits`                           | The resources limits for the workspace-api containers                                                  | `{}`                            |
+| `workspaceApi.resources.requests`                         | The requested resources for the workspace-api containers                                               | `{}`                            |
+| `workspaceApi.podSecurityContext.enabled`                 | Enabled workspace-api pods' Security Context                                                           | `true`                          |
+| `workspaceApi.podSecurityContext.fsGroup`                 | Set workspace-api pod's Security Context fsGroup                                                       | `0`                             |
+| `workspaceApi.containerSecurityContext.enabled`           | Enabled workspace-api containers' Security Context                                                     | `true`                          |
+| `workspaceApi.containerSecurityContext.runAsUser`         | Set workspace-api containers' Security Context runAsUser                                               | `0`                             |
+| `workspaceApi.containerSecurityContext.runAsNonRoot`      | Set workspace-api containers' Security Context runAsNonRoot                                            | `false`                         |
+| `workspaceApi.configuration`                              | Configuration settings (env vars) for workspace-api                                                    | `{}`                            |
+| `workspaceApi.secretConfiguration`                        | Configuration settings (env vars) for workspace-api                                                    | `""`                            |
+| `workspaceApi.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for workspace-api                     | `""`                            |
+| `workspaceApi.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for workspace-api                     | `""`                            |
+| `workspaceApi.command`                                    | Override default container command (useful when using custom images)                                   | `[]`                            |
+| `workspaceApi.args`                                       | Override default container args (useful when using custom images)                                      | `[]`                            |
+| `workspaceApi.hostAliases`                                | workspace-api pods host aliases                                                                        | `[]`                            |
+| `workspaceApi.podLabels`                                  | Extra labels for workspace-api pods                                                                    | `{}`                            |
+| `workspaceApi.podAnnotations`                             | Annotations for workspace-api pods                                                                     | `{}`                            |
+| `workspaceApi.podAffinityPreset`                          | Pod affinity preset. Ignored if `workspaceApi.affinity` is set. Allowed values: `soft` or `hard`       | `""`                            |
+| `workspaceApi.podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `workspaceApi.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                          |
+| `workspaceApi.nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `workspaceApi.affinity` is set. Allowed values: `soft` or `hard` | `""`                            |
+| `workspaceApi.nodeAffinityPreset.key`                     | Node label key to match. Ignored if `workspaceApi.affinity` is set                                     | `""`                            |
+| `workspaceApi.nodeAffinityPreset.values`                  | Node label values to match. Ignored if `workspaceApi.affinity` is set                                  | `[]`                            |
+| `workspaceApi.affinity`                                   | Affinity for workspace-api pods assignment                                                             | `{}`                            |
+| `workspaceApi.nodeSelector`                               | Node labels for workspace-api pods assignment                                                          | `{}`                            |
+| `workspaceApi.tolerations`                                | Tolerations for workspace-api pods assignment                                                          | `[]`                            |
+| `workspaceApi.updateStrategy.type`                        | workspace-api statefulset strategy type                                                                | `RollingUpdate`                 |
+| `workspaceApi.priorityClassName`                          | workspace-api pods' priorityClassName                                                                  | `""`                            |
+| `workspaceApi.schedulerName`                              | Name of the k8s scheduler (other than default) for workspace-api pods                                  | `""`                            |
+| `workspaceApi.lifecycleHooks`                             | for the workspace-api container(s) to automate configuration before or after startup                   | `{}`                            |
+| `workspaceApi.extraEnvVars`                               | Array with extra environment variables to add to workspace-api nodes                                   | `[]`                            |
+| `workspaceApi.extraEnvVarsCM`                             | Name of existing ConfigMap containing extra env vars for workspace-api nodes                           | `""`                            |
+| `workspaceApi.extraEnvVarsSecret`                         | Name of existing Secret containing extra env vars for workspace-api nodes                              | `""`                            |
+| `workspaceApi.extraVolumes`                               | Optionally specify extra list of additional volumes for the workspace-api pod(s)                       | `[]`                            |
+| `workspaceApi.extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts for the workspace-api container(s)            | `[]`                            |
+| `workspaceApi.sidecars`                                   | Add additional sidecar containers to the workspace-api pod(s)                                          | `{}`                            |
+| `workspaceApi.initContainers`                             | Add additional init containers to the workspace-api pod(s)                                             | `{}`                            |
 
 
 ### workspace-api Service Parameters
@@ -953,51 +962,52 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 ### workspace-subscriber Deployment Parameters
 
-| Name                                                        | Description                                                                                                   | Value                                         |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| `workspaceSubscriber.image.name`                            | workspace-subscriber image registry and repository                                                            | `gcr.io/carto-onprem-artifacts/workspace-api` |
-| `workspaceSubscriber.image.tag`                             | workspace-subscriber image tag (immutable tags are recommended)                                               | `""`                                          |
-| `workspaceSubscriber.image.pullPolicy`                      | workspace-subscriber image pull policy                                                                        | `IfNotPresent`                                |
-| `workspaceSubscriber.image.pullSecrets`                     | workspace-subscriber image pull secrets                                                                       | `[]`                                          |
-| `workspaceSubscriber.replicaCount`                          | Number of workspace-subscriber replicas to deploy                                                             | `1`                                           |
-| `workspaceSubscriber.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                           | `{}`                                          |
-| `workspaceSubscriber.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                          | `{}`                                          |
-| `workspaceSubscriber.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                            | `{}`                                          |
-| `workspaceSubscriber.resources.limits`                      | The resources limits for the workspace-subscriber containers                                                  | `{}`                                          |
-| `workspaceSubscriber.resources.requests`                    | The requested resources for the workspace-subscriber containers                                               | `{}`                                          |
-| `workspaceSubscriber.podSecurityContext.enabled`            | Enabled workspace-subscriber pods' Security Context                                                           | `true`                                        |
-| `workspaceSubscriber.podSecurityContext.fsGroup`            | Set workspace-subscriber pod's Security Context fsGroup                                                       | `0`                                           |
-| `workspaceSubscriber.containerSecurityContext.enabled`      | Enabled workspace-subscriber containers' Security Context                                                     | `true`                                        |
-| `workspaceSubscriber.containerSecurityContext.runAsUser`    | Set workspace-subscriber containers' Security Context runAsUser                                               | `0`                                           |
-| `workspaceSubscriber.containerSecurityContext.runAsNonRoot` | Set workspace-subscriber containers' Security Context runAsNonRoot                                            | `false`                                       |
-| `workspaceSubscriber.configuration`                         | Configuration settings (env vars) for workspace-subscriber                                                    | `{}`                                          |
-| `workspaceSubscriber.secretConfiguration`                   | Configuration settings (env vars) for workspace-subscriber                                                    | `""`                                          |
-| `workspaceSubscriber.existingConfigMap`                     | The name of an existing ConfigMap with your custom configuration for workspace-subscriber                     | `""`                                          |
-| `workspaceSubscriber.existingSecret`                        | The name of an existing ConfigMap with your custom configuration for workspace-subscriber                     | `""`                                          |
-| `workspaceSubscriber.command`                               | Override default container command (useful when using custom images)                                          | `[]`                                          |
-| `workspaceSubscriber.args`                                  | Override default container args (useful when using custom images)                                             | `[]`                                          |
-| `workspaceSubscriber.hostAliases`                           | workspace-subscriber pods host aliases                                                                        | `[]`                                          |
-| `workspaceSubscriber.podLabels`                             | Extra labels for workspace-subscriber pods                                                                    | `{}`                                          |
-| `workspaceSubscriber.podAnnotations`                        | Annotations for workspace-subscriber pods                                                                     | `{}`                                          |
-| `workspaceSubscriber.podAffinityPreset`                     | Pod affinity preset. Ignored if `workspaceSubscriber.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                          |
-| `workspaceSubscriber.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `workspaceSubscriber.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                        |
-| `workspaceSubscriber.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `workspaceSubscriber.affinity` is set. Allowed values: `soft` or `hard` | `""`                                          |
-| `workspaceSubscriber.nodeAffinityPreset.key`                | Node label key to match. Ignored if `workspaceSubscriber.affinity` is set                                     | `""`                                          |
-| `workspaceSubscriber.nodeAffinityPreset.values`             | Node label values to match. Ignored if `workspaceSubscriber.affinity` is set                                  | `[]`                                          |
-| `workspaceSubscriber.affinity`                              | Affinity for workspace-subscriber pods assignment                                                             | `{}`                                          |
-| `workspaceSubscriber.nodeSelector`                          | Node labels for workspace-subscriber pods assignment                                                          | `{}`                                          |
-| `workspaceSubscriber.tolerations`                           | Tolerations for workspace-subscriber pods assignment                                                          | `[]`                                          |
-| `workspaceSubscriber.updateStrategy.type`                   | workspace-subscriber statefulset strategy type                                                                | `RollingUpdate`                               |
-| `workspaceSubscriber.priorityClassName`                     | workspace-subscriber pods' priorityClassName                                                                  | `""`                                          |
-| `workspaceSubscriber.schedulerName`                         | Name of the k8s scheduler (other than default) for workspace-subscriber pods                                  | `""`                                          |
-| `workspaceSubscriber.lifecycleHooks`                        | for the workspace-subscriber container(s) to automate configuration before or after startup                   | `{}`                                          |
-| `workspaceSubscriber.extraEnvVars`                          | Array with extra environment variables to add to workspace-subscriber nodes                                   | `[]`                                          |
-| `workspaceSubscriber.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for workspace-subscriber nodes                           | `""`                                          |
-| `workspaceSubscriber.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for workspace-subscriber nodes                              | `""`                                          |
-| `workspaceSubscriber.extraVolumes`                          | Optionally specify extra list of additional volumes for the workspace-subscriber pod(s)                       | `[]`                                          |
-| `workspaceSubscriber.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the workspace-subscriber container(s)            | `[]`                                          |
-| `workspaceSubscriber.sidecars`                              | Add additional sidecar containers to the workspace-subscriber pod(s)                                          | `{}`                                          |
-| `workspaceSubscriber.initContainers`                        | Add additional init containers to the workspace-subscriber pod(s)                                             | `{}`                                          |
+| Name                                                        | Description                                                                                                   | Value                           |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `workspaceSubscriber.image.registry`                        | workspace-subscriber image registry                                                                           | `gcr.io/carto-onprem-artifacts` |
+| `workspaceSubscriber.image.repository`                      | workspace-subscriber image repository                                                                         | `workspace-api`                 |
+| `workspaceSubscriber.image.tag`                             | workspace-subscriber image tag (immutable tags are recommended)                                               | `""`                            |
+| `workspaceSubscriber.image.pullPolicy`                      | workspace-subscriber image pull policy                                                                        | `IfNotPresent`                  |
+| `workspaceSubscriber.image.pullSecrets`                     | workspace-subscriber image pull secrets                                                                       | `[]`                            |
+| `workspaceSubscriber.replicaCount`                          | Number of workspace-subscriber replicas to deploy                                                             | `1`                             |
+| `workspaceSubscriber.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                           | `{}`                            |
+| `workspaceSubscriber.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                          | `{}`                            |
+| `workspaceSubscriber.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                            | `{}`                            |
+| `workspaceSubscriber.resources.limits`                      | The resources limits for the workspace-subscriber containers                                                  | `{}`                            |
+| `workspaceSubscriber.resources.requests`                    | The requested resources for the workspace-subscriber containers                                               | `{}`                            |
+| `workspaceSubscriber.podSecurityContext.enabled`            | Enabled workspace-subscriber pods' Security Context                                                           | `true`                          |
+| `workspaceSubscriber.podSecurityContext.fsGroup`            | Set workspace-subscriber pod's Security Context fsGroup                                                       | `0`                             |
+| `workspaceSubscriber.containerSecurityContext.enabled`      | Enabled workspace-subscriber containers' Security Context                                                     | `true`                          |
+| `workspaceSubscriber.containerSecurityContext.runAsUser`    | Set workspace-subscriber containers' Security Context runAsUser                                               | `0`                             |
+| `workspaceSubscriber.containerSecurityContext.runAsNonRoot` | Set workspace-subscriber containers' Security Context runAsNonRoot                                            | `false`                         |
+| `workspaceSubscriber.configuration`                         | Configuration settings (env vars) for workspace-subscriber                                                    | `{}`                            |
+| `workspaceSubscriber.secretConfiguration`                   | Configuration settings (env vars) for workspace-subscriber                                                    | `""`                            |
+| `workspaceSubscriber.existingConfigMap`                     | The name of an existing ConfigMap with your custom configuration for workspace-subscriber                     | `""`                            |
+| `workspaceSubscriber.existingSecret`                        | The name of an existing ConfigMap with your custom configuration for workspace-subscriber                     | `""`                            |
+| `workspaceSubscriber.command`                               | Override default container command (useful when using custom images)                                          | `[]`                            |
+| `workspaceSubscriber.args`                                  | Override default container args (useful when using custom images)                                             | `[]`                            |
+| `workspaceSubscriber.hostAliases`                           | workspace-subscriber pods host aliases                                                                        | `[]`                            |
+| `workspaceSubscriber.podLabels`                             | Extra labels for workspace-subscriber pods                                                                    | `{}`                            |
+| `workspaceSubscriber.podAnnotations`                        | Annotations for workspace-subscriber pods                                                                     | `{}`                            |
+| `workspaceSubscriber.podAffinityPreset`                     | Pod affinity preset. Ignored if `workspaceSubscriber.affinity` is set. Allowed values: `soft` or `hard`       | `""`                            |
+| `workspaceSubscriber.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `workspaceSubscriber.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                          |
+| `workspaceSubscriber.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `workspaceSubscriber.affinity` is set. Allowed values: `soft` or `hard` | `""`                            |
+| `workspaceSubscriber.nodeAffinityPreset.key`                | Node label key to match. Ignored if `workspaceSubscriber.affinity` is set                                     | `""`                            |
+| `workspaceSubscriber.nodeAffinityPreset.values`             | Node label values to match. Ignored if `workspaceSubscriber.affinity` is set                                  | `[]`                            |
+| `workspaceSubscriber.affinity`                              | Affinity for workspace-subscriber pods assignment                                                             | `{}`                            |
+| `workspaceSubscriber.nodeSelector`                          | Node labels for workspace-subscriber pods assignment                                                          | `{}`                            |
+| `workspaceSubscriber.tolerations`                           | Tolerations for workspace-subscriber pods assignment                                                          | `[]`                            |
+| `workspaceSubscriber.updateStrategy.type`                   | workspace-subscriber statefulset strategy type                                                                | `RollingUpdate`                 |
+| `workspaceSubscriber.priorityClassName`                     | workspace-subscriber pods' priorityClassName                                                                  | `""`                            |
+| `workspaceSubscriber.schedulerName`                         | Name of the k8s scheduler (other than default) for workspace-subscriber pods                                  | `""`                            |
+| `workspaceSubscriber.lifecycleHooks`                        | for the workspace-subscriber container(s) to automate configuration before or after startup                   | `{}`                            |
+| `workspaceSubscriber.extraEnvVars`                          | Array with extra environment variables to add to workspace-subscriber nodes                                   | `[]`                            |
+| `workspaceSubscriber.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for workspace-subscriber nodes                           | `""`                            |
+| `workspaceSubscriber.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for workspace-subscriber nodes                              | `""`                            |
+| `workspaceSubscriber.extraVolumes`                          | Optionally specify extra list of additional volumes for the workspace-subscriber pod(s)                       | `[]`                            |
+| `workspaceSubscriber.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the workspace-subscriber container(s)            | `[]`                            |
+| `workspaceSubscriber.sidecars`                              | Add additional sidecar containers to the workspace-subscriber pod(s)                                          | `{}`                            |
+| `workspaceSubscriber.initContainers`                        | Add additional init containers to the workspace-subscriber pod(s)                                             | `{}`                            |
 
 
 ### workspace-subscriber ServiceAccount configuration
@@ -1011,74 +1021,75 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 ### workspace-www Deployment Parameters
 
-| Name                                                      | Description                                                                                            | Value                                         |
-| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
-| `workspaceWww.image.name`                                 | workspace-www image registry and repository                                                            | `gcr.io/carto-onprem-artifacts/workspace-www` |
-| `workspaceWww.image.tag`                                  | workspace-www image tag (immutable tags are recommended)                                               | `""`                                          |
-| `workspaceWww.image.pullPolicy`                           | workspace-www image pull policy                                                                        | `IfNotPresent`                                |
-| `workspaceWww.image.pullSecrets`                          | workspace-www image pull secrets                                                                       | `[]`                                          |
-| `workspaceWww.replicaCount`                               | Number of workspace-www replicas to deploy                                                             | `1`                                           |
-| `workspaceWww.containerPorts.http`                        | workspace-www HTTP container port                                                                      | `8080`                                        |
-| `workspaceWww.livenessProbe.enabled`                      | Enable livenessProbe on workspace-www containers                                                       | `true`                                        |
-| `workspaceWww.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                                                | `10`                                          |
-| `workspaceWww.livenessProbe.periodSeconds`                | Period seconds for livenessProbe                                                                       | `30`                                          |
-| `workspaceWww.livenessProbe.timeoutSeconds`               | Timeout seconds for livenessProbe                                                                      | `5`                                           |
-| `workspaceWww.livenessProbe.failureThreshold`             | Failure threshold for livenessProbe                                                                    | `5`                                           |
-| `workspaceWww.livenessProbe.successThreshold`             | Success threshold for livenessProbe                                                                    | `1`                                           |
-| `workspaceWww.readinessProbe.enabled`                     | Enable readinessProbe on workspace-www containers                                                      | `true`                                        |
-| `workspaceWww.readinessProbe.initialDelaySeconds`         | Initial delay seconds for readinessProbe                                                               | `10`                                          |
-| `workspaceWww.readinessProbe.periodSeconds`               | Period seconds for readinessProbe                                                                      | `30`                                          |
-| `workspaceWww.readinessProbe.timeoutSeconds`              | Timeout seconds for readinessProbe                                                                     | `5`                                           |
-| `workspaceWww.readinessProbe.failureThreshold`            | Failure threshold for readinessProbe                                                                   | `5`                                           |
-| `workspaceWww.readinessProbe.successThreshold`            | Success threshold for readinessProbe                                                                   | `1`                                           |
-| `workspaceWww.startupProbe.enabled`                       | Enable startupProbe on workspace-www containers                                                        | `false`                                       |
-| `workspaceWww.startupProbe.initialDelaySeconds`           | Initial delay seconds for startupProbe                                                                 | `10`                                          |
-| `workspaceWww.startupProbe.periodSeconds`                 | Period seconds for startupProbe                                                                        | `30`                                          |
-| `workspaceWww.startupProbe.timeoutSeconds`                | Timeout seconds for startupProbe                                                                       | `5`                                           |
-| `workspaceWww.startupProbe.failureThreshold`              | Failure threshold for startupProbe                                                                     | `5`                                           |
-| `workspaceWww.startupProbe.successThreshold`              | Success threshold for startupProbe                                                                     | `1`                                           |
-| `workspaceWww.customLivenessProbe`                        | Custom livenessProbe that overrides the default one                                                    | `{}`                                          |
-| `workspaceWww.customReadinessProbe`                       | Custom readinessProbe that overrides the default one                                                   | `{}`                                          |
-| `workspaceWww.customStartupProbe`                         | Custom startupProbe that overrides the default one                                                     | `{}`                                          |
-| `workspaceWww.autoscaling.enabled`                        | Enable autoscaling for the workspace-www containers                                                    | `false`                                       |
-| `workspaceWww.autoscaling.minReplicas`                    | The minimal number of containters for the workspace-www deployment                                     | `1`                                           |
-| `workspaceWww.autoscaling.maxReplicas`                    | The maximum number of containers for the workspace-www deployment                                      | `2`                                           |
-| `workspaceWww.autoscaling.targetCPUUtilizationPercentage` | The CPU utilization percentage used for scale up containers in workspace-www deployment                | `75`                                          |
-| `workspaceWww.resources.limits`                           | The resources limits for the workspace-www containers                                                  | `{}`                                          |
-| `workspaceWww.resources.requests`                         | The requested resources for the workspace-www containers                                               | `{}`                                          |
-| `workspaceWww.podSecurityContext.enabled`                 | Enabled workspace-www pods' Security Context                                                           | `true`                                        |
-| `workspaceWww.podSecurityContext.fsGroup`                 | Set workspace-www pod's Security Context fsGroup                                                       | `0`                                           |
-| `workspaceWww.containerSecurityContext.enabled`           | Enabled workspace-www containers' Security Context                                                     | `true`                                        |
-| `workspaceWww.containerSecurityContext.runAsUser`         | Set workspace-www containers' Security Context runAsUser                                               | `0`                                           |
-| `workspaceWww.containerSecurityContext.runAsNonRoot`      | Set workspace-www containers' Security Context runAsNonRoot                                            | `false`                                       |
-| `workspaceWww.configuration`                              | Configuration settings (env vars) for workspace-www                                                    | `{}`                                          |
-| `workspaceWww.secretConfiguration`                        | Configuration settings (env vars) for workspace-www                                                    | `""`                                          |
-| `workspaceWww.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for workspace-www                     | `""`                                          |
-| `workspaceWww.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for workspace-www                     | `""`                                          |
-| `workspaceWww.command`                                    | Override default container command (useful when using custom images)                                   | `[]`                                          |
-| `workspaceWww.args`                                       | Override default container args (useful when using custom images)                                      | `[]`                                          |
-| `workspaceWww.hostAliases`                                | workspace-www pods host aliases                                                                        | `[]`                                          |
-| `workspaceWww.podLabels`                                  | Extra labels for workspace-www pods                                                                    | `{}`                                          |
-| `workspaceWww.podAnnotations`                             | Annotations for workspace-www pods                                                                     | `{}`                                          |
-| `workspaceWww.podAffinityPreset`                          | Pod affinity preset. Ignored if `workspaceWww.affinity` is set. Allowed values: `soft` or `hard`       | `""`                                          |
-| `workspaceWww.podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `workspaceWww.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                        |
-| `workspaceWww.nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `workspaceWww.affinity` is set. Allowed values: `soft` or `hard` | `""`                                          |
-| `workspaceWww.nodeAffinityPreset.key`                     | Node label key to match. Ignored if `workspaceWww.affinity` is set                                     | `""`                                          |
-| `workspaceWww.nodeAffinityPreset.values`                  | Node label values to match. Ignored if `workspaceWww.affinity` is set                                  | `[]`                                          |
-| `workspaceWww.affinity`                                   | Affinity for workspace-www pods assignment                                                             | `{}`                                          |
-| `workspaceWww.nodeSelector`                               | Node labels for workspace-www pods assignment                                                          | `{}`                                          |
-| `workspaceWww.tolerations`                                | Tolerations for workspace-www pods assignment                                                          | `[]`                                          |
-| `workspaceWww.updateStrategy.type`                        | workspace-www statefulset strategy type                                                                | `RollingUpdate`                               |
-| `workspaceWww.priorityClassName`                          | workspace-www pods' priorityClassName                                                                  | `""`                                          |
-| `workspaceWww.schedulerName`                              | Name of the k8s scheduler (other than default) for workspace-www pods                                  | `""`                                          |
-| `workspaceWww.lifecycleHooks`                             | for the workspace-www container(s) to automate configuration before or after startup                   | `{}`                                          |
-| `workspaceWww.extraEnvVars`                               | Array with extra environment variables to add to workspace-www nodes                                   | `[]`                                          |
-| `workspaceWww.extraEnvVarsCM`                             | Name of existing ConfigMap containing extra env vars for workspace-www nodes                           | `""`                                          |
-| `workspaceWww.extraEnvVarsSecret`                         | Name of existing Secret containing extra env vars for workspace-www nodes                              | `""`                                          |
-| `workspaceWww.extraVolumes`                               | Optionally specify extra list of additional volumes for the workspace-www pod(s)                       | `[]`                                          |
-| `workspaceWww.extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts for the workspace-www container(s)            | `[]`                                          |
-| `workspaceWww.sidecars`                                   | Add additional sidecar containers to the workspace-www pod(s)                                          | `{}`                                          |
-| `workspaceWww.initContainers`                             | Add additional init containers to the workspace-www pod(s)                                             | `{}`                                          |
+| Name                                                      | Description                                                                                            | Value                           |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------- |
+| `workspaceWww.image.registry`                             | workspace-www image registry                                                                           | `gcr.io/carto-onprem-artifacts` |
+| `workspaceWww.image.repository`                           | workspace-www image repository                                                                         | `workspace-www`                 |
+| `workspaceWww.image.tag`                                  | workspace-www image tag (immutable tags are recommended)                                               | `""`                            |
+| `workspaceWww.image.pullPolicy`                           | workspace-www image pull policy                                                                        | `IfNotPresent`                  |
+| `workspaceWww.image.pullSecrets`                          | workspace-www image pull secrets                                                                       | `[]`                            |
+| `workspaceWww.replicaCount`                               | Number of workspace-www replicas to deploy                                                             | `1`                             |
+| `workspaceWww.containerPorts.http`                        | workspace-www HTTP container port                                                                      | `8080`                          |
+| `workspaceWww.livenessProbe.enabled`                      | Enable livenessProbe on workspace-www containers                                                       | `true`                          |
+| `workspaceWww.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                                                | `10`                            |
+| `workspaceWww.livenessProbe.periodSeconds`                | Period seconds for livenessProbe                                                                       | `30`                            |
+| `workspaceWww.livenessProbe.timeoutSeconds`               | Timeout seconds for livenessProbe                                                                      | `5`                             |
+| `workspaceWww.livenessProbe.failureThreshold`             | Failure threshold for livenessProbe                                                                    | `5`                             |
+| `workspaceWww.livenessProbe.successThreshold`             | Success threshold for livenessProbe                                                                    | `1`                             |
+| `workspaceWww.readinessProbe.enabled`                     | Enable readinessProbe on workspace-www containers                                                      | `true`                          |
+| `workspaceWww.readinessProbe.initialDelaySeconds`         | Initial delay seconds for readinessProbe                                                               | `10`                            |
+| `workspaceWww.readinessProbe.periodSeconds`               | Period seconds for readinessProbe                                                                      | `30`                            |
+| `workspaceWww.readinessProbe.timeoutSeconds`              | Timeout seconds for readinessProbe                                                                     | `5`                             |
+| `workspaceWww.readinessProbe.failureThreshold`            | Failure threshold for readinessProbe                                                                   | `5`                             |
+| `workspaceWww.readinessProbe.successThreshold`            | Success threshold for readinessProbe                                                                   | `1`                             |
+| `workspaceWww.startupProbe.enabled`                       | Enable startupProbe on workspace-www containers                                                        | `false`                         |
+| `workspaceWww.startupProbe.initialDelaySeconds`           | Initial delay seconds for startupProbe                                                                 | `10`                            |
+| `workspaceWww.startupProbe.periodSeconds`                 | Period seconds for startupProbe                                                                        | `30`                            |
+| `workspaceWww.startupProbe.timeoutSeconds`                | Timeout seconds for startupProbe                                                                       | `5`                             |
+| `workspaceWww.startupProbe.failureThreshold`              | Failure threshold for startupProbe                                                                     | `5`                             |
+| `workspaceWww.startupProbe.successThreshold`              | Success threshold for startupProbe                                                                     | `1`                             |
+| `workspaceWww.customLivenessProbe`                        | Custom livenessProbe that overrides the default one                                                    | `{}`                            |
+| `workspaceWww.customReadinessProbe`                       | Custom readinessProbe that overrides the default one                                                   | `{}`                            |
+| `workspaceWww.customStartupProbe`                         | Custom startupProbe that overrides the default one                                                     | `{}`                            |
+| `workspaceWww.autoscaling.enabled`                        | Enable autoscaling for the workspace-www containers                                                    | `false`                         |
+| `workspaceWww.autoscaling.minReplicas`                    | The minimal number of containters for the workspace-www deployment                                     | `1`                             |
+| `workspaceWww.autoscaling.maxReplicas`                    | The maximum number of containers for the workspace-www deployment                                      | `2`                             |
+| `workspaceWww.autoscaling.targetCPUUtilizationPercentage` | The CPU utilization percentage used for scale up containers in workspace-www deployment                | `75`                            |
+| `workspaceWww.resources.limits`                           | The resources limits for the workspace-www containers                                                  | `{}`                            |
+| `workspaceWww.resources.requests`                         | The requested resources for the workspace-www containers                                               | `{}`                            |
+| `workspaceWww.podSecurityContext.enabled`                 | Enabled workspace-www pods' Security Context                                                           | `true`                          |
+| `workspaceWww.podSecurityContext.fsGroup`                 | Set workspace-www pod's Security Context fsGroup                                                       | `0`                             |
+| `workspaceWww.containerSecurityContext.enabled`           | Enabled workspace-www containers' Security Context                                                     | `true`                          |
+| `workspaceWww.containerSecurityContext.runAsUser`         | Set workspace-www containers' Security Context runAsUser                                               | `0`                             |
+| `workspaceWww.containerSecurityContext.runAsNonRoot`      | Set workspace-www containers' Security Context runAsNonRoot                                            | `false`                         |
+| `workspaceWww.configuration`                              | Configuration settings (env vars) for workspace-www                                                    | `{}`                            |
+| `workspaceWww.secretConfiguration`                        | Configuration settings (env vars) for workspace-www                                                    | `""`                            |
+| `workspaceWww.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for workspace-www                     | `""`                            |
+| `workspaceWww.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for workspace-www                     | `""`                            |
+| `workspaceWww.command`                                    | Override default container command (useful when using custom images)                                   | `[]`                            |
+| `workspaceWww.args`                                       | Override default container args (useful when using custom images)                                      | `[]`                            |
+| `workspaceWww.hostAliases`                                | workspace-www pods host aliases                                                                        | `[]`                            |
+| `workspaceWww.podLabels`                                  | Extra labels for workspace-www pods                                                                    | `{}`                            |
+| `workspaceWww.podAnnotations`                             | Annotations for workspace-www pods                                                                     | `{}`                            |
+| `workspaceWww.podAffinityPreset`                          | Pod affinity preset. Ignored if `workspaceWww.affinity` is set. Allowed values: `soft` or `hard`       | `""`                            |
+| `workspaceWww.podAntiAffinityPreset`                      | Pod anti-affinity preset. Ignored if `workspaceWww.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                          |
+| `workspaceWww.nodeAffinityPreset.type`                    | Node affinity preset type. Ignored if `workspaceWww.affinity` is set. Allowed values: `soft` or `hard` | `""`                            |
+| `workspaceWww.nodeAffinityPreset.key`                     | Node label key to match. Ignored if `workspaceWww.affinity` is set                                     | `""`                            |
+| `workspaceWww.nodeAffinityPreset.values`                  | Node label values to match. Ignored if `workspaceWww.affinity` is set                                  | `[]`                            |
+| `workspaceWww.affinity`                                   | Affinity for workspace-www pods assignment                                                             | `{}`                            |
+| `workspaceWww.nodeSelector`                               | Node labels for workspace-www pods assignment                                                          | `{}`                            |
+| `workspaceWww.tolerations`                                | Tolerations for workspace-www pods assignment                                                          | `[]`                            |
+| `workspaceWww.updateStrategy.type`                        | workspace-www statefulset strategy type                                                                | `RollingUpdate`                 |
+| `workspaceWww.priorityClassName`                          | workspace-www pods' priorityClassName                                                                  | `""`                            |
+| `workspaceWww.schedulerName`                              | Name of the k8s scheduler (other than default) for workspace-www pods                                  | `""`                            |
+| `workspaceWww.lifecycleHooks`                             | for the workspace-www container(s) to automate configuration before or after startup                   | `{}`                            |
+| `workspaceWww.extraEnvVars`                               | Array with extra environment variables to add to workspace-www nodes                                   | `[]`                            |
+| `workspaceWww.extraEnvVarsCM`                             | Name of existing ConfigMap containing extra env vars for workspace-www nodes                           | `""`                            |
+| `workspaceWww.extraEnvVarsSecret`                         | Name of existing Secret containing extra env vars for workspace-www nodes                              | `""`                            |
+| `workspaceWww.extraVolumes`                               | Optionally specify extra list of additional volumes for the workspace-www pod(s)                       | `[]`                            |
+| `workspaceWww.extraVolumeMounts`                          | Optionally specify extra list of additional volumeMounts for the workspace-www container(s)            | `[]`                            |
+| `workspaceWww.sidecars`                                   | Add additional sidecar containers to the workspace-www pod(s)                                          | `{}`                            |
+| `workspaceWww.initContainers`                             | Add additional init containers to the workspace-www pod(s)                                             | `{}`                            |
 
 
 ### workspace-www Service Parameters
@@ -1108,19 +1119,20 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 ### Init Container Parameters
 
-| Name                                                        | Description                                                          | Value                                        |
-| ----------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------- |
-| `workspaceMigrations.image.name`                            | workspace-db image registry and repository                           | `gcr.io/carto-onprem-artifacts/workspace-db` |
-| `workspaceMigrations.image.tag`                             | workspace-db image tag (immutable tags are recommended)              | `""`                                         |
-| `workspaceMigrations.image.pullPolicy`                      | workspace-db image pull policy                                       | `IfNotPresent`                               |
-| `workspaceMigrations.image.pullSecrets`                     | workspace-db image pull secrets                                      | `[]`                                         |
-| `workspaceMigrations.command`                               | Override default container command (useful when using custom images) | `[]`                                         |
-| `workspaceMigrations.args`                                  | Override default container args (useful when using custom images)    | `[]`                                         |
-| `workspaceMigrations.resources.limits`                      | The resources limits for the init container                          | `{}`                                         |
-| `workspaceMigrations.resources.requests`                    | The requested resources for the init container                       | `{}`                                         |
-| `workspaceMigrations.containerSecurityContext.enabled`      | Enable container security context                                    | `true`                                       |
-| `workspaceMigrations.containerSecurityContext.runAsUser`    | Set init container's Security Context runAsUser                      | `0`                                          |
-| `workspaceMigrations.containerSecurityContext.runAsNonRoot` | Force the init container to run as non root                          | `false`                                      |
+| Name                                                        | Description                                                          | Value                           |
+| ----------------------------------------------------------- | -------------------------------------------------------------------- | ------------------------------- |
+| `workspaceMigrations.image.registry`                        | workspace-db image registry                                          | `gcr.io/carto-onprem-artifacts` |
+| `workspaceMigrations.image.repository`                      | workspace-db image repository                                        | `workspace-db`                  |
+| `workspaceMigrations.image.tag`                             | workspace-db image tag (immutable tags are recommended)              | `""`                            |
+| `workspaceMigrations.image.pullPolicy`                      | workspace-db image pull policy                                       | `IfNotPresent`                  |
+| `workspaceMigrations.image.pullSecrets`                     | workspace-db image pull secrets                                      | `[]`                            |
+| `workspaceMigrations.command`                               | Override default container command (useful when using custom images) | `[]`                            |
+| `workspaceMigrations.args`                                  | Override default container args (useful when using custom images)    | `[]`                            |
+| `workspaceMigrations.resources.limits`                      | The resources limits for the init container                          | `{}`                            |
+| `workspaceMigrations.resources.requests`                    | The requested resources for the init container                       | `{}`                            |
+| `workspaceMigrations.containerSecurityContext.enabled`      | Enable container security context                                    | `true`                          |
+| `workspaceMigrations.containerSecurityContext.runAsUser`    | Set init container's Security Context runAsUser                      | `0`                             |
+| `workspaceMigrations.containerSecurityContext.runAsNonRoot` | Force the init container to run as non root                          | `false`                         |
 
 
 ### Internal Redis&trade; subchart parameters

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -134,6 +134,25 @@ Generate the secret def to be used in pods definitions
 {{- end -}}
 
 {{/*
+As a replacement for "common.images.image" that forces you to set image.tag value
+*/}}
+{{- define "carto.images.image" -}}
+{{- $registryName := .imageRoot.registry -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $tag := (coalesce .imageRoot.tag .Chart.AppVersion) | toString -}}
+{{- if .global }}
+    {{- if .global.imageRegistry }}
+     {{- $registryName = .global.imageRegistry -}}
+    {{- end -}}
+{{- end -}}
+{{- if $registryName }}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create gcpBucketsProjectId using the gcpBucketsProjectId config or, if not defined, selfHostedGcpProjectId.
 */}}
 {{- define "carto.gcpBucketsProjectId" -}}
@@ -191,10 +210,10 @@ Return the proper Carto lds-api full name
 {{- end -}}
 
 {{/*
-Return the proper tag name for ldsApi image
+Return the proper Carto lds-api image name
 */}}
-{{- define "carto.ldsApi.tag" -}}
-{{- default .Chart.AppVersion .Values.ldsApi.image.tag -}}
+{{- define "carto.ldsApi.image" -}}
+{{- include "carto.images.image" (dict "imageRoot" .Values.ldsApi.image "global" .Values.global "Chart" .Chart) -}}
 {{- end -}}
 
 {{/*
@@ -238,10 +257,10 @@ Return the proper Carto import-worker full name
 {{- end -}}
 
 {{/*
-Return the proper tag name for importWorker image
+Return the proper Carto import-worker image name
 */}}
-{{- define "carto.importWorker.tag" -}}
-{{- default .Chart.AppVersion .Values.importWorker.image.tag -}}
+{{- define "carto.importWorker.image" -}}
+{{- include "carto.images.image" (dict "imageRoot" .Values.importWorker.image "global" .Values.global "Chart" .Chart) -}}
 {{- end -}}
 
 {{/*
@@ -285,10 +304,10 @@ Return the proper Carto import-api full name
 {{- end -}}
 
 {{/*
-Return the proper tag name for importApi image
+Return the proper Carto import-api image name
 */}}
-{{- define "carto.importApi.tag" -}}
-{{- default .Chart.AppVersion .Values.importApi.image.tag -}}
+{{- define "carto.importApi.image" -}}
+{{- include "carto.images.image" (dict "imageRoot" .Values.importApi.image "global" .Values.global "Chart" .Chart) -}}
 {{- end -}}
 
 {{/*
@@ -332,10 +351,10 @@ Return the proper Carto maps-api full name
 {{- end -}}
 
 {{/*
-Return the proper tag name for mapsApi image
+Return the proper Carto maps-api image name
 */}}
-{{- define "carto.mapsApi.tag" -}}
-{{- default .Chart.AppVersion .Values.mapsApi.image.tag -}}
+{{- define "carto.mapsApi.image" -}}
+{{- include "carto.images.image" (dict "imageRoot" .Values.mapsApi.image "global" .Values.global "Chart" .Chart) -}}
 {{- end -}}
 
 {{/*
@@ -379,10 +398,10 @@ Return the proper Carto workspace-subscriber full name
 {{- end -}}
 
 {{/*
-Return the proper tag name for workspaceSubscriber image
+Return the proper Carto workspace-subscriber image name
 */}}
-{{- define "carto.workspaceSubscriber.tag" -}}
-{{- default .Chart.AppVersion .Values.workspaceSubscriber.image.tag -}}
+{{- define "carto.workspaceSubscriber.image" -}}
+{{- include "carto.images.image" (dict "imageRoot" .Values.workspaceSubscriber.image "global" .Values.global "Chart" .Chart) -}}
 {{- end -}}
 
 {{/*
@@ -426,10 +445,10 @@ Return the proper Carto workspace-api full name
 {{- end -}}
 
 {{/*
-Return the proper tag name for workspaceApi image
+Return the proper Carto workspaceApi image name
 */}}
-{{- define "carto.workspaceApi.tag" -}}
-{{- default .Chart.AppVersion .Values.workspaceApi.image.tag -}}
+{{- define "carto.workspaceApi.image" -}}
+{{- include "carto.images.image" (dict "imageRoot" .Values.workspaceApi.image "global" .Values.global "Chart" .Chart) -}}
 {{- end -}}
 
 {{/*
@@ -486,10 +505,10 @@ Return the proper Carto workspace-www full name
 {{- end -}}
 
 {{/*
-Return the proper tag name for workspaceWww image
+Return the proper Carto workspace-www image name
 */}}
-{{- define "carto.workspaceWww.tag" -}}
-{{- default .Chart.AppVersion .Values.workspaceWww.image.tag -}}
+{{- define "carto.workspaceWww.image" -}}
+{{- include "carto.images.image" (dict "imageRoot" .Values.workspaceWww.image "global" .Values.global "Chart" .Chart) -}}
 {{- end -}}
 
 {{/*
@@ -533,10 +552,10 @@ Return the proper Carto accounts-www full name
 {{- end -}}
 
 {{/*
-Return the proper tag name for accountsWww image
+Return the proper Carto accounts-www image name
 */}}
-{{- define "carto.accountsWww.tag" -}}
-{{- default .Chart.AppVersion .Values.accountsWww.image.tag -}}
+{{- define "carto.accountsWww.image" -}}
+{{- include "carto.images.image" (dict "imageRoot" .Values.accountsWww.image "global" .Values.global "Chart" .Chart) -}}
 {{- end -}}
 
 {{/*
@@ -580,10 +599,10 @@ Return the proper Carto router full name
 {{- end -}}
 
 {{/*
-Return the proper tag name for router image
+Return the proper Carto router image name
 */}}
-{{- define "carto.router.tag" -}}
-{{- default .Chart.AppVersion .Values.router.image.tag -}}
+{{- define "carto.router.image" -}}
+{{- include "carto.images.image" (dict "imageRoot" .Values.router.image "global" .Values.global "Chart" .Chart) -}}
 {{- end -}}
 
 {{/*
@@ -627,10 +646,10 @@ Return the proper Carto http-cache full name
 {{- end -}}
 
 {{/*
-Return the proper tag name for httpCache image
+Return the proper Carto http-cache image name
 */}}
-{{- define "carto.httpCache.tag" -}}
-{{- default .Chart.AppVersion .Values.httpCache.image.tag -}}
+{{- define "carto.httpCache.image" -}}
+{{- include "carto.images.image" (dict "imageRoot" .Values.httpCache.image "global" .Values.global "Chart" .Chart) -}}
 {{- end -}}
 
 {{/*
@@ -674,10 +693,10 @@ Return the proper Carto cdn-invalidator-sub full name
 {{- end -}}
 
 {{/*
-Return the proper tag name for cdnInvalidatorSub image
+Return the proper Carto cdn-invalidator-sub image name
 */}}
-{{- define "carto.cdnInvalidatorSub.tag" -}}
-{{- default .Chart.AppVersion .Values.cdnInvalidatorSub.image.tag -}}
+{{- define "carto.cdnInvalidatorSub.image" -}}
+{{- include "carto.images.image" (dict "imageRoot" .Values.cdnInvalidatorSub.image "global" .Values.global "Chart" .Chart) -}}
 {{- end -}}
 
 {{/*
@@ -714,10 +733,10 @@ Create the name of the service account to use for the cdn-invalidator-sub deploy
 {{- end -}}
 
 {{/*
-Return the proper tag name for workspaceMigrations image
+Return the proper Carto workspace-db image name
 */}}
-{{- define "carto.workspaceMigrations.tag" -}}
-{{- default .Chart.AppVersion .Values.workspaceMigrations.image.tag -}}
+{{- define "carto.workspaceMigrations.image" -}}
+{{- include "carto.images.image" (dict "imageRoot" .Values.workspaceMigrations.image "global" .Values.global "Chart" .Chart) -}}
 {{- end -}}
 
 {{/*

--- a/chart/templates/accounts-www/deployment.yaml
+++ b/chart/templates/accounts-www/deployment.yaml
@@ -69,7 +69,7 @@ spec:
       {{- end }}
       containers:
         - name: accounts-www
-          image: "{{ .Values.accountsWww.image.name }}:{{- include "carto.accountsWww.tag" . -}}"
+          image: {{ template "carto.accountsWww.image" . }}
           imagePullPolicy: {{ .Values.accountsWww.image.pullPolicy }}
           {{- if .Values.accountsWww.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.accountsWww.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/chart/templates/cdn-invalidator-sub/deployment.yaml
+++ b/chart/templates/cdn-invalidator-sub/deployment.yaml
@@ -73,7 +73,7 @@ spec:
       {{- end }}
       containers:
         - name: cdn-invalidator-sub
-          image: "{{ .Values.cdnInvalidatorSub.image.name }}:{{- include "carto.cdnInvalidatorSub.tag" . -}}"
+          image: {{ template "carto.cdnInvalidatorSub.image" . }}
           imagePullPolicy: {{ .Values.cdnInvalidatorSub.image.pullPolicy }}
           {{- if .Values.cdnInvalidatorSub.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.cdnInvalidatorSub.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/chart/templates/http-cache/deployment.yaml
+++ b/chart/templates/http-cache/deployment.yaml
@@ -73,7 +73,7 @@ spec:
       {{- end }}
       containers:
         - name: http-cache
-          image: "{{ .Values.httpCache.image.name }}:{{- include "carto.httpCache.tag" . -}}"
+          image: {{ template "carto.httpCache.image" . }}
           imagePullPolicy: {{ .Values.httpCache.image.pullPolicy }}
           {{- if .Values.httpCache.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.httpCache.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/chart/templates/import-api/deployment.yaml
+++ b/chart/templates/import-api/deployment.yaml
@@ -76,7 +76,7 @@ spec:
       {{- end }}
       containers:
         - name: import-api
-          image: "{{ .Values.importApi.image.name }}:{{- include "carto.importApi.tag" . -}}"
+          image: {{ template "carto.importApi.image" . }}
           imagePullPolicy: {{ .Values.importApi.image.pullPolicy }}
           {{- if .Values.importApi.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.importApi.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/chart/templates/import-worker/deployment.yaml
+++ b/chart/templates/import-worker/deployment.yaml
@@ -77,7 +77,7 @@ spec:
       {{- end }}
       containers:
         - name: import-worker
-          image: "{{ .Values.importWorker.image.name }}:{{- include "carto.importWorker.tag" . -}}"
+          image: {{ template "carto.importWorker.image" . }}
           imagePullPolicy: {{ .Values.importWorker.image.pullPolicy }}
           {{- if .Values.importWorker.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.importWorker.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/chart/templates/lds-api/deployment.yaml
+++ b/chart/templates/lds-api/deployment.yaml
@@ -76,7 +76,7 @@ spec:
       {{- end }}
       containers:
         - name: lds-api
-          image: "{{ .Values.ldsApi.image.name }}:{{- include "carto.ldsApi.tag" . -}}"
+          image: {{ template "carto.ldsApi.image" . }}
           imagePullPolicy: {{ .Values.ldsApi.image.pullPolicy }}
           {{- if .Values.ldsApi.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.ldsApi.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/chart/templates/maps-api/deployment.yaml
+++ b/chart/templates/maps-api/deployment.yaml
@@ -76,7 +76,7 @@ spec:
       {{- end }}
       containers:
         - name: maps-api
-          image: "{{ .Values.mapsApi.image.name }}:{{- include "carto.mapsApi.tag" . -}}"
+          image: {{ template "carto.mapsApi.image" . }}
           imagePullPolicy: {{ .Values.mapsApi.image.pullPolicy }}
           {{- if .Values.mapsApi.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.mapsApi.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/chart/templates/router/deployment.yaml
+++ b/chart/templates/router/deployment.yaml
@@ -72,7 +72,7 @@ spec:
       {{- end }}
       containers:
         - name: router
-          image: "{{ .Values.router.image.name }}:{{- include "carto.router.tag" . -}}"
+          image: {{ template "carto.router.image" . }}
           imagePullPolicy: {{ .Values.router.image.pullPolicy }}
           {{- if .Values.router.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.router.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/chart/templates/workspace-api/deployment.yaml
+++ b/chart/templates/workspace-api/deployment.yaml
@@ -71,7 +71,7 @@ spec:
         {{ include "carto.redis-init-container" . | nindent 8 }}
         {{- end }}
         - name: workspace-migrations
-          image: "{{ .Values.workspaceMigrations.image.name }}:{{- include "carto.workspaceMigrations.tag" . -}}"
+          image: {{ template "carto.workspaceMigrations.image" . }}
           imagePullPolicy: {{ .Values.workspaceMigrations.image.pullPolicy }}
           {{- if .Values.workspaceMigrations.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.workspaceMigrations.containerSecurityContext "enabled" | toYaml | nindent 12 }}
@@ -127,7 +127,7 @@ spec:
       {{- end }}
       containers:
         - name: workspace-api
-          image: "{{ .Values.workspaceApi.image.name }}:{{- include "carto.workspaceApi.tag" . -}}"
+          image: {{ template "carto.workspaceApi.image" . }}
           imagePullPolicy: {{ .Values.workspaceApi.image.pullPolicy }}
           {{- if .Values.workspaceApi.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.workspaceApi.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/chart/templates/workspace-subscriber/deployment.yaml
+++ b/chart/templates/workspace-subscriber/deployment.yaml
@@ -77,7 +77,7 @@ spec:
       {{- end }}
       containers:
         - name: workspace-subscriber
-          image: "{{ .Values.workspaceSubscriber.image.name }}:{{- include "carto.workspaceSubscriber.tag" . -}}"
+          image: {{ template "carto.workspaceSubscriber.image" . }}
           imagePullPolicy: {{ .Values.workspaceSubscriber.image.pullPolicy }}
           {{- if .Values.workspaceSubscriber.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.workspaceSubscriber.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/chart/templates/workspace-www/deployment.yaml
+++ b/chart/templates/workspace-www/deployment.yaml
@@ -70,7 +70,7 @@ spec:
       {{- end }}
       containers:
         - name: workspace-www
-          image: "{{ .Values.workspaceWww.image.name }}:{{- include "carto.workspaceWww.tag" . -}}"
+          image: {{ template "carto.workspaceWww.image" . }}
           imagePullPolicy: {{ .Values.workspaceWww.image.pullPolicy }}
           {{- if .Values.workspaceWww.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.workspaceWww.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -227,13 +227,15 @@ commonSecretConfiguration: |
 ##
 accountsWww:
   ## accounts-www image
-  ## @param accountsWww.image.name accounts-www image registry and repository
+  ## @param accountsWww.image.registry accounts-www image registry
+  ## @param accountsWww.image.repository accounts-www image repository
   ## @param accountsWww.image.tag accounts-www image tag (immutable tags are recommended)
   ## @param accountsWww.image.pullPolicy accounts-www image pull policy
   ## @param accountsWww.image.pullSecrets accounts-www image pull secrets
   ##
   image:
-    name: gcr.io/carto-onprem-artifacts/accounts-www
+    registry: gcr.io/carto-onprem-artifacts
+    repository: accounts-www
     ## Specify a custom image tag
     tag: ""
     ## Specify a imagePullPolicy
@@ -545,13 +547,15 @@ accountsWww:
 ##
 importApi:
   ## import-api image
-  ## @param importApi.image.name import-api image registry and repository
+  ## @param importApi.image.registry import-api image registry
+  ## @param importApi.image.repository import-api image repository
   ## @param importApi.image.tag import-api image tag (immutable tags are recommended)
   ## @param importApi.image.pullPolicy import-api image pull policy
   ## @param importApi.image.pullSecrets import-api image pull secrets
   ##
   image:
-    name: gcr.io/carto-onprem-artifacts/import-api
+    registry: gcr.io/carto-onprem-artifacts
+    repository: import-api
     ## Specify a custom image tag
     tag: ""
     ## Specify a imagePullPolicy
@@ -862,13 +866,15 @@ importApi:
 ##
 importWorker:
   ## import-worker image
-  ## @param importWorker.image.name import-worker image registry and repository
+  ## @param importWorker.image.registry import-worker image registry
+  ## @param importWorker.image.repository import-worker image repository
   ## @param importWorker.image.tag import-worker image tag (immutable tags are recommended)
   ## @param importWorker.image.pullPolicy import-worker image pull policy
   ## @param importWorker.image.pullSecrets import-worker image pull secrets
   ##
   image:
-    name: gcr.io/carto-onprem-artifacts/import-api
+    registry: gcr.io/carto-onprem-artifacts
+    repository: import-api
     ## Specify a custom image tag
     tag: ""
     ## Specify a imagePullPolicy
@@ -1073,13 +1079,15 @@ importWorker:
 ##
 ldsApi:
   ## lds-api image
-  ## @param ldsApi.image.name lds-api image registry and repository
+  ## @param ldsApi.image.registry lds-api image registry
+  ## @param ldsApi.image.repository lds-api image repository
   ## @param ldsApi.image.tag lds-api image tag (immutable tags are recommended)
   ## @param ldsApi.image.pullPolicy lds-api image pull policy
   ## @param ldsApi.image.pullSecrets lds-api image pull secrets
   ##
   image:
-    name: gcr.io/carto-onprem-artifacts/lds-api
+    registry: gcr.io/carto-onprem-artifacts
+    repository: lds-api
     ## Specify a custom image tag
     tag: ""
     ## Specify a imagePullPolicy
@@ -1390,13 +1398,15 @@ ldsApi:
 ##
 mapsApi:
   ## maps-api image
-  ## @param mapsApi.image.name maps-api image registry and repository
+  ## @param mapsApi.image.registry maps-api image registry
+  ## @param mapsApi.image.repository maps-api image repository
   ## @param mapsApi.image.tag maps-api image tag (immutable tags are recommended)
   ## @param mapsApi.image.pullPolicy maps-api image pull policy
   ## @param mapsApi.image.pullSecrets maps-api image pull secrets
   ##
   image:
-    name: gcr.io/carto-onprem-artifacts/maps-api
+    registry: gcr.io/carto-onprem-artifacts
+    repository: maps-api
     ## Specify a custom image tag
     tag: ""
     ## Specify a imagePullPolicy
@@ -1708,13 +1718,15 @@ mapsApi:
 ##
 router:
   ## router image
-  ## @param router.image.name router image registry and repository
+  ## @param router.image.registry router image registry
+  ## @param router.image.repository router image repository
   ## @param router.image.tag router image tag (immutable tags are recommended)
   ## @param router.image.pullPolicy router image pull policy
   ## @param router.image.pullSecrets router image pull secrets
   ##
   image:
-    name: gcr.io/carto-onprem-artifacts/router
+    registry: gcr.io/carto-onprem-artifacts
+    repository: router
     ## Specify a custom image tag
     tag: ""
     ## Specify a imagePullPolicy
@@ -2032,13 +2044,16 @@ router:
 ##
 httpCache:
   ## httpCache image
+  ## @param httpCache.image.registry http-cache image registry
+  ## @param httpCache.image.repository http-cache image repository
   ## @param httpCache.image.name http-cache image registry and repository
   ## @param httpCache.image.tag http-cache image tag (immutable tags are recommended)
   ## @param httpCache.image.pullPolicy http-cache image pull policy
   ## @param httpCache.image.pullSecrets http-cache image pull secrets
   ##
   image:
-    name: gcr.io/carto-onprem-artifacts/http-cache
+    registry: gcr.io/carto-onprem-artifacts
+    repository: http-cache
     ## Specify a custom image tag
     tag: ""
     ## Specify a imagePullPolicy
@@ -2338,13 +2353,15 @@ httpCache:
 ##
 cdnInvalidatorSub:
   ## cdnInvalidatorSub image
-  ## @param cdnInvalidatorSub.image.name cdnInvalidatorSub image registry and repository
-  ## @param cdnInvalidatorSub.image.tag cdnInvalidatorSub image tag (immutable tags are recommended)
-  ## @param cdnInvalidatorSub.image.pullPolicy cdnInvalidatorSub image pull policy
-  ## @param cdnInvalidatorSub.image.pullSecrets cdnInvalidatorSub image pull secrets
+  ## @param cdnInvalidatorSub.image.registry cdn-invalidator-sub image registry
+  ## @param cdnInvalidatorSub.image.repository cdn-invalidator-sub image repository
+  ## @param cdnInvalidatorSub.image.tag cdn-invalidator-sub image tag (immutable tags are recommended)
+  ## @param cdnInvalidatorSub.image.pullPolicy cdn-invalidator-sub image pull policy
+  ## @param cdnInvalidatorSub.image.pullSecrets cdn-invalidator-sub image pull secrets
   ##
   image:
-    name: gcr.io/carto-onprem-artifacts/consumers/cdn-invalidator-sub
+    registry: gcr.io/carto-onprem-artifacts
+    repository: consumers/cdn-invalidator-sub
     ## Specify a custom image tag
     tag: ""
     ## Specify a imagePullPolicy
@@ -2646,13 +2663,15 @@ cdnInvalidatorSub:
 ##
 workspaceApi:
   ## workspace-api image
-  ## @param workspaceApi.image.name workspace-api image registry and repository
+  ## @param workspaceApi.image.registry workspace-api image registry
+  ## @param workspaceApi.image.repository workspace-api image repository
   ## @param workspaceApi.image.tag workspace-api image tag (immutable tags are recommended)
   ## @param workspaceApi.image.pullPolicy workspace-api image pull policy
   ## @param workspaceApi.image.pullSecrets workspace-api image pull secrets
   ##
   image:
-    name: gcr.io/carto-onprem-artifacts/workspace-api
+    registry: gcr.io/carto-onprem-artifacts
+    repository: workspace-api
     ## Specify a custom image tag
     tag: ""
     ## Specify a imagePullPolicy
@@ -2964,13 +2983,15 @@ workspaceApi:
 ##
 workspaceSubscriber:
   ## workspace-subscriber image
-  ## @param workspaceSubscriber.image.name workspace-subscriber image registry and repository
+  ## @param workspaceSubscriber.image.registry workspace-subscriber image registry
+  ## @param workspaceSubscriber.image.repository workspace-subscriber image repository
   ## @param workspaceSubscriber.image.tag workspace-subscriber image tag (immutable tags are recommended)
   ## @param workspaceSubscriber.image.pullPolicy workspace-subscriber image pull policy
   ## @param workspaceSubscriber.image.pullSecrets workspace-subscriber image pull secrets
   ##
   image:
-    name: gcr.io/carto-onprem-artifacts/workspace-api
+    registry: gcr.io/carto-onprem-artifacts
+    repository: workspace-api
     ## Specify a custom image tag
     tag: ""
     ## Specify a imagePullPolicy
@@ -3175,13 +3196,15 @@ workspaceSubscriber:
 ##
 workspaceWww:
   ## workspace-www image
-  ## @param workspaceWww.image.name workspace-www image registry and repository
+  ## @param workspaceWww.image.registry workspace-www image registry
+  ## @param workspaceWww.image.repository workspace-www image repository
   ## @param workspaceWww.image.tag workspace-www image tag (immutable tags are recommended)
   ## @param workspaceWww.image.pullPolicy workspace-www image pull policy
   ## @param workspaceWww.image.pullSecrets workspace-www image pull secrets
   ##
   image:
-    name: gcr.io/carto-onprem-artifacts/workspace-www
+    registry: gcr.io/carto-onprem-artifacts
+    repository: workspace-www
     ## Specify a custom image tag
     tag: ""
     ## Specify a imagePullPolicy
@@ -3491,14 +3514,16 @@ workspaceWww:
 ## @section Init Container Parameters
 ##
 workspaceMigrations:
-  ## Migrations image
-  ## @param workspaceMigrations.image.name workspace-db image registry and repository
+  ## workspace-db image
+  ## @param workspaceMigrations.image.registry workspace-db image registry
+  ## @param workspaceMigrations.image.repository workspace-db image repository
   ## @param workspaceMigrations.image.tag workspace-db image tag (immutable tags are recommended)
   ## @param workspaceMigrations.image.pullPolicy workspace-db image pull policy
   ## @param workspaceMigrations.image.pullSecrets workspace-db image pull secrets
   ##
   image:
-    name: gcr.io/carto-onprem-artifacts/workspace-db
+    registry: gcr.io/carto-onprem-artifacts
+    repository: workspace-db
     ## Specify a custom image tag
     tag: ""
     pullPolicy: IfNotPresent

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2046,7 +2046,6 @@ httpCache:
   ## httpCache image
   ## @param httpCache.image.registry http-cache image registry
   ## @param httpCache.image.repository http-cache image repository
-  ## @param httpCache.image.name http-cache image registry and repository
   ## @param httpCache.image.tag http-cache image tag (immutable tags are recommended)
   ## @param httpCache.image.pullPolicy http-cache image pull policy
   ## @param httpCache.image.pullSecrets http-cache image pull secrets


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

Now the Docker image name it's split into 2 different values

```yaml
workspaceApi:
    registry: gcr.io/carto-onprem-artifacts
    repository: workspace-www
```

You can also specify the image tag for only 1 component

```yaml
workspaceApi:
    tag: latest
```

**Benefits**

More user-friendly :)

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->