### PR TITLE
Update to `1.21.7-2022.05.11` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 11.1.28
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.8.10
-digest: sha256:028ae3c91765f3f17dbecdb045b7449d575ee6e45fc58694f314114010bc65bf
-generated: "2022-05-05T15:23:58.092525907Z"
+  version: 16.9.2
+digest: sha256:3ed377b981f052edb8c06ed0d49cef6b1eadc536b896ef94f0ea5de8cbaadc20
+generated: "2022-05-11T12:16:03.838969165Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.05.05
+appVersion: 2022.05.11
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -28,4 +28,4 @@ keywords:
 name: carto
 sources:
   - https://carto.com/
-version: 1.21.6
+version: 1.21.7


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/6162bb2467f37c3f1ef039bf425512beda4c920b