### PR TITLE
feat(chart): scale 0 replicas if tenant info value is missing

### DIFF
--- a/chart/templates/cdn-invalidator-sub/deployment.yaml
+++ b/chart/templates/cdn-invalidator-sub/deployment.yaml
@@ -13,7 +13,12 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  # We need the tenant config values to start this component without errors
+  {{- if .Values.cartoConfigValues.selfHostedTenantId }}
   replicas: {{ .Values.cdnInvalidatorSub.replicaCount }}
+  {{- else }}
+  replicas: 0
+  {{- end }}
   {{- if .Values.cdnInvalidatorSub.updateStrategy }}
   strategy: {{- toYaml .Values.cdnInvalidatorSub.updateStrategy | nindent 4 }}
   {{- end }}

--- a/chart/templates/cdn-invalidator-sub/deployment.yaml
+++ b/chart/templates/cdn-invalidator-sub/deployment.yaml
@@ -13,7 +13,8 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  # We need the tenant config values to start this component without errors
+  # In order to publish the charts in official marketplaces, it's necessary that all components are able to start with default values without errors
+  # Components which needs other configuration requirements such as client specific parameters should not boot if these values ​​are not provided
   {{- if .Values.cartoConfigValues.selfHostedTenantId }}
   replicas: {{ .Values.cdnInvalidatorSub.replicaCount }}
   {{- else }}

--- a/chart/templates/import-worker/deployment.yaml
+++ b/chart/templates/import-worker/deployment.yaml
@@ -13,7 +13,8 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  # We need the tenant config values to start this component without errors
+  # In order to publish the charts in official marketplaces, it's necessary that all components are able to start with default values without errors
+  # Components which needs other configuration requirements such as client specific parameters should not boot if these values ​​are not provided
   {{- if .Values.cartoConfigValues.selfHostedTenantId }}
   replicas: {{ .Values.importWorker.replicaCount }}
   {{- else }}

--- a/chart/templates/import-worker/deployment.yaml
+++ b/chart/templates/import-worker/deployment.yaml
@@ -13,6 +13,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  # We need the tenant config values to start this component without errors
   {{- if .Values.cartoConfigValues.selfHostedTenantId }}
   replicas: {{ .Values.importWorker.replicaCount }}
   {{- else }}

--- a/chart/templates/workspace-subscriber/deployment.yaml
+++ b/chart/templates/workspace-subscriber/deployment.yaml
@@ -13,6 +13,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  # We need the tenant config values to start this component without errors
   {{- if .Values.cartoConfigValues.selfHostedTenantId }}
   replicas: {{ .Values.workspaceSubscriber.replicaCount }}
   {{- else }}

--- a/chart/templates/workspace-subscriber/deployment.yaml
+++ b/chart/templates/workspace-subscriber/deployment.yaml
@@ -13,7 +13,8 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  # We need the tenant config values to start this component without errors
+  # In order to publish the charts in official marketplaces, it's necessary that all components are able to start with default values without errors
+  # Components which needs other configuration requirements such as client specific parameters should not boot if these values ​​are not provided
   {{- if .Values.cartoConfigValues.selfHostedTenantId }}
   replicas: {{ .Values.workspaceSubscriber.replicaCount }}
   {{- else }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

The idea is that if you execute helm install carto from the official helm repo (without any customer file) all pods were able to run without restarts, `import-worker`, `workspace-subscriber` and `cnd-invalidator` needs these tenant config params, in other case they will be restarting continually. The rests of the components do not need this params to stay in running state.

This is a prerequisite in some marketplaces to publish the chart

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->