### PR TITLE
Update to `1.26.2-2022.6.10-1` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.16.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.4
+  version: 11.6.5
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.11.3
-digest: sha256:76d2ac395aa49281bd6fdbeaead5d0fdf69cdf15858ee69da8fad45158079e71
-generated: "2022-06-08T10:53:15.121584618Z"
+  version: 16.12.0
+digest: sha256:ccdceb1a945dbdd6359cbccffe996d3522bc908aadcf1364216d7dbe962b396b
+generated: "2022-06-10T10:00:07.334390748Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.6.8-3
+appVersion: 2022.6.10-1
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.05.12-5"
-version: 1.25.2
+version: 1.26.2


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/4c738da8b0224cea823316c3b6799f6b8d075fbd