### PR TITLE
fix commonBackendServiceAccount create condition

### DIFF
--- a/chart/templates/carto-common-service-account.yaml
+++ b/chart/templates/carto-common-service-account.yaml
@@ -1,3 +1,4 @@
+{{- if Values.commonBackendServiceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,3 +15,4 @@ metadata:
     {{- end }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonBackendServiceAccount.annotations "context" $ ) | nindent 4 }}
 automountServiceAccountToken: {{ .Values.commonBackendServiceAccount.automountServiceAccountToken }}
+{{- end}}

--- a/chart/templates/carto-common-service-account.yaml
+++ b/chart/templates/carto-common-service-account.yaml
@@ -1,4 +1,4 @@
-{{- if Values.commonBackendServiceAccount.create }}
+{{- if .Values.commonBackendServiceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/doc/gke/gke-workload-identity.md
+++ b/doc/gke/gke-workload-identity.md
@@ -56,6 +56,8 @@ The process of configuring Workload Identity includes using an IAM policy bindin
       iam.gke.io/gcp-service-account: "<IAM_SERVICE_ACCOUNT_EMAIL>"
   ```
 
+> :warning: The chart gives the possibility of disable commonBackendServiceAccount account creation with `commonBackendServiceAccount.create: false` but this is not compatible with  `enableGCPWorkloadIdentity: true`
+
 - Install Carto Self Hosted Helm Chart, please see the [installations steps](../../README.md#installation-steps)
 
 - Then, allow the Kubernetes service account that is going to be created in your GKE cluster to impersonate the IAM service account by adding an IAM policy binding between the two service accounts. This binding allows the Kubernetes service account to act as the IAM service account.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

The value `commonBackendServiceAccount.create` is not mapped with the related resource. There is a conflict If we disable commonBackendServiceAccount creation  and we want to use enableGCPWorkloadIdentity. We have added a warning in the documentation

**Benefits**

Users can deactivate the creation of k8s service account
**Possible drawbacks**

Workload identity will not work if commonBackendServiceAccount.create is false


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->