### PR TITLE
Use stable version for VIB action

### DIFF
--- a/.github/workflows/vib.yaml
+++ b/.github/workflows/vib.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - uses: vmware-labs/vmware-image-builder-action@main
+      - uses: vmware-labs/vmware-image-builder-action@0.2.0
 
   vib-k8s-verify: # verify in multiple target platforms
     runs-on: ubuntu-latest
@@ -35,7 +35,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - uses: vmware-labs/vmware-image-builder-action@main
+      - uses: vmware-labs/vmware-image-builder-action@0.2.0
         with:
           pipeline: vib-platform-verify.json
         env:


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

We should avoid using the `main` branch of the VIB action, which can be subjected to faulty code. Changing the action version to a fixed release reduces the risk.

This PR changes the `vmware-labs/vmware-image-builder-action` action to its latest release per the [GH's marketplace](https://github.com/marketplace/actions/vmware-image-builder).

**Benefits**

<!-- What benefits will be realized by the code change? -->

Stability increase for the VIB action.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

We'll need to manually update the used version whenever there is a new release.
