### PR TITLE
add missing variables to maps-api

### DIFF
--- a/chart/templates/maps-api/configmap.yaml
+++ b/chart/templates/maps-api/configmap.yaml
@@ -15,6 +15,7 @@ data:
   AUTH0_AUDIENCE: "carto-cloud-native-api"
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
+  BIGQUERY_OAUTH2_CLIENT_ID: {{ .Values.appConfigValues.bigqueryOauth2ClientId | quote }}
   EVENT_BUS_PROJECT_ID: {{ .Values.cartoConfigValues.cartoAccGcpProjectId | quote }}
   EVENT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.cartoAccGcpProjectId }}/topics/{{ .Values.cartoConfigValues.cartoAccGcpProjectRegion }}-event-bus"
   {{- if not .Values.commonBackendServiceAccount.enableGCPWorkloadIdentity }}

--- a/chart/templates/maps-api/deployment.yaml
+++ b/chart/templates/maps-api/deployment.yaml
@@ -111,6 +111,7 @@ spec:
                   name: {{ include "carto.redis.secretName" . }}
                   key: {{ include "carto.redis.existingsecret.key" . | quote }}
             {{- include "carto._utils.generateSecretDefs" (dict "vars" (list
+             "BIGQUERY_OAUTH2_CLIENT_SECRET"
              "ENCRYPTION_SECRET_KEY"
              "MAPS_API_V3_JWT_SECRET"
              ) "context" $ ) | nindent 12 }}
@@ -121,6 +122,7 @@ spec:
             - configMapRef:
                 name: {{ template "carto.mapsApi.configmapName" . }}
             {{- $secretContent := include "carto._utils.generateSecretObjects" (dict "vars" (list
+             "BIGQUERY_OAUTH2_CLIENT_SECRET"
              "ENCRYPTION_SECRET_KEY"
              "MAPS_API_V3_JWT_SECRET"
              ) "context" $ ) -}}

--- a/chart/templates/maps-api/secret.yaml
+++ b/chart/templates/maps-api/secret.yaml
@@ -1,4 +1,5 @@
 {{ $secretContent := include "carto._utils.generateSecretObjects" (dict "vars" (list
+  "BIGQUERY_OAUTH2_CLIENT_SECRET"
   "ENCRYPTION_SECRET_KEY"
   "MAPS_API_V3_JWT_SECRET"
  ) "context" $ )}}


### PR DESCRIPTION
- The BQ Oauth connection client id and secret need to be propagated to maps-api component