### PR TITLE
Update to `1.35.2-2022.7.1` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2022.7.1 (July 01, 2022)
+IMPROVEMENTS
++ Dynamic Tilling Queries
++ Bugs Fixing and minor improvements
+
+## 2022.6.30 (June 30, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
++ New Pop-ups in Builder
+
 ## 2022.6.29 (June 29, 2022)
 IMPROVEMENTS
 + Bugs Fixing and minor improvements

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.16.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.11
+  version: 11.6.12
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.13.0
-digest: sha256:7c4239b2b13a1d6e741e9ebd8c076b6c359826e23de7d2b915ca095bf62fad36
-generated: "2022-06-29T15:13:01.415926677Z"
+  version: 16.13.1
+digest: sha256:a4281e8b97093487bf6430617fce0a59a5017cdb14b707a043e0524cc40512e1
+generated: "2022-07-01T06:30:39.016390181Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.6.29
+appVersion: 2022.7.1
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.6.28"
-version: 1.34.1
+version: 1.35.2


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/9c5e87c08b6ce69ab1e81be05756a66bbb1ff28c