### PR TITLE
Update to `1.39.13-2022.8.10` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2022.8.10 (August 10, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
+
+## 2022.8.9 (August 09, 2022)
+IMPROVEMENTS
++ Bugs Fixing and minor improvements
+
 ## 2022.8.1 (August 01, 2022)
 IMPROVEMENTS
 + New Range widget in Builder

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.16.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.20
+  version: 11.6.26
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 16.13.2
-digest: sha256:c4b81154944cddff8f98db49736959dbda42ba6275394827466535ac410e6e70
-generated: "2022-08-01T08:21:01.204768653Z"
+digest: sha256:33f59c0530aea8ba95d0657d6880b1e8fca85a4f2b0887f37574a5f8cd5955a7
+generated: "2022-08-10T15:30:54.66906465Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.8.1
+appVersion: 2022.8.10
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.6.28"
-version: 1.39.1
+version: 1.39.13


### PR DESCRIPTION
Commit(s) from:
                 - https://github.com/CartoDB/cloud-native/commit/4a43913282a575b8ebac788be10d449c43788b88