### PR TITLE
Update to `1.35.4-2022.7.5-1` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2022.7.5-1 (July 05, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
+
+## 2022.7.5 (July 05, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
+
+## 2022.7.4 (July 04, 2022)
+IMPROVEMENTS
++ Support for H3 and Quadbin data sources in APIs and Builder
++ Bugs Fixing and minor improvements
+
 ## 2022.7.1 (July 01, 2022)
 IMPROVEMENTS
 + Dynamic Tilling Queries

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.16.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.12
+  version: 11.6.14
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.13.1
-digest: sha256:a4281e8b97093487bf6430617fce0a59a5017cdb14b707a043e0524cc40512e1
-generated: "2022-07-01T06:30:39.016390181Z"
+  version: 16.13.2
+digest: sha256:1d86afad705f95b54b2ffbc456354afd75fbdedaa5001cbd41c124419dac3792
+generated: "2022-07-05T10:40:11.990548476Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.7.1
+appVersion: 2022.7.5-1
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.6.28"
-version: 1.35.2
+version: 1.35.4


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/1f6c6ba19c4e829bccea6f3a999e9d70806911ff