### PR TITLE
Update to `1.43.3-2022.11.15` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 2022.11.8 (November 08, 2022)
+IMPROVEMENTS
++ Stability fixes
++ Critical security fixes (SQL injection)
++ Category aggregation for Spatial Indexes layers
++ Aggregation resolution selector for Spatial Indexes layers
++ Bugs Fixing and minor improvements
++ Show LDS quota consumption
++ Postgres connection stability fixes
++ Map collaboration on builder (added new component (notifier))
++ Show owner's email in Map & Connection cards
++ Google basemaps improvements
+
+FIXES
++ Fix dynamic tiling and columns with lower case letters in Snowflake 
+
 ## 2022.10.18 (October 18, 2022)
 IMPROVEMENTS
 + New and improved login and signup
@@ -11,12 +27,9 @@ IMPROVEMENTS
 + Updated base Docker images with security fixes
 + Use a connection pool for Postgres
 + K8: TLS offload in AWS LoadBalancer
++ K8: Increase min instances of workspace-api and maps-api
 + Create tileset options: Spatial Index and aggragations
-+ Stability fixes
 + Other bugs fixes and minor improvements
-
-CHANGES
-+ K8: Increase min instances of workspace-api, maps-api and import-api to two
 
 ## 2022.9.2 (September 02, 2022)
 IMPROVEMENTS

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.17.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.9.10
+  version: 11.9.13
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 16.13.2
-digest: sha256:317d8491c22be03700168607b5a18c04e86f85191e5d856aaaef22e1c2b146a4
-generated: "2022-10-18T15:23:38.26245418Z"
+digest: sha256:84aee0e8646953162685396ac350cb02c9805f3324b0bb794dc13c8ac5cd8553
+generated: "2022-11-29T10:32:56.884290145Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2022.10.18
+appVersion: 2022.11.15
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2022.8.19-1"
-version: 1.42.27
+version: 1.43.3


### PR DESCRIPTION
https://github.com/CartoDB/cloud-native/commit/0e413cbd31c3d5ec9a7f6f5461086e5766a6cdea