### PR TITLE
Update to `1.25.2-2022.6.8-1` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.16.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.3
+  version: 11.6.4
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 16.11.3
-digest: sha256:252f0ccc24d99fc4c53c1cc11be1c46e8ccfe387b39ff23b63f04f84adef1346
-generated: "2022-06-07T08:56:12.08936131Z"
+digest: sha256:76d2ac395aa49281bd6fdbeaead5d0fdf69cdf15858ee69da8fad45158079e71
+generated: "2022-06-08T10:41:47.446132633Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.6.7
+appVersion: 2022.6.8-1
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.05.12-5"
-version: 1.24.6
+version: 1.25.2


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/1c39ecbd71518478555b9deddd40560c5a301fa9