### PR TITLE
Fix assignment of `carto.googleCloudStorageServiceAccountKey.secretNa…

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -171,7 +171,7 @@ Return the proper GCP Buckets Service Account Key Secret name
 */}}
 {{- define "carto.googleCloudStorageServiceAccountKey.secretName" -}}
 {{- if .Values.appSecrets.googleCloudStorageServiceAccountKey.existingSecret.name }}
-{{- .Values.cartoSecrets.googleCloudStorageServiceAccountKey.existingSecret.name -}}
+{{- .Values.appSecrets.googleCloudStorageServiceAccountKey.existingSecret.name -}}
 {{- else -}}
 {{- printf "%s-gcp-buckets-service-account" (include "common.names.fullname" .) -}}
 {{- end -}}
@@ -181,8 +181,8 @@ Return the proper GCP Buckets Service Account Key Secret name
 Return the proper GCP Buckets Service Account Key Secret key
 */}}
 {{- define "carto.googleCloudStorageServiceAccountKey.secretKey" -}}
-{{- if .Values.cartoSecrets.googleCloudStorageServiceAccountKey.existingSecret.key -}}
-{{- .Values.cartoSecrets.googleCloudStorageServiceAccountKey.existingSecret.key -}}
+{{- if .Values.appSecrets.googleCloudStorageServiceAccountKey.existingSecret.key -}}
+{{- .Values.appSecrets.googleCloudStorageServiceAccountKey.existingSecret.key -}}
 {{- else -}}
 {{- print "key.json" -}}
 {{- end -}}


### PR DESCRIPTION
`carto.googleCloudStorageServiceAccountKey.secretName` is assigned by first checking if a var is already set and then taking another variables value. This seems inconsistent with how the rest of the chart works.

example:

suppose you have a `customization.yaml` that looks like this.

```yaml
appSecrets:
  googleCloudStorageServiceAccountKey:
    existingSecret:
      name: "bar"
      key: "foo"

# deliberately commented out in the example, to ensure there is no values set. 
# cartoSecrets:
#   googleCloudStorageServiceAccountKey:
#     existingSecret:
#       name: "foo"
#       key: "bar"

```

When your run `helm template carto carto/carto -f customizations.yaml` you will get a error that describes the expected variable not being set.

```
Error: template: carto/templates/workspace-api/deployment.yaml:290:27: executing "carto/templates/workspace-api/deployment.yaml" at <include "carto.googleCloudStorageServiceAccountKey.secretName" .>: error calling include: template: carto/templates/_helpers.tpl:169:11: executing "carto.googleCloudStorageServiceAccountKey.secretName" at <.Values.cartoSecrets.googleCloudStorageServiceAccountKey.existingSecret.name>: nil pointer evaluating interface {}.existingSecret
helm.go:88: [debug] template: carto/templates/workspace-api/deployment.yaml:290:27: executing "carto/templates/workspace-api/deployment.yaml" at <include "carto.googleCloudStorageServiceAccountKey.secretName" .>: error calling include: template: carto/templates/_helpers.tpl:169:11: executing "carto.googleCloudStorageServiceAccountKey.secretName" at <.Values.cartoSecrets.googleCloudStorageServiceAccountKey.existingSecret.name>: nil pointer evaluating interface {}.existingSecret
```

Therefore this MR changes the variable assigned. I also updated the helper to use `.Values.appSecrets.googleCloudStorageServiceAccountKey.existingSecret.key` instead of `.Values.cartoSecrets.googleCloudStorageServiceAccountKey.existingSecret.key` so it is defined in only one place in the `customizations.yaml` file.
