### PR TITLE
Update to `1.28.1-2022.6.21` release

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.16.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.6
+  version: 11.6.7
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 16.12.2
-digest: sha256:5615d276d5093571c05e8c424445d161624f82a5c906515478c88bc6b34a6bc0
-generated: "2022-06-15T10:27:07.003348754Z"
+digest: sha256:f34084ceb363521f8c51938e2ad2d87ef716880d360902cca951ac14189e708e
+generated: "2022-06-21T07:17:21.4351144Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.6.15-1
+appVersion: 2022.6.21
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.05.12-5"
-version: 1.27.1
+version: 1.28.1


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/c6804eb05923e31ba59585b475efd70e32fe099b