### PR TITLE
Update to `1.27.1-2022.6.15-1` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.16.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.5
+  version: 11.6.6
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.12.0
-digest: sha256:ccdceb1a945dbdd6359cbccffe996d3522bc908aadcf1364216d7dbe962b396b
-generated: "2022-06-10T10:00:07.334390748Z"
+  version: 16.12.2
+digest: sha256:5615d276d5093571c05e8c424445d161624f82a5c906515478c88bc6b34a6bc0
+generated: "2022-06-15T10:27:07.003348754Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.6.10-1
+appVersion: 2022.6.15-1
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.05.12-5"
-version: 1.26.2
+version: 1.27.1


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/a24884481c4a588ab40039db21822e6642bb91d1