### PR TITLE
Update to `1.34.1-2022.6.29` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+## 2022.6.29 (June 29, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
++ Added partner tag to queries in BigQuery
+
+## 2022.6.24-2 (June 24, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
++ BUILDER - Visibility by zoom level control for layers
+
+## 2022.6.24-1 (June 24, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
+
+## 2022.6.23 (June 23, 2022)
+IMPROVEMENTS:
+- Bugs fixing and minor improvements
+
+## 2022.6.21 (June 21, 2022)
+IMPROVEMENTS:
+- Bugs fixing and minor improvements

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.16.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.8
+  version: 11.6.11
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.12.3
-digest: sha256:bce51df48cfa453ac301cd2a8bc501c3f74098f1ba20b9f4e7f5ca19d727ded8
-generated: "2022-06-23T07:57:17.424853306Z"
+  version: 16.13.0
+digest: sha256:7c4239b2b13a1d6e741e9ebd8c076b6c359826e23de7d2b915ca095bf62fad36
+generated: "2022-06-29T15:13:01.415926677Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.6.23
+appVersion: 2022.6.29
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -29,5 +29,5 @@ name: carto
 sources:
   - https://carto.com/
 annotations:
-  minVersion: "2022.05.12-5"
-version: 1.29.4
+  minVersion: "2022.6.28"
+version: 1.34.1


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/d3758dcd029211fd1d5a4b8f75c17d4b9f687a5c