### PR TITLE
adjust varnish resources

### DIFF
--- a/chart/templates/http-cache/configmap.yaml
+++ b/chart/templates/http-cache/configmap.yaml
@@ -16,5 +16,5 @@ data:
   VARNISH_WORKSPACE_API_INTERNAL_URL: {{ include "carto.workspaceApi.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
   VARNISH_PURGE_ALLOWED_IPS: "0.0.0.0/0"
   VARNISH_REPORT_BASIC_INFORMATION_HEADERS: "true"
-  VARNISH_SIZE: {{ include "carto.httpCache.resources.requests.memory" . }}
+  VARNISH_SIZE: {{ .Values.httpCache.resources.requests.memory | replace "M" "" | atoi | add ( .Values.httpCache.resources.requests.memory | replace "M" "" | atoi | div 4 ) }}
 {{- end }}

--- a/chart/templates/http-cache/configmap.yaml
+++ b/chart/templates/http-cache/configmap.yaml
@@ -16,5 +16,5 @@ data:
   VARNISH_WORKSPACE_API_INTERNAL_URL: {{ include "carto.workspaceApi.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
   VARNISH_PURGE_ALLOWED_IPS: "0.0.0.0/0"
   VARNISH_REPORT_BASIC_INFORMATION_HEADERS: "true"
-  VARNISH_SIZE: {{ div "carto.httpCache.resources.limits.memory" 2 }}
+  VARNISH_SIZE: {{ include "carto.httpCache.resources.requests.memory" . }}
 {{- end }}

--- a/chart/templates/http-cache/configmap.yaml
+++ b/chart/templates/http-cache/configmap.yaml
@@ -16,5 +16,9 @@ data:
   VARNISH_WORKSPACE_API_INTERNAL_URL: {{ include "carto.workspaceApi.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
   VARNISH_PURGE_ALLOWED_IPS: "0.0.0.0/0"
   VARNISH_REPORT_BASIC_INFORMATION_HEADERS: "true"
-  VARNISH_SIZE: {{ ( div ( mul ( .Values.httpCache.resources.requests.memory | replace "Mi" "" | atoi ) 75 ) 100 ) | toString | printf "%sM" }}
+  {{- if .Values.httpCache.resources.requests }}
+  {{- if .Values.httpCache.resources.requests.memory }}
+  VARNISH_SIZE: {{ ( div ( mul ( ( .Values.httpCache.resources.requests.memory ) | replace "Mi" "" | atoi ) 75 ) 100 ) | toString | printf "%sM" | quote }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/http-cache/configmap.yaml
+++ b/chart/templates/http-cache/configmap.yaml
@@ -16,5 +16,5 @@ data:
   VARNISH_WORKSPACE_API_INTERNAL_URL: {{ include "carto.workspaceApi.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
   VARNISH_PURGE_ALLOWED_IPS: "0.0.0.0/0"
   VARNISH_REPORT_BASIC_INFORMATION_HEADERS: "true"
-  VARNISH_SIZE: {{ .Values.httpCache.resources.requests.memory | replace "M" "" | atoi | add ( .Values.httpCache.resources.requests.memory | replace "M" "" | atoi | div 4 ) }}
+  VARNISH_SIZE: {{ ( div ( mul ( .Values.httpCache.resources.requests.memory | replace "Mi" "" | atoi ) 75 ) 100 ) | toString | printf "%sM" }}
 {{- end }}

--- a/chart/templates/http-cache/configmap.yaml
+++ b/chart/templates/http-cache/configmap.yaml
@@ -16,4 +16,5 @@ data:
   VARNISH_WORKSPACE_API_INTERNAL_URL: {{ include "carto.workspaceApi.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
   VARNISH_PURGE_ALLOWED_IPS: "0.0.0.0/0"
   VARNISH_REPORT_BASIC_INFORMATION_HEADERS: "true"
+  VARNISH_SIZE: {{ div "carto.httpCache.resources.limits.memory" 2 }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2387,10 +2387,10 @@ httpCache:
   ##
   resources:
     limits:
-      memory: "1024Mi"
+      memory: "2048Mi"
       cpu: "500m"
     requests:
-      memory: "768Mi"
+      memory: "1256Mi"
       cpu: "375m"
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod


### PR DESCRIPTION
https://app.shortcut.com/cartoteam/story/219532/adjust-varnish-to-docker-kubernetes#activity-237384

## Changes

- Adjusting varnish resources
- Dynamically setting `VARNISH_SIZE` (`malloc`) depending on the value configured in `resources.requests.memory` 

With these new settings:
- `resources.limits.memory` = 2048M
- `resources.requests.memory` = 1256M
- `VARNISH_SIZE` (`varnish malloc`) = `resources.requests.memory` * 3 / 4 = 942M
(75%, leaving a margin of 25% for fragmentation, overhead, etc as recommended in the docs)

In case the `resources.requests.memory` is absent, varnish will run with its default value for malloc, which will be `256M` once [this PR](https://github.com/CartoDB/cloud-native/pull/7678) is merged.

## Testing with `resources.requests.memory` present
With the following values:
```
httpCache:
  resources:
    limits:
      memory: "2048Mi"
      cpu: "500m"
    requests:
      memory: "1256Mi"
      cpu: "375m"
```
The value of `VARNISH_SIZE` is:
```
$ helm template  adjust-varnish-resources   chart   --namespace albertoh   -f ~/Desktop/ahg-back-k8s/carto-values.yaml   -f ~/Desktop/ahg-back-k8s/carto-secrets.yaml -f ~/Desktop/ahg-back-k8s/customizations.yaml | grep VARNISH_SIZE
  VARNISH_SIZE: "942M"
```

## Testing with `resources.requests.memory` absent
```
$ helm template  adjust-varnish-resources   chart   --namespace albertoh   -f ~/Desktop/ahg-back-k8s/carto-values.yaml   -f ~/Desktop/ahg-back-k8s/carto-secrets.yaml -f ~/Desktop/ahg-back-k8s/customizations.yaml | grep VARNISH_SIZE
```
The variable `VARNISH_SIZE` is not set in the chart.