### PR TITLE
Update to `1.38.4-2022.7.20` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2022.7.20 (July 20, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
+
 ## 2022.7.15-2 (July 15, 2022)
 IMPROVEMENTS
 + New Data Explorer section

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.16.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.16
+  version: 11.6.17
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 16.13.2
-digest: sha256:d255e50efef84214d1c78da66ea223f23fb75d845645234831539be61d45274a
-generated: "2022-07-15T11:18:47.634899783Z"
+digest: sha256:97e1ed6eb13fe4c888e264ce3bf82c5d0f8f39e5393625638bb9d868594fa4e6
+generated: "2022-07-20T13:52:38.017133798Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.7.15-2
+appVersion: 2022.7.20
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.6.28"
-version: 1.37.2
+version: 1.38.4


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/ab5ec39d60facfc71c8416fc846d343a628dcfd7