### PR TITLE
Update to `1.30.1-2022.6.24-2` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+## 2022.6.24-2 (June 24, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
+
+## 2022.6.24-1 (June 24, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
+
+## 2022.6.23 (June 23, 2022)
+IMPROVEMENTS:
+- Bugs fixing and minor improvements
+
+## 2022.6.21 (June 21, 2022)
+IMPROVEMENTS:
+- Bugs fixing and minor improvements

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.16.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.8
+  version: 11.6.9
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 16.12.3
-digest: sha256:bce51df48cfa453ac301cd2a8bc501c3f74098f1ba20b9f4e7f5ca19d727ded8
-generated: "2022-06-23T07:57:17.424853306Z"
+digest: sha256:511267bfe24f61055541dcb3293bfb5cad10c5bf86ad4d9b05f2f0b844d144f6
+generated: "2022-06-24T11:06:49.983990764Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.6.23
+appVersion: 2022.6.24-2
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.05.12-5"
-version: 1.29.4
+version: 1.30.1


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/663a5455773274b214e81cc4dec68c9c2e4c44f3