### PR TITLE
Update to `1.37.2-2022.7.15` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2022.7.15 (July 15, 2022)
+IMPROVEMENTS
++ New Data Explorer section
++ CARTOColors available in Builder
++ Custom HTML Popups
++ Bugs Fixing and minor improvements
+
 ## 2022.7.5-1 (July 05, 2022)
 IMPROVEMENTS
 + Bugs Fixing and minor improvements

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.0
+  version: 1.16.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.14
+  version: 11.6.16
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 16.13.2
-digest: sha256:1d86afad705f95b54b2ffbc456354afd75fbdedaa5001cbd41c124419dac3792
-generated: "2022-07-05T10:40:11.990548476Z"
+digest: sha256:d255e50efef84214d1c78da66ea223f23fb75d845645234831539be61d45274a
+generated: "2022-07-15T08:16:20.936323762Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.7.5-1
+appVersion: 2022.7.15
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.6.28"
-version: 1.35.4
+version: 1.37.2


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/14323a124b400acc4c28a82a36991d1a1c828dd3