### PR TITLE
Remove duplicate PUBSUB_PROJECT_ID key from sql-worker cm

### DIFF
--- a/chart/templates/sql-worker/configmap.yaml
+++ b/chart/templates/sql-worker/configmap.yaml
@@ -20,7 +20,6 @@ data:
   {{- end }}
   LOG_LEVEL: "debug"
   EVENT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.cartoAccGcpProjectId }}/topics/{{ .Values.cartoConfigValues.cartoAccGcpProjectRegion }}-event-bus"
-  PUBSUB_PROJECT_ID: {{ .Values.cartoConfigValues.selfHostedGcpProjectId | quote }}
   MAPS_API_V3_COMPONENT_NAME: "sql-worker"
   MAPS_API_V3_RESOURCE_URL_ALLOWED_HOSTS: {{ .Values.appConfigValues.selfHostedDomain | quote }}
   MAPS_API_V3_RESOURCE_URL_HOST: {{ .Values.appConfigValues.selfHostedDomain | quote }}


### PR DESCRIPTION
**Description of the change**

Fix duplicate key error.

**Benefits**

Fixing the broken.

**Possible drawbacks**

None.