### PR TITLE
Update to `1.21.5-2022.04.18` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.13.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.15
+  version: 11.1.20
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.8.2
-digest: sha256:65addcc1431762d22d72be2474589d89c9779fa3dd65e4c4d33c8f64d9762df4
-generated: "2022-04-04T14:00:27.11685176Z"
+  version: 16.8.5
+digest: sha256:b3c07422b2dc2eb61839eba23d8ab8c1491531d7c0a66e6c1f9a8794dfef1a3e
+generated: "2022-04-18T13:20:11.151763668Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.04.04
+appVersion: 2022.04.18
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -28,4 +28,4 @@ keywords:
 name: carto
 sources:
   - https://carto.com/
-version: 1.21.2
+version: 1.21.5


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/6fdc573abb0158e50ccd24591136da947e49d358