### PR TITLE
Update VIB Trivy action threshold

### DIFF
--- a/.vib/vib-pipeline.json
+++ b/.vib/vib-pipeline.json
@@ -24,7 +24,7 @@
         {
           "action_id": "trivy",
           "params": {
-            "threshold": "IGNORE_ALL",
+            "threshold": "CRITICAL",
             "vuln_type": ["OS"]
           }
         }


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

Now that the CVE related to `Varnish 6.0.10` (CVE-2022-23959) has been whitelisted in VIB, this PR reverts Trivy's action threshold change so it fails when a fixable CVE of `CRITICAL` severity is detected.

**Benefits**

The vulnerability analysis will come back up online.

**Additional information**

Tested in a fork https://github.com/FraPazGal/carto-selfhosted-helm/pull/4 where the 400 error in this PR vib action is avoided (present here because the PR is coming from a fork):
```
      {
        "vulnerability_id": "CVE-2022-23959",
        "location": "gcr.io/carto-onprem-artifacts/http-cache:2022.04.04",
        "package_name": "varnish",
        "package_type": "OS",
        "affected_version": "6.0.10",
        "title": "varnish: HTTP/1 request smuggling vulnerability",
        "url": "https://avd.aquasec.com/nvd/cve-2022-23959",
        "description": "In Varnish Cache before 6.6.2 and 7.x before 7.0.2, Varnish Cache 6.0 LTS before 6.0.10, and and Varnish Enterprise (Cache Plus) 4.1.x before 4.1.11r6 and 6.0.x before 6.0.9r4, request smuggling can occur for HTTP/1 connections.",
        "severity": "CRITICAL",
        "cvss_score": 9.1,
        "fixed": "FIXED",
        "fixed_version": "6.5.1-1+deb11u2",
        "ignored": false,
        "allowed": true
      },
```