### PR TITLE
Update to `1.23.7-2022.6.1-6` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.14.1
+  version: 1.14.2
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.5.0
+  version: 11.6.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.10.0
-digest: sha256:0545ab770e964c5761067d59da69e248d5ce3bedbe90654647e16ae6d984ad3b
-generated: "2022-05-30T11:48:18.341134403Z"
+  version: 16.10.1
+digest: sha256:a622cf32a6b43dc7359f4722ed12291be05bf14b93d5ec3b6010f63a3ca20402
+generated: "2022-06-01T09:25:19.407944178Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.5.30
+appVersion: 2022.6.1-6
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.05.12-5"
-version: 1.23.5
+version: 1.23.7


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/5f057f4b9b0fb852f3ded8248bc6b0014d2a1ff8