### PR TITLE
Update to `1.21.2-2022.04.04` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.13.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.12
+  version: 11.1.15
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.7.0
-digest: sha256:55af71220be8f7ce54fee199209be05579c472d89e703eb26314408b66df4ba7
-generated: "2022-03-30T10:11:17.087017455Z"
+  version: 16.8.2
+digest: sha256:65addcc1431762d22d72be2474589d89c9779fa3dd65e4c4d33c8f64d9762df4
+generated: "2022-04-04T14:00:27.11685176Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.03.30.1
+appVersion: 2022.04.04
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -28,4 +28,4 @@ keywords:
 name: carto
 sources:
   - https://carto.com/
-version: 1.20.1
+version: 1.21.2


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/10c7ac3a4e71203b58d25328e38d47dc091199e1