### PR TITLE
Update to `1.22.1-2022.05.12` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -9,4 +9,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 16.9.3
 digest: sha256:898467cc06bd3aa22c8975937b52a8353dab1de596b1acf224da2f4ff3c7bd80
-generated: "2022-05-12T14:23:18.506920054Z"
+generated: "2022-05-12T14:39:59.231006004Z"

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 11.1.28
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.9.2
-digest: sha256:3ed377b981f052edb8c06ed0d49cef6b1eadc536b896ef94f0ea5de8cbaadc20
-generated: "2022-05-11T12:33:25.524477925Z"
+  version: 16.9.3
+digest: sha256:898467cc06bd3aa22c8975937b52a8353dab1de596b1acf224da2f4ff3c7bd80
+generated: "2022-05-12T14:23:18.506920054Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.05.11
+appVersion: 2022.05.12
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -28,4 +28,4 @@ keywords:
 name: carto
 sources:
   - https://carto.com/
-version: 1.21.8
+version: 1.22.1


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/7aa4329727e13a2cac8e3cc376fccec4b730c27e