### PR TITLE
Update to `1.23.5-2022.5.27` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.14.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.2.6
+  version: 11.4.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.9.10
-digest: sha256:f0d2a9c45480939fe9e68bfeff1010aadbbaa78ad320a3cea2f69c7ef470ea6a
-generated: "2022-05-23T13:42:38.877710802Z"
+  version: 16.10.0
+digest: sha256:1f66c685f68cf6637ffd0cdeb62c90e89be197e77daf3724cdd3229167fca83c
+generated: "2022-05-27T09:23:09.572629456Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.5.23
+appVersion: 2022.5.27
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,5 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.05.12-5"
-version: 1.23.2
-
+version: 1.23.5


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/ecb91e12bae731811067133d16c0a80c458ec492