### PR TITLE
Add TLS offloading on AWS LB

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -701,7 +701,9 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | `router.service.type`                     | router service type                                                                                                              | `ClusterIP`              |
 | `router.service.ports.http`               | router service HTTP port                                                                                                         | `80`                     |
+| `router.service.ports.httpTargetPort`     | router service HTTP Target port                                                                                                  | `http`                   |
 | `router.service.ports.https`              | router service HTTPS port                                                                                                        | `443`                    |
+| `router.service.ports.httpsTargetPort`    | router service HTTPS Target port                                                                                                 | `https`                  |
 | `router.service.nodePorts.http`           | Node.js port for HTTP                                                                                                            | `""`                     |
 | `router.service.nodePorts.https`          | Node.js port for HTTPS                                                                                                           | `""`                     |
 | `router.service.clusterIP`                | router service Cluster IP                                                                                                        | `""`                     |

--- a/chart/templates/router/service.yaml
+++ b/chart/templates/router/service.yaml
@@ -31,7 +31,7 @@ spec:
   {{- end }}
   ports:
     - port: {{ .Values.router.service.ports.http }}
-      targetPort: http
+      targetPort: {{ .Values.router.service.ports.httpTargetPort }}
       protocol: TCP
       name: http
       {{- if and (or (eq .Values.router.service.type "NodePort") (eq .Values.router.service.type "LoadBalancer")) .Values.router.service.nodePorts.http }}
@@ -40,7 +40,7 @@ spec:
       nodePort: null
       {{- end }}
     - port: {{ .Values.router.service.ports.https }}
-      targetPort: https
+      targetPort: {{ .Values.router.service.ports.httpsTargetPort }}
       protocol: TCP
       name: https
       {{- if and (or (eq .Values.router.service.type "NodePort") (eq .Values.router.service.type "LoadBalancer")) .Values.router.service.nodePorts.https }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2178,11 +2178,16 @@ router:
     ##
     type: ClusterIP
     ## @param router.service.ports.http router service HTTP port
+    ## @param router.service.ports.httpTargetPort router service HTTP Target port
     ## @param router.service.ports.https router service HTTPS port
+    ## @param router.service.ports.httpsTargetPort router service HTTPS Target port
     ##
     ports:
       http: 80
+      httpTargetPort: "http"
       https: 443
+      httpsTargetPort: "https"
+
     ## Node.js ports to expose
     ## @param router.service.nodePorts.http Node.js port for HTTP
     ## @param router.service.nodePorts.https Node.js port for HTTPS

--- a/customizations/README.md
+++ b/customizations/README.md
@@ -124,7 +124,7 @@ But this only makes it accessible to your machine.
 
 **Requirements when exposing the service:**
 
-- CARTO only works with HTTPS. TLS termination can be done in the CARTO application level (Router service), or in a load balancer that gets the request before sending it back to the application.
+- CARTO only works with HTTPS. TLS termination can be done in the CARTO application level (Router component), or in a load balancer that gets the request before sending it back to the application.
 - The connection timeout of all incoming connections must be at least `605` seconds.
 - Configure a domain pointing to the exposed service.
 
@@ -155,6 +155,7 @@ But this only makes it accessible to your machine.
 You can find an example [here](service_loadBalancer/config.yaml). Also, we have prepared a few specifics for different Kubernetes flavors, just add the config that you need in your `customizations.yaml`:
 
 - [AWS EKS](service_loadBalancer/aws_eks/config.yaml)
+- [AWS EKS](service_loadBalancer/aws_eks_tls_offloading/config.yaml) Note you need to [import your certificate in AWS ACM](https://docs.aws.amazon.com/acm/latest/userguide/import-certificate.html)
 - [GCP GKE](service_loadBalancer/config.yaml)
 - [AZU AKS](service_loadBalancer/azu_aks/config.yaml)
 

--- a/customizations/service_loadBalancer/aws_eks_tls_offloading/config.yaml
+++ b/customizations/service_loadBalancer/aws_eks_tls_offloading/config.yaml
@@ -1,0 +1,21 @@
+tlsCerts:
+  httpsEnabled: false # So the router talks in http
+router:
+  service:
+    type: LoadBalancer
+    annotations:
+     # Note that the backend (router) talks over HTTP.
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+
+      ############ IMPORT YOUR CERTIFICATE ###############
+      # Store your own certificate in AWS ACM with
+      # $ aws acm import-certificate --certificate fileb://tls.crt --private-key fileb://tls.key --certificate-chain fileb://chain.crt
+      # DOCUMENTATION https://docs.aws.amazon.com/acm/latest/userguide/import-certificate.html
+      ####################################################
+
+      # Fill in with the ARN of your certificate.
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:<REGION>:<AWS_ACCOUNTS>:certificate/<CERTIFICATE_ID>
+      # Only run SSL on the port named "https" below.
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
+      # change Connection idle timeout ot 605
+      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "605"

--- a/customizations/service_loadBalancer/aws_eks_tls_offloading/config.yaml
+++ b/customizations/service_loadBalancer/aws_eks_tls_offloading/config.yaml
@@ -19,3 +19,6 @@ router:
       service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
       # change Connection idle timeout ot 605
       service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "605"
+  ports:
+    httpsTargetPort: http
+


### PR DESCRIPTION
**Description of the change**

Modified service template and values.yaml to mek configurable the target por for tls offloading cases.
Add an example config for TLS Offloading with AWS ELBs (network load balancing) using ACM certificates



<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Now uses have a template to configure external connection with EKS + TLS Offloadings without ingress, just with a network load balancer

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

You need to upload your certificate (or generate one ) in AWS ACM 
 https://docs.aws.amazon.com/acm/latest/userguide/import-certificate.html

AWS ELB gives you an dns domain name that need to be configured as CNAME of yourt SH domain.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->