### PR TITLE
breaking change: Add thumbnailsBucketExternalURL var to www configs

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -23,6 +23,7 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `appConfigValues.workspaceImportsBucket`      | Bucket to be used to store metadata of the workspace                                                                   | `""`                   |
 | `appConfigValues.workspaceImportsPublic`      | Indicate if the imports could be accessed publicly                                                                     | `true`                 |
 | `appConfigValues.workspaceThumbnailsBucket`   | Bucket to be used to store the thumbnails generated in the app                                                         | `""`                   |
+| `appConfigValues.thumbnailsBucketExternalURL` | Bucket URL to be used to store the thumbnails generated in the app                                                     | `""`                   |
 | `appConfigValues.workspaceThumbnailsPublic`   | Indicate if the thumbnails could be accessed publicly                                                                  | `true`                 |
 | `appConfigValues.googleCloudStorageProjectId` | If the bucket is GCP, the ProjectId to be used                                                                         | `""`                   |
 | `appConfigValues.awsS3Region`                 | If the bucket is S3, the region to be used                                                                             | `""`                   |

--- a/chart/templates/accounts-www/configmap.yaml
+++ b/chart/templates/accounts-www/configmap.yaml
@@ -20,4 +20,5 @@ data:
   REACT_APP_CLIENT_ID: {{ .Values.cartoConfigValues.cartoAuth0ClientId | quote }}
   REACT_APP_CUSTOM_TENANT: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
   REACT_APP_WORKSPACE_URL_TEMPLATE: "https://{tenantDomain}"
+  WORKSPACE_THUMBNAILS_BUCKET: {{ .Values.appConfigValues.workspaceThumbnailsBucket | quote }}
 {{- end }}

--- a/chart/templates/accounts-www/configmap.yaml
+++ b/chart/templates/accounts-www/configmap.yaml
@@ -20,5 +20,5 @@ data:
   REACT_APP_CLIENT_ID: {{ .Values.cartoConfigValues.cartoAuth0ClientId | quote }}
   REACT_APP_CUSTOM_TENANT: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
   REACT_APP_WORKSPACE_URL_TEMPLATE: "https://{tenantDomain}"
-  WORKSPACE_THUMBNAILS_BUCKET: {{ .Values.appConfigValues.workspaceThumbnailsBucket | quote }}
+  THUMBNAILS_BUCKET_EXTERNAL_URL: {{ .Values.appConfigValues.thumbnailsBucketExternalURL | quote }}
 {{- end }}

--- a/chart/templates/workspace-www/configmap.yaml
+++ b/chart/templates/workspace-www/configmap.yaml
@@ -30,4 +30,5 @@ data:
   REACT_APP_PUBLIC_MAP_URL: "https://{{ .Values.appConfigValues.selfHostedDomain }}/api/v3/maps/public"
   REACT_APP_WORKSPACE_API_URL: "https://{{ .Values.appConfigValues.selfHostedDomain }}/workspace-api"
   REACT_APP_WORKSPACE_URL_TEMPLATE: "https://{tenantDomain}"
+  WORKSPACE_THUMBNAILS_BUCKET: {{ .Values.appConfigValues.workspaceThumbnailsBucket | quote }}
 {{- end }}

--- a/chart/templates/workspace-www/configmap.yaml
+++ b/chart/templates/workspace-www/configmap.yaml
@@ -30,5 +30,5 @@ data:
   REACT_APP_PUBLIC_MAP_URL: "https://{{ .Values.appConfigValues.selfHostedDomain }}/api/v3/maps/public"
   REACT_APP_WORKSPACE_API_URL: "https://{{ .Values.appConfigValues.selfHostedDomain }}/workspace-api"
   REACT_APP_WORKSPACE_URL_TEMPLATE: "https://{tenantDomain}"
-  WORKSPACE_THUMBNAILS_BUCKET: {{ .Values.appConfigValues.workspaceThumbnailsBucket | quote }}
+  THUMBNAILS_BUCKET_EXTERNAL_URL: {{ .Values.appConfigValues.thumbnailsBucketExternalURL | quote }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -271,7 +271,7 @@ accountsWww:
     registry: gcr.io/carto-onprem-artifacts
     repository: accounts-www
     ## Specify a custom image tag
-    tag: "sc_246962_csp_custom_markers_new"
+    tag: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -3421,7 +3421,7 @@ workspaceWww:
     registry: gcr.io/carto-onprem-artifacts
     repository: workspace-www
     ## Specify a custom image tag
-    tag: "sc_246962_csp_custom_markers_new"
+    tag: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,6 +15,8 @@ appConfigValues:
   workspaceImportsPublic: "true"
   ## @param appConfigValues.workspaceThumbnailsBucket Bucket to be used to store the thumbnails generated in the app
   workspaceThumbnailsBucket: ""
+  ## @param appConfigValues.thumbnailsBucketExternalURL Bucket URL to be used to store the thumbnails generated in the app
+  thumbnailsBucketExternalURL: ""
   ## @param appConfigValues.workspaceThumbnailsPublic Indicate if the thumbnails could be accessed publicly
   workspaceThumbnailsPublic: "true"
   ## @param appConfigValues.googleCloudStorageProjectId If the bucket is GCP, the ProjectId to be used

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -271,7 +271,7 @@ accountsWww:
     registry: gcr.io/carto-onprem-artifacts
     repository: accounts-www
     ## Specify a custom image tag
-    tag: ""
+    tag: "sc_246962_csp_custom_markers_new"
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -3421,7 +3421,7 @@ workspaceWww:
     registry: gcr.io/carto-onprem-artifacts
     repository: workspace-www
     ## Specify a custom image tag
-    tag: ""
+    tag: "sc_246962_csp_custom_markers_new"
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/customizations/README.md
+++ b/customizations/README.md
@@ -635,7 +635,7 @@ externalRedis:
 
 ### Custom Buckets
 
-For every CARTO Self Hosted installation, we create GCS buckets in our side as part of the required infrastructure for importing data, map thumbnails and other internal data.
+For every CARTO Self Hosted installation, we create GCS buckets in our side as part of the required infrastructure for importing data, map thumbnails, custom markers and other internal data.
 
 You can create and use your own storage buckets in any of the following supported storage providers:
 
@@ -696,8 +696,11 @@ In order to use Google Cloud Storage custom buckets you need to:
      workspaceImportsPublic: <false|true>
      workspaceThumbnailsBucket: <thumbnails_bucket_name>
      workspaceThumbnailsPublic: <false|true>
+     thumbnailsBucketExternalURL: <public or authenticated external bucket URL>
      googleCloudStorageProjectId: <gcp_project_id>
    ```
+
+   > Note that thumbnailsBucketExternalURL could be https://storage.googleapis.com/<thumbnails_bucket_name>/ for public access or https://storage.cloud.google.com/<thumbnails_bucket_name>/ for authenticated access.
 
 4. Select a **Service Account** that will be used by the application to interact with the buckets. There are three options:
 
@@ -767,8 +770,11 @@ appConfigValues:
   workspaceImportsPublic: <false|true>
   workspaceThumbnailsBucket: <thumbnails_bucket_name>
   workspaceThumbnailsPublic: <false|true>
+  thumbnailsBucketExternalURL: <external bucket URL>
   awsS3Region: <s3_buckets_region>
 ```
+
+> Note that thumbnailsBucketExternalURL should be https://<thumbnails_bucket_name>.s3.amazonaws.com/
 
 6. Pass your AWS credentials as secrets by using one of the options below:
 
@@ -837,8 +843,10 @@ appConfigValues:
   workspaceImportsBucket: <client_bucket_name>
   workspaceImportsPublic: <false|true>
   workspaceThumbnailsBucket: <thumbnails_bucket_name>
+  thumbnailsBucketExternalURL: <external bucket URL>
   workspaceThumbnailsPublic: <false|true>
 ```
+  > Note that thumbnailsBucketExternalURL should be https://<azure_resource_group>.blob.core.windows.net/<thumbnails_bucket_name>/
 
 6. Pass your credentials as secrets by using one of the options below:
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

- Add WORKSPACE_THUMBNAILS_BUCKET env var to www config maps
- Relates to https://github.com/CartoDB/cloud-native/pull/8781

**Benefits**

- We need this env var to generate dynamically the csp and nginx configs

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->