### PR TITLE
Update to `1.23.3-2022.5.24` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 11.2.6
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.9.10
-digest: sha256:f0d2a9c45480939fe9e68bfeff1010aadbbaa78ad320a3cea2f69c7ef470ea6a
-generated: "2022-05-23T13:42:38.877710802Z"
+  version: 16.9.11
+digest: sha256:de6f5ce85506bf18438a32b4ae96fd0e90ac3cc6861299a952eac7e68b4681d3
+generated: "2022-05-24T08:48:47.056202905Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.5.23
+appVersion: 2022.5.24
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -28,4 +28,4 @@ keywords:
 name: carto
 sources:
   - https://carto.com/
-version: 1.23.2
+version: 1.23.3


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/20652c242e098f273e14c30f57e0ef78f18b7f5c