### PR TITLE
Update to `1.28.4-2022.6.21` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 2022.6.21 (June 21, 2022)
+
+IMPROVEMENTS:
+
+- Bugs fixing and minor improvements

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.05.12-5"
-version: 1.28.1
+version: 1.28.4


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/7da9bf585706a0a40c627f605c33ebc4ccba032c