### PR TITLE
Update to `1.21.5-2022.05.04` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.13.0
+  version: 1.13.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.15
+  version: 11.1.26
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.8.2
-digest: sha256:65addcc1431762d22d72be2474589d89c9779fa3dd65e4c4d33c8f64d9762df4
-generated: "2022-04-04T14:00:27.11685176Z"
+  version: 16.8.9
+digest: sha256:73e5680ce8384be553120abce95c13f21322151159b85dd544ab20eb8793077f
+generated: "2022-05-04T15:22:32.610536602Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.04.04
+appVersion: 2022.05.04
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -28,4 +28,4 @@ keywords:
 name: carto
 sources:
   - https://carto.com/
-version: 1.21.2
+version: 1.21.5


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/a06c22ceeb73c1b9097c8302b068a0a7784bdecc