### PR TITLE
FIX: Add misisng event bus variables

### DIFF
--- a/chart/templates/import-api/configmap.yaml
+++ b/chart/templates/import-api/configmap.yaml
@@ -21,6 +21,8 @@ data:
   IMPORT_TENANT_ID: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
   IMPORT_WORKER_PROCESSING_DIR: "/tmp/import-worker"
   LOG_LEVEL: "debug"
+  EVENT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.cartoAccGcpProjectId }}/topics/{{ .Values.cartoConfigValues.cartoAccGcpProjectRegion }}-event-bus"
+  PUBSUB_PROJECT_ID: {{ .Values.cartoConfigValues.selfHostedGcpProjectId | quote }}
   {{- if not .Values.commonBackendServiceAccount.enableGCPWorkloadIdentity }}
   GOOGLE_APPLICATION_CREDENTIALS: {{ include "carto.google.secretMountAbsolutePath" . }}
   {{- end }}

--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -20,6 +20,8 @@ data:
   IMPORT_TENANT_ID: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
   IMPORT_WORKER_PROCESSING_DIR: "/tmp/import-worker"
   LOG_LEVEL: "debug"
+  EVENT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.cartoAccGcpProjectId }}/topics/{{ .Values.cartoConfigValues.cartoAccGcpProjectRegion }}-event-bus"
+  PUBSUB_PROJECT_ID: {{ .Values.cartoConfigValues.selfHostedGcpProjectId | quote }}
   WORKSPACE_POSTGRES_DB: {{ include "carto.postgresql.databaseName" . }}
   WORKSPACE_POSTGRES_HOST: {{ include "carto.postgresql.host" . }}
   WORKSPACE_POSTGRES_PORT: {{ include "carto.postgresql.port" . }}

--- a/chart/templates/sql-worker/configmap.yaml
+++ b/chart/templates/sql-worker/configmap.yaml
@@ -19,6 +19,8 @@ data:
   GOOGLE_APPLICATION_CREDENTIALS: {{ include "carto.google.secretMountAbsolutePath" . }}
   {{- end }}
   LOG_LEVEL: "debug"
+  EVENT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.cartoAccGcpProjectId }}/topics/{{ .Values.cartoConfigValues.cartoAccGcpProjectRegion }}-event-bus"
+  PUBSUB_PROJECT_ID: {{ .Values.cartoConfigValues.selfHostedGcpProjectId | quote }}
   MAPS_API_V3_COMPONENT_NAME: "sql-worker"
   MAPS_API_V3_RESOURCE_URL_ALLOWED_HOSTS: {{ .Values.appConfigValues.selfHostedDomain | quote }}
   MAPS_API_V3_RESOURCE_URL_HOST: {{ .Values.appConfigValues.selfHostedDomain | quote }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

Issue found testing https://app.shortcut.com/cartoteam/story/219531/make-container-rootless

some services tries to publish to pub sub event bus through commons library but `EVENT_BUS_TOPIC` and `PUBSUB_PROJECT_ID` was not defined.

```json
{
   "time":"2022-07-11T10:36:39.862Z",
   "data":{
      "meta.local_hostname":"acarrera-onprem-carto-import-api-57fb56dbc8-v4p5q",
      "service_name":"import-api",
      "service.name":"import-api",
      "name":"Publish to PubSub",
      "trace.trace_id":"a2fe83c1274ac6ed8d4b92236fb493dc",
      "trace.span_id":"13ac0b25005ca1e6",
      "trace.parent_id":"50204ca18ae45b63",
      "error":true,
      "errorName":"Error",
      "errorMessage":"5 NOT_FOUND: Requested project not found or user does not have access to it (project=projectid-not-set). Make sure to specify the unique project identifier and not the Google Cloud Console display name.",
      "errorStack":"Error: 5 NOT_FOUND: Requested project not found or user does not have access to it (project=projectid-not-set). Make sure to specify the unique project identifier and not the Google Cloud Console display name.\n    at Object.callErrorFromStatus (/usr/src/commons/node_modules/@grpc/grpc-js/build/src/call.js:31:26)\n    at Object.onReceiveStatus (/usr/src/commons/node_modules/@grpc/grpc-js/build/src/client.js:179:52)\n    at Object.onReceiveStatus (/usr/src/commons/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:336:141)\n    at Object.onReceiveStatus (/usr/src/commons/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:299:181)\n    at /usr/src/commons/node_modules/@grpc/grpc-js/build/src/call-stream.js:145:78\n    at processTicksAndRejections (node:internal/process/task_queues:78:11)",
      "pubsub.topic":"topic-not-set",
      "pubsub.publishError":true,
      "duration_ms":878.790027,
      "app.user_id":"auth0|0eb1437f1c93388535710dba13e53b0b631285b2285633604fb7d810322c23d2",
      "app.account_id":"ac_jainqet8",
      "app.token.type":"auth0",
      "app.org_id":null,
      "app.acting_as":null,
      "app.github_student":null,
      "app.join_target_roles":null,
      "meta.instrumentations":[
         "child_process",
         "http",
         "https",
         "pg"
      ],
      "meta.instrumentation_count":4,
      "meta.beeline_version":"3.4.0",
      "meta.node_version":"v16.13.2",
      "meta.package_version":"ea675653d930a53f9753e11bd2ea5eb31762dfd8",
      "tenant_id":"onp-acarrera-onprem",
      "instance_id":"0468bff58694207e068d61f776ad0b55"
   }
}{
   "time":"2022-07-11T10:36:39.862Z",
   "data":{
      "meta.local_hostname":"acarrera-onprem-carto-import-api-57fb56dbc8-v4p5q",
      "service_name":"import-api",
      "service.name":"import-api",
      "name":"Publish to PubSub ",
      "trace.trace_id":"a2fe83c1274ac6ed8d4b92236fb493dc",
      "trace.span_id":"50204ca18ae45b63",
      "trace.parent_id":"a66b78ae4c80c7e0",
      "topic":"topic-not-set",
      "payload":{
         "attributes":{
            "type":"FileImportCreated",
            "tenantId":"onp-acarrera-onprem"
         },
         "timestamp":"2022-07-11T10:36:39.862Z",
         "payload":{
            "userId":"auth0|0eb1437f1c93388535710dba13e53b0b631285b2285633604fb7d810322c23d2",
            "accountId":"ac_jainqet8",
            "providerId":"bigquery",
            "connectionId":"cba3ae3e-24ba-4eb4-b4ff-399f73ed542e",
            "contentType":"application/geopackage+sqlite3",
            "sourceType":"remote"
         }
      },
      "scheduling":"rt",
      "messageId":null,
      "duration_ms":879.754617,
      "app.user_id":"auth0|0eb1437f1c93388535710dba13e53b0b631285b2285633604fb7d810322c23d2",
      "app.account_id":"ac_jainqet8",
      "app.token.type":"auth0",
      "app.org_id":null,
      "app.acting_as":null,
      "app.github_student":null,
      "app.join_target_roles":null,
      "meta.instrumentations":[
         "child_process",
         "http",
         "https",
         "pg"
      ],
      "meta.instrumentation_count":4,
      "meta.beeline_version":"3.4.0",
      "meta.node_version":"v16.13.2",
      "meta.package_version":"ea675653d930a53f9753e11bd2ea5eb31762dfd8",
      "tenant_id":"onp-acarrera-onprem",
      "instance_id":"0468bff58694207e068d61f776ad0b55"
   }
}{
   "time":"2022-07-11T10:36:53.093Z",
   "data":{
      "meta.local_hostname":"acarrera-onprem-carto-import-api-57fb56dbc8-v4p5q",
      "service_name":"import-api",
      "service.name":"import-api",
      "name":"Authenticate JWT user",
      "trace.trace_id":"d726c2a37eaa61a697b09ddc60ed6138",
      "trace.span_id":"29d0fb8a813a7596",
      "trace.parent_id":"986a4afaea1d06e5",
      "duration_ms":0.77216,
      "app.user_id":"auth0|0eb1437f1c93388535710dba13e53b0b631285b2285633604fb7d810322c23d2",
      "app.account_id":"ac_jainqet8",
      "app.token.type":"auth0",
      "app.org_id":null,
      "app.acting_as":null,
      "app.github_student":null,
      "app.join_target_roles":null,
      "meta.instrumentations":[
         "child_process",
         "http",
         "https",
         "pg"
      ],
      "meta.instrumentation_count":4,
      "meta.beeline_version":"3.4.0",
      "meta.node_version":"v16.13.2",
      "meta.package_version":"ea675653d930a53f9753e11bd2ea5eb31762dfd8",
      "tenant_id":"onp-acarrera-onprem",
      "instance_id":"0468bff58694207e068d61f776ad0b55"
   }
}
```