### PR TITLE
Update to `1.24.6-2022.6.7` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 11.6.3
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.11.2
-digest: sha256:a8d8b7667ff8a8fe1939137e7348747a7b0f16428b0f5680c97c079877c0333c
-generated: "2022-06-06T08:51:29.879313656Z"
+  version: 16.11.3
+digest: sha256:252f0ccc24d99fc4c53c1cc11be1c46e8ccfe387b39ff23b63f04f84adef1346
+generated: "2022-06-07T08:56:12.08936131Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.6.6-2
+appVersion: 2022.6.7
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.05.12-5"
-version: 1.24.3
+version: 1.24.6


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/032b4315834951b8f0a73d66234b61cb4c3f83c4