### PR TITLE
Update to `1.39.1-2022.8.1` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2022.8.1 (August 01, 2022)
+IMPROVEMENTS
++ New Range widget in Builder
++ Renaming of data sources in Builder
++ Maps API support for parameterized queries
++ Import API support for GeoParquet files
++ Bugs Fixing and minor improvements
+
 ## 2022.7.20 (July 20, 2022)
 IMPROVEMENTS
 + Bugs Fixing and minor improvements

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.16.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.17
+  version: 11.6.20
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 16.13.2
-digest: sha256:97e1ed6eb13fe4c888e264ce3bf82c5d0f8f39e5393625638bb9d868594fa4e6
-generated: "2022-07-20T13:52:38.017133798Z"
+digest: sha256:c4b81154944cddff8f98db49736959dbda42ba6275394827466535ac410e6e70
+generated: "2022-08-01T08:21:01.204768653Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.7.20
+appVersion: 2022.8.1
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.6.28"
-version: 1.38.4
+version: 1.39.1


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/d5eda43e7b930dd127e81b4049a954ac7e43453a