### PR TITLE
Feature/optional b64 encoding

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -27,6 +27,7 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `appConfigValues.googleCloudStorageProjectId` | If the bucket is GCP, the ProjectId to be used                                                                         | `""`                   |
 | `appConfigValues.awsS3Region`                 | If the bucket is S3, the region to be used                                                                             | `""`                   |
 | `appConfigValues.bigqueryOauth2ClientId`      | The Client ID used in BigQuery OAuth connections using Sign in with Google instead of providing a service account key. | `""`                   |
+| `appConfigValues.b64EncodeSecrets`            | Indicate if secret values should be base64 encoded.                                                                    | `true`                 |
 
 
 ### CARTO config parameters

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -41,6 +41,11 @@ If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value
 {{- end -}}
 
 {{/*
+Define b64EncodeSecrets variable from the outersope to be used in another context
+*/}}
+{{- $b64EncodeSecrets := .Values.appConfigValues.b64EncodeSecrets -}}
+
+{{/*
 Association between env secret and path of the secret in values.yaml
 */}}
 {{- define "carto._utils.secretAssociation" -}}
@@ -84,7 +89,11 @@ Generate secret file content for a variable if a existingSecret.name is not prov
 {{ get $mapSecrets $key }}({{ $key }})={{ $secretValue }}:{{ $secretExistingName }}:{{ $secretExistingKey }}:
 */}}
 {{- if not $secretExistingName }}
+{{- if $.b64EncodeSecrets }}
 {{ $var }}: {{ $secretValue | b64enc | quote }}  # {{ $key }}.value
+{{- else }}
+{{ $var }}: {{ $secretValue | quote }}  # {{ $key }}.value
+{{- end }}
 {{- end }}
 {{- end -}}
 

--- a/chart/templates/externalpostgresql-secret.yaml
+++ b/chart/templates/externalpostgresql-secret.yaml
@@ -13,6 +13,11 @@ metadata:
   {{- end }}
 type: Opaque
 data:
+{{- if .Values.appConfigValues.b64EncodeSecrets }}
   db-password: {{ .Values.externalPostgresql.password | b64enc | quote }}
   db-admin-password: {{ .Values.externalPostgresql.adminPassword | b64enc | quote }}
+{{- else }}
+  db-password: {{ .Values.externalPostgresql.password | quote }}
+  db-admin-password: {{ .Values.externalPostgresql.adminPassword | quote }}
+{{- end }}
 {{- end }}

--- a/chart/templates/externalredis-secret.yaml
+++ b/chart/templates/externalredis-secret.yaml
@@ -13,5 +13,9 @@ metadata:
   {{- end }}
 type: Opaque
 data:
+{{- if .Values.appConfigValues.b64EncodeSecrets }}
   redis-password: {{ .Values.externalRedis.password | b64enc | quote }}
+{{- else }}
+  redis-password: {{ .Values.externalRedis.password | quote }}
+{{- end }}
 {{- end }}

--- a/chart/templates/google-default-serviceaccount-secret.yaml
+++ b/chart/templates/google-default-serviceaccount-secret.yaml
@@ -13,5 +13,9 @@ metadata:
   {{- end }}
 type: Opaque
 data:
+{{- if .Values.appConfigValues.b64EncodeSecrets }}
   key.json: {{ .Values.cartoSecrets.defaultGoogleServiceAccount.value | b64enc | quote }}
+{{- else }}
+  key.json: {{ .Values.cartoSecrets.defaultGoogleServiceAccount.value | quote }}
+{{- end }}
 {{- end }}

--- a/chart/templates/google-default-serviceaccount-secret.yaml
+++ b/chart/templates/google-default-serviceaccount-secret.yaml
@@ -1,0 +1,17 @@
+{{- if not .Values.cartoSecrets.defaultGoogleServiceAccount.existingSecret.name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "carto.google.secretName" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  key.json: {{ .Values.cartoSecrets.defaultGoogleServiceAccount.value | b64enc | quote }}
+{{- end }}

--- a/chart/templates/goole-cloud-storage-serviceaccount-secret.yaml
+++ b/chart/templates/goole-cloud-storage-serviceaccount-secret.yaml
@@ -13,5 +13,9 @@ metadata:
   {{- end }}
 type: Opaque
 data:
+{{- if .Values.appConfigValues.b64EncodeSecrets }}
   key.json: {{ .Values.appSecrets.googleCloudStorageServiceAccountKey.value | b64enc | quote }}
+{{- else }}
+  key.json: {{ .Values.appSecrets.googleCloudStorageServiceAccountKey.value | quote }}
+{{- end }}
 {{- end }}

--- a/chart/templates/goole-cloud-storage-serviceaccount-secret.yaml
+++ b/chart/templates/goole-cloud-storage-serviceaccount-secret.yaml
@@ -1,22 +1,3 @@
-{{- if not .Values.cartoSecrets.defaultGoogleServiceAccount.existingSecret.name }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "carto.google.secretName" . }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
-  namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
-type: Opaque
-data:
-  key.json: {{ .Values.cartoSecrets.defaultGoogleServiceAccount.value | b64enc | quote }}
-{{- end }}
-
----
 {{- if not .Values.appSecrets.googleCloudStorageServiceAccountKey.existingSecret.name }}
 apiVersion: v1
 kind: Secret

--- a/chart/templates/tls-secret.yaml
+++ b/chart/templates/tls-secret.yaml
@@ -15,6 +15,11 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
+{{- if .Values.appConfigValues.b64EncodeSecrets }}
   {{ template "carto.tlsCerts.secretCertKey" . }}: {{ $cert_chain | b64enc | quote }}
   {{ template "carto.tlsCerts.secretKeyKey" . }}: {{ $cert.Key | b64enc | quote }}
+{{- else }}
+  {{ template "carto.tlsCerts.secretCertKey" . }}: {{ $cert_chain | quote }}
+  {{ template "carto.tlsCerts.secretKeyKey" . }}: {{ $cert.Key | quote }}
+{{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -23,6 +23,8 @@ appConfigValues:
   awsS3Region: ""
   ## @param appConfigValues.bigqueryOauth2ClientId The Client ID used in BigQuery OAuth connections using Sign in with Google instead of providing a service account key.
   bigqueryOauth2ClientId: ""
+  ## @param appConfigValues.b64EncodeSecrets Indicate if secret values should be base64 encoded.
+  b64EncodeSecrets: true
 
 ## @section CARTO config parameters
 ## Global configuration provided by CARTO. If you changed something from this section probably your self-hosted is going to stop working.


### PR DESCRIPTION
**Adds a flag to toggle b64 decoding of secrets**

I have added an option to set a field `.Values.appConfigValues.b64EncodeSecrets`

It defaults to `"false"` and therefore will default to the current behavior. 

**Benefits**

Ability to leave the secret string as they are inputted, then placeholders can be used, and further template-ing can happen downstream. This is good for our use-case that we want to separate the prod and staging environments.

**Possible drawbacks**

None

**Applicable issues**

**Additional information**

I also split a composite secret.yaml into two individual files, this is because I would like all the outputted manifests to be single files. This is to easily validate them with available tools and  fits with our internal tool for deploying (expects 1 yaml per file)