### PR TITLE
Update to `1.28.2-2022.6.21-1655878529` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+<!--- NEW RELEASE TEMPLATE
+## very00.fake11.version22 (January 22, 2022)
+
+NOTES:
+
+- Very importante notice
+
+FEATURES:
+- workspace: This is a very new feature (#3458)
+
+IMPROVEMENTS:
+
+- maps: This is an improvement (#4532)
+
+BUG FIXES:
+
+- imports: This is an important bug fixing (#3456)
+
+--->
+
+## 2022.6.21 (June 21, 2022)
+
+IMPROVEMENTS:
+
+- Bugs fixing and minor improvements

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.6.21
+appVersion: 2022.6.21-1655878529
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.05.12-5"
-version: 1.28.1
+version: 1.28.2


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/63614aafd706cc0b382773fd0b820427c2b5334b