### PR TITLE
Update to `1.24.2-2022.6.6` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.15.1
+  version: 1.16.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.0
+  version: 11.6.3
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.10.1
-digest: sha256:36eb88c2b1794242f550cdabcbcac3cb5b4982e29f558d75bb1ea740ded36650
-generated: "2022-06-02T07:25:00.347141165Z"
+  version: 16.11.2
+digest: sha256:a8d8b7667ff8a8fe1939137e7348747a7b0f16428b0f5680c97c079877c0333c
+generated: "2022-06-06T08:51:29.879313656Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.6.2
+appVersion: 2022.6.6
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.05.12-5"
-version: 1.23.8
+version: 1.24.2


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/ab503135539cce706f8514a6d067b4b4850d8a1e