### PR TITLE
Update to `1.23.8-2022.6.2` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.14.1
+  version: 1.15.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.5.0
+  version: 11.6.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.10.0
-digest: sha256:0545ab770e964c5761067d59da69e248d5ce3bedbe90654647e16ae6d984ad3b
-generated: "2022-05-30T11:48:18.341134403Z"
+  version: 16.10.1
+digest: sha256:36eb88c2b1794242f550cdabcbcac3cb5b4982e29f558d75bb1ea740ded36650
+generated: "2022-06-02T07:25:00.347141165Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.6.1-11
+appVersion: 2022.6.2
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.05.12-5"
-version: 1.23.7
+version: 1.23.8


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/9f097ed5908572e2f0af140db6d888848f75149d