### PR TITLE
Update to `1.33.1-2022.6.28` release

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -31,6 +31,7 @@ MD036: false # Emphasis used instead of a heading
 
 # Disabled by CARTO
 MD028: false # Allow no-blanks-blockquote Blank line inside blockquote
+MD041: false # Allow start file with h2 title
 
 #################
 # Rules by tags #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+## 2022.6.28 (June 28, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
++ Added partner tag to queries in BigQuery
+
+## 2022.6.24-2 (June 24, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
++ BUILDER - Visibility by zoom level control for layers
+
+## 2022.6.24-1 (June 24, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
+
+## 2022.6.23 (June 23, 2022)
+IMPROVEMENTS:
+- Bugs fixing and minor improvements
+
+## 2022.6.21 (June 21, 2022)
+IMPROVEMENTS:
+- Bugs fixing and minor improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,21 @@
-# 2022.6.28 (June 28, 2022)
+## 2022.6.28 (June 28, 2022)
 IMPROVEMENTS
 + Bugs Fixing and minor improvements
 + Added partner tag to queries in BigQuery
 
-# 2022.6.24-2 (June 24, 2022)
+## 2022.6.24-2 (June 24, 2022)
 IMPROVEMENTS
 + Bugs Fixing and minor improvements
 + BUILDER - Visibility by zoom level control for layers
 
-# 2022.6.24-1 (June 24, 2022)
+## 2022.6.24-1 (June 24, 2022)
 IMPROVEMENTS
 + Bugs Fixing and minor improvements
 
-# 2022.6.23 (June 23, 2022)
+## 2022.6.23 (June 23, 2022)
 IMPROVEMENTS:
 - Bugs fixing and minor improvements
 
-# 2022.6.21 (June 21, 2022)
+## 2022.6.21 (June 21, 2022)
 IMPROVEMENTS:
 - Bugs fixing and minor improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,21 @@
-## 2022.6.28 (June 28, 2022)
+# 2022.6.28 (June 28, 2022)
 IMPROVEMENTS
 + Bugs Fixing and minor improvements
 + Added partner tag to queries in BigQuery
 
-## 2022.6.24-2 (June 24, 2022)
+# 2022.6.24-2 (June 24, 2022)
 IMPROVEMENTS
 + Bugs Fixing and minor improvements
 + BUILDER - Visibility by zoom level control for layers
 
-## 2022.6.24-1 (June 24, 2022)
+# 2022.6.24-1 (June 24, 2022)
 IMPROVEMENTS
 + Bugs Fixing and minor improvements
 
-## 2022.6.23 (June 23, 2022)
+# 2022.6.23 (June 23, 2022)
 IMPROVEMENTS:
 - Bugs fixing and minor improvements
 
-## 2022.6.21 (June 21, 2022)
+# 2022.6.21 (June 21, 2022)
 IMPROVEMENTS:
 - Bugs fixing and minor improvements

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.16.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.8
+  version: 11.6.10
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.12.3
-digest: sha256:bce51df48cfa453ac301cd2a8bc501c3f74098f1ba20b9f4e7f5ca19d727ded8
-generated: "2022-06-23T07:57:17.424853306Z"
+  version: 16.13.0
+digest: sha256:6088358edc6bc2f4dc856492f7e168f3cfd316748d859f3f5d14031b82bda993
+generated: "2022-06-28T15:26:14.353890779Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.6.23
+appVersion: 2022.6.28
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -29,5 +29,5 @@ name: carto
 sources:
   - https://carto.com/
 annotations:
-  minVersion: "2022.05.12-5"
-version: 1.29.4
+  minVersion: "2022.6.28"
+version: 1.33.1


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/05bbb246244fc36e0a0255081351e21d13c8f9c0