### PR TITLE
Update to `1.35.2-2022.6.30` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2022.6.30 (June 30, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
++ New Pop-ups in Builder
+
 ## 2022.6.29 (June 29, 2022)
 IMPROVEMENTS
 + Bugs Fixing and minor improvements

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 11.6.11
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.13.0
-digest: sha256:7c4239b2b13a1d6e741e9ebd8c076b6c359826e23de7d2b915ca095bf62fad36
-generated: "2022-06-29T15:13:01.415926677Z"
+  version: 16.13.1
+digest: sha256:566e8cc6a96c8e270cf3a2ea6574665873f427329da63ee53358929482eac580
+generated: "2022-06-30T10:41:51.298631539Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.6.29
+appVersion: 2022.6.30
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.6.28"
-version: 1.34.1
+version: 1.35.2


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/addaa08dae2e2957b58a23bae2335f0ee47e6870