### PR TITLE
Add support for an external proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 **/*carto-secrets.yaml*
 **/*carto-values.yaml*
 **/customer.env
-**/*customization*.yaml*
+**/*customization.yaml*

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 **/*carto-secrets.yaml*
 **/*carto-values.yaml*
 **/customer.env
-**/*customization.yaml*
+**/*customization*.yaml*

--- a/chart/README.md
+++ b/chart/README.md
@@ -1409,12 +1409,13 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | Name                                  | Description                                                                              | Value   |
 | ------------------------------------- | ---------------------------------------------------------------------------------------- | ------- |
 | `externalProxy.enabled`               | Whether the APIs will use an external proxy or not                                       | `false` |
-| `externalProxy.host`                  | Proxy host                                                                               | `nil`   |
-| `externalProxy.port`                  | Proxy port                                                                               | `nil`   |
+| `externalProxy.host`                  | Proxy host                                                                               | `""`    |
+| `externalProxy.port`                  | Proxy port                                                                               | `""`    |
 | `externalProxy.type`                  | Proxy type. Only HTTP and HTTPS proxies are supported                                    | `""`    |
 | `externalProxy.username`              | Proxy username (if required)                                                             | `nil`   |
 | `externalProxy.password`              | Proxy password (if required)                                                             | `nil`   |
-| `externalProxy.sslRejectUnauthorized` | Wheter or not verify the HTTPS proxy SSL certificate                                     | `true`  |
+| `externalProxy.excludedDomains`       | List of domains that will bypass the proxy                                               | `[]`    |
+| `externalProxy.sslRejectUnauthorized` | Whether or not verify the HTTPS proxy SSL certificate                                    | `true`  |
 | `externalProxy.sslCA`                 | CA for the proxy SSL certificate in case is self-signed or signed by a not well-known CA | `""`    |
 
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -204,6 +204,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `accountsWww.containerSecurityContext.runAsUser`         | Set accounts-www containers' Security Context runAsUser                                                                      | `101`                           |
 | `accountsWww.containerSecurityContext.runAsNonRoot`      | Set accounts-www containers' Security Context runAsNonRoot                                                                   | `false`                         |
 | `accountsWww.containerSecurityContext.capabilities.drop` | removes accounts-www containers' Security Context capabilities                                                               | `["all"]`                       |
+| `accountsWww.podDisruptionBudget.enabled`                | defines disruption budget for accounts-www                                                                                   | `false`                         |
+| `accountsWww.terminationGracePeriodSeconds`              | Time to wait before force killing the container                                                                              | `60`                            |
 | `accountsWww.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for accounts-www                                            | `""`                            |
 | `accountsWww.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for accounts-www                                            | `""`                            |
 | `accountsWww.command`                                    | Override default container command (useful when using custom images)                                                         | `[]`                            |
@@ -305,6 +307,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `importApi.containerSecurityContext.runAsUser`         | Set import-api containers' Security Context runAsUser                                                                             | `1000`                          |
 | `importApi.containerSecurityContext.runAsNonRoot`      | Set import-api containers' Security Context runAsNonRoot                                                                          | `false`                         |
 | `importApi.containerSecurityContext.capabilities.drop` | removes import-api containers' Security Context capabilities                                                                      | `["all"]`                       |
+| `importApi.podDisruptionBudget.enabled`                | defines disruption budget for import-api                                                                                          | `false`                         |
+| `importApi.terminationGracePeriodSeconds`              | Time to wait before force killing the container                                                                                   | `300`                           |
 | `importApi.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for import-api                                                   | `""`                            |
 | `importApi.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for import-api                                                   | `""`                            |
 | `importApi.command`                                    | Override default container command (useful when using custom images)                                                              | `[]`                            |
@@ -374,6 +378,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `importWorker.containerSecurityContext.runAsUser`         | Set import-worker containers' Security Context runAsUser                                                                          | `1000`                          |
 | `importWorker.containerSecurityContext.runAsNonRoot`      | Set import-worker containers' Security Context runAsNonRoot                                                                       | `false`                         |
 | `importWorker.containerSecurityContext.capabilities.drop` | removes import-worker containers' Security Context capabilities                                                                   | `["all"]`                       |
+| `importWorker.podDisruptionBudget.enabled`                | defines disruption budget for import-worker                                                                                       | `false`                         |
+| `importWorker.terminationGracePeriodSeconds`              | Time to wait before force killing the container                                                                                   | `3600`                          |
 | `importWorker.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for import-worker                                                | `""`                            |
 | `importWorker.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for import-worker                                                | `""`                            |
 | `importWorker.command`                                    | Override default container command (useful when using custom images)                                                              | `[]`                            |
@@ -450,6 +456,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `ldsApi.containerSecurityContext.runAsUser`         | Set lds-api containers' Security Context runAsUser                                                                                | `1000`                          |
 | `ldsApi.containerSecurityContext.runAsNonRoot`      | Set lds-api containers' Security Context runAsNonRoot                                                                             | `false`                         |
 | `ldsApi.containerSecurityContext.capabilities.drop` | removes lds-api containers' Security Context capabilities                                                                         | `["all"]`                       |
+| `ldsApi.podDisruptionBudget.enabled`                | defines disruption budget for lds-api                                                                                             | `false`                         |
+| `ldsApi.terminationGracePeriodSeconds`              | Time to wait before force killing the container                                                                                   | `60`                            |
 | `ldsApi.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for lds-api                                                      | `""`                            |
 | `ldsApi.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for lds-api                                                      | `""`                            |
 | `ldsApi.command`                                    | Override default container command (useful when using custom images)                                                              | `[]`                            |
@@ -542,6 +550,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `mapsApi.containerSecurityContext.runAsUser`         | Set maps-api containers' Security Context runAsUser                                                                               | `1000`                          |
 | `mapsApi.containerSecurityContext.runAsNonRoot`      | Set maps-api containers' Security Context runAsNonRoot                                                                            | `false`                         |
 | `mapsApi.containerSecurityContext.capabilities.drop` | removes maps-api containers' Security Context capabilities                                                                        | `["all"]`                       |
+| `mapsApi.podDisruptionBudget.enabled`                | defines disruption budget for maps-api                                                                                            | `false`                         |
+| `mapsApi.terminationGracePeriodSeconds`              | Time to wait before force killing the container                                                                                   | `600`                           |
 | `mapsApi.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for maps-api                                                     | `""`                            |
 | `mapsApi.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for maps-api                                                     | `""`                            |
 | `mapsApi.command`                                    | Override default container command (useful when using custom images)                                                              | `[]`                            |
@@ -626,6 +636,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `sqlWorker.containerSecurityContext.runAsUser`         | Set sql-worker containers' Security Context runAsUser                                                                             | `1000`                          |
 | `sqlWorker.containerSecurityContext.runAsNonRoot`      | Set sql-worker containers' Security Context runAsNonRoot                                                                          | `false`                         |
 | `sqlWorker.containerSecurityContext.capabilities.drop` | removes sql-worker containers' Security Context capabilities                                                                      | `["all"]`                       |
+| `sqlWorker.podDisruptionBudget.enabled`                | defines disruption budget for sql-worker                                                                                          | `false`                         |
+| `sqlWorker.terminationGracePeriodSeconds`              | Time to wait before force killing the container                                                                                   | `300`                           |
 | `sqlWorker.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for sql-worker                                                   | `""`                            |
 | `sqlWorker.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for sql-worker                                                   | `""`                            |
 | `sqlWorker.command`                                    | Override default container command (useful when using custom images)                                                              | `[]`                            |
@@ -701,6 +713,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `router.containerSecurityContext.runAsUser`         | Set router containers' Security Context runAsUser                                                                      | `101`                           |
 | `router.containerSecurityContext.runAsNonRoot`      | Set router containers' Security Context runAsNonRoot                                                                   | `false`                         |
 | `router.containerSecurityContext.capabilities.drop` | removes router containers' Security Context capabilities                                                               | `["all"]`                       |
+| `router.podDisruptionBudget.enabled`                | defines disruption budget for router                                                                                   | `false`                         |
+| `router.terminationGracePeriodSeconds`              | Time to wait before force killing the container                                                                        | `600`                           |
 | `router.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for router                                            | `""`                            |
 | `router.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for router                                            | `""`                            |
 | `router.command`                                    | Override default container command (useful when using custom images)                                                   | `[]`                            |
@@ -811,6 +825,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `httpCache.containerSecurityContext.runAsUser`         | Set http-cache containers' Security Context runAsUser                                                                      | `101`                           |
 | `httpCache.containerSecurityContext.runAsNonRoot`      | Set http-cache containers' Security Context runAsNonRoot                                                                   | `false`                         |
 | `httpCache.containerSecurityContext.capabilities.drop` | removes http-cache containers' Security Context capabilities                                                               | `["all"]`                       |
+| `httpCache.podDisruptionBudget.enabled`                | defines disruption budget for http-cache                                                                                   | `false`                         |
+| `httpCache.terminationGracePeriodSeconds`              | Time to wait before force killing the container                                                                            | `600`                           |
 | `httpCache.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for http-cache                                            | `""`                            |
 | `httpCache.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for http-cache                                            | `""`                            |
 | `httpCache.command`                                    | Override default container command (useful when using custom images)                                                       | `[]`                            |
@@ -905,6 +921,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `notifier.containerSecurityContext.runAsUser`         | Set notifier containers' Security Context runAsUser                                                                      | `101`                           |
 | `notifier.containerSecurityContext.runAsNonRoot`      | Set notifier containers' Security Context runAsNonRoot                                                                   | `false`                         |
 | `notifier.containerSecurityContext.capabilities.drop` | removes notifier containers' Security Context capabilities                                                               | `["all"]`                       |
+| `notifier.podDisruptionBudget.enabled`                | defines disruption budget for notifier                                                                                   | `false`                         |
+| `notifier.terminationGracePeriodSeconds`              | Time to wait before force killing the container                                                                          | `60`                            |
 | `notifier.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for notifier                                            | `""`                            |
 | `notifier.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for notifier                                            | `""`                            |
 | `notifier.command`                                    | Override default container command (useful when using custom images)                                                     | `[]`                            |
@@ -1004,6 +1022,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `cdnInvalidatorSub.containerSecurityContext.runAsUser`         | Set cdnInvalidatorSub containers' Security Context runAsUser                                                                      | `1000`                          |
 | `cdnInvalidatorSub.containerSecurityContext.runAsNonRoot`      | Set cdnInvalidatorSub containers' Security Context runAsNonRoot                                                                   | `false`                         |
 | `cdnInvalidatorSub.containerSecurityContext.capabilities.drop` | removes cdnInvalidatorSub containers' Security Context capabilities                                                               | `["all"]`                       |
+| `cdnInvalidatorSub.podDisruptionBudget.enabled`                | defines disruption budget for cdn-invalidator-sub                                                                                 | `false`                         |
+| `cdnInvalidatorSub.terminationGracePeriodSeconds`              | Time to wait before force killing the container                                                                                   | `300`                           |
 | `cdnInvalidatorSub.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for cdnInvalidatorSub                                            | `""`                            |
 | `cdnInvalidatorSub.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for cdnInvalidatorSub                                            | `""`                            |
 | `cdnInvalidatorSub.command`                                    | Override default container command (useful when using custom images)                                                              | `[]`                            |
@@ -1097,6 +1117,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `workspaceApi.containerSecurityContext.runAsUser`         | Set workspace-api containers' Security Context runAsUser                                                                          | `1000`                          |
 | `workspaceApi.containerSecurityContext.runAsNonRoot`      | Set workspace-api containers' Security Context runAsNonRoot                                                                       | `false`                         |
 | `workspaceApi.containerSecurityContext.capabilities.drop` | removes workspace-api containers' Security Context capabilities                                                                   | `["all"]`                       |
+| `workspaceApi.podDisruptionBudget.enabled`                | defines disruption budget for workspace-api                                                                                       | `false`                         |
+| `workspaceApi.terminationGracePeriodSeconds`              | Time to wait before force killing the container                                                                                   | `300`                           |
 | `workspaceApi.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for workspace-api                                                | `""`                            |
 | `workspaceApi.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for workspace-api                                                | `""`                            |
 | `workspaceApi.command`                                    | Override default container command (useful when using custom images)                                                              | `[]`                            |
@@ -1166,6 +1188,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `workspaceSubscriber.containerSecurityContext.runAsUser`         | Set workspace-subscriber containers' Security Context runAsUser                                                                      | `1000`                          |
 | `workspaceSubscriber.containerSecurityContext.runAsNonRoot`      | Set workspace-subscriber containers' Security Context runAsNonRoot                                                                   | `false`                         |
 | `workspaceSubscriber.containerSecurityContext.capabilities.drop` | removes workspace-subscriber containers' Security Context capabilities                                                               | `["all"]`                       |
+| `workspaceSubscriber.podDisruptionBudget.enabled`                | defines disruption budget for workspace-subscriber                                                                                   | `false`                         |
+| `workspaceSubscriber.terminationGracePeriodSeconds`              | Time to wait before force killing the container                                                                                      | `300`                           |
 | `workspaceSubscriber.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for workspace-subscriber                                            | `""`                            |
 | `workspaceSubscriber.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for workspace-subscriber                                            | `""`                            |
 | `workspaceSubscriber.command`                                    | Override default container command (useful when using custom images)                                                                 | `[]`                            |
@@ -1240,6 +1264,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `workspaceWww.containerSecurityContext.runAsUser`         | Set workspace-www containers' Security Context runAsUser                                                                      | `101`                           |
 | `workspaceWww.containerSecurityContext.runAsNonRoot`      | Set workspace-www containers' Security Context runAsNonRoot                                                                   | `false`                         |
 | `workspaceWww.containerSecurityContext.capabilities.drop` | removes workspace-www containers' Security Context capabilities                                                               | `["all"]`                       |
+| `workspaceWww.podDisruptionBudget.enabled`                | defines disruption budget for workspace-www                                                                                   | `false`                         |
+| `workspaceWww.terminationGracePeriodSeconds`              | Time to wait before force killing the container                                                                               | `60`                            |
 | `workspaceWww.existingConfigMap`                          | The name of an existing ConfigMap with your custom configuration for workspace-www                                            | `""`                            |
 | `workspaceWww.existingSecret`                             | The name of an existing ConfigMap with your custom configuration for workspace-www                                            | `""`                            |
 | `workspaceWww.command`                                    | Override default container command (useful when using custom images)                                                          | `[]`                            |
@@ -1378,6 +1404,17 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `externalPostgresql.sslCA`                          | CA certificate in case CARTO Postgresql TLS cert it's selfsigned                                                                       | `""`              |
 
 
+### External proxy configuration
+
+| Name                                  | Description                                                                              | Value  |
+| ------------------------------------- | ---------------------------------------------------------------------------------------- | ------ |
+| `externalProxy.host`                  | Proxy host                                                                               | `nil`  |
+| `externalProxy.port`                  | Proxy port                                                                               | `nil`  |
+| `externalProxy.type`                  | Proxy type. Only HTTP and HTTPS proxies are supported                                    | `""`   |
+| `externalProxy.sslRejectUnauthorized` | Wheter or not verify the HTTPS proxy SSL certificate                                     | `true` |
+| `externalProxy.sslCA`                 | CA for the proxy SSL certificate in case is self-signed or signed by a not well-known CA | `""`   |
+
+
 ### Upgrade Check pre hook parameters
 
 | Name                                                      | Description                                                              | Value                           |
@@ -1398,6 +1435,11 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `upgradeCheck.containerSecurityContext.runAsUser`         | Set Upgrade Check pre-hook containers' Security Context runAsUser        | `1000`                          |
 | `upgradeCheck.containerSecurityContext.runAsNonRoot`      | Set Upgrade Check pre-hook containers' Security Context runAsNonRoot     | `false`                         |
 | `upgradeCheck.containerSecurityContext.capabilities.drop` | removes Upgrade Check pre-hook containers' Security Context capabilities | `["all"]`                       |
+
+
+### router-metrics parameters
+
+
 
 
 ### routerMetrics container parametres
@@ -1421,6 +1463,7 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `routerMetrics.containerSecurityContext.runAsUser`         | Set router-metrics containers' Security Context runAsUser                  | `1000`                          |
 | `routerMetrics.containerSecurityContext.runAsNonRoot`      | Set router-metrics containers' Security Context runAsNonRoot               | `false`                         |
 | `routerMetrics.containerSecurityContext.capabilities.drop` | removes router-metrics containers' Security Context capabilities           | `["all"]`                       |
+| `routerMetrics.podDisruptionBudget.enabled`                | defines disruption budget for router-metrics                               | `false`                         |
 | `routerMetrics.containerPorts.http`                        | routerMetrics HTTP container port                                          | `5447`                          |
 | `routerMetrics.livenessProbe.enabled`                      | Enable livenessProbe on router containers                                  | `false`                         |
 | `routerMetrics.livenessProbe.initialDelaySeconds`          | Initial delay seconds for livenessProbe                                    | `10`                            |

--- a/chart/README.md
+++ b/chart/README.md
@@ -1406,13 +1406,16 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 ### External proxy configuration
 
-| Name                                  | Description                                                                              | Value  |
-| ------------------------------------- | ---------------------------------------------------------------------------------------- | ------ |
-| `externalProxy.host`                  | Proxy host                                                                               | `nil`  |
-| `externalProxy.port`                  | Proxy port                                                                               | `nil`  |
-| `externalProxy.type`                  | Proxy type. Only HTTP and HTTPS proxies are supported                                    | `""`   |
-| `externalProxy.sslRejectUnauthorized` | Wheter or not verify the HTTPS proxy SSL certificate                                     | `true` |
-| `externalProxy.sslCA`                 | CA for the proxy SSL certificate in case is self-signed or signed by a not well-known CA | `""`   |
+| Name                                  | Description                                                                              | Value   |
+| ------------------------------------- | ---------------------------------------------------------------------------------------- | ------- |
+| `externalProxy.enabled`               | Whether the APIs will use an external proxy or not                                       | `false` |
+| `externalProxy.host`                  | Proxy host                                                                               | `nil`   |
+| `externalProxy.port`                  | Proxy port                                                                               | `nil`   |
+| `externalProxy.type`                  | Proxy type. Only HTTP and HTTPS proxies are supported                                    | `""`    |
+| `externalProxy.username`              | Proxy username (if required)                                                             | `nil`   |
+| `externalProxy.password`              | Proxy password (if required)                                                             | `nil`   |
+| `externalProxy.sslRejectUnauthorized` | Wheter or not verify the HTTPS proxy SSL certificate                                     | `true`  |
+| `externalProxy.sslCA`                 | CA for the proxy SSL certificate in case is self-signed or signed by a not well-known CA | `""`    |
 
 
 ### Upgrade Check pre hook parameters

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1323,7 +1323,6 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := list -}}
 {{- $messages := append $messages (include "carto.validateValues.redis" .) -}}
 {{- $messages := append $messages (include "carto.validateValues.postgresql" .) -}}
-{{- $messages := append $messages (include "carto.validateValues.proxy" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -1373,15 +1372,4 @@ Return the absolute path where the proxy CA cert will be mounted
 */}}
 {{- define "carto.proxy.configMapMountAbsolutePath" -}}
 {{- printf "%s/%s" (include "carto.proxy.configMapMountDir" .) (include "carto.proxy.configMapMountFilename" .) -}}
-{{- end -}}
-
-{{/*
-Validate external proxy config
-*/}}
-{{- define "carto.validateValues.proxy" -}}
-{{- if and .Values.externalProxy.enabled (not .Values.externalProxy.host) (not .Values.externalProxy.port) (not .Values.externalProxy.type) -}}
-CARTO: Missing proxy configuration
-
-If externalProxy.enabled=true you need to specify the host, port and type of the external proxy
-{{- end -}}
 {{- end -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1344,7 +1344,7 @@ Add environment variables to configure proxy values
 FIXME: Add support for user and password
 */}}
 {{- define "carto.proxy.connectionString" -}}
-{{- printf "%s:%d" .Values.externalProxy.host (int .Values.externalProxy.port) -}}
+{{- printf "%s://%s:%d" (lower .Values.externalProxy.type) .Values.externalProxy.host (int .Values.externalProxy.port) -}}
 {{- end -}}
 
 {{/*

--- a/chart/templates/cdn-invalidator-sub/configmap.yaml
+++ b/chart/templates/cdn-invalidator-sub/configmap.yaml
@@ -29,6 +29,8 @@ data:
   http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
+  GRPC_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  grpc_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}

--- a/chart/templates/cdn-invalidator-sub/configmap.yaml
+++ b/chart/templates/cdn-invalidator-sub/configmap.yaml
@@ -24,4 +24,18 @@ data:
   GOOGLE_APPLICATION_CREDENTIALS: {{ include "carto.google.secretMountAbsolutePath" . }}
   {{- end }}
   PUBSUB_PROJECT_ID: {{ .Values.cartoConfigValues.selfHostedGcpProjectId | quote }}
+  {{- if .Values.externalProxy.enabled }}
+  {{- if eq (lower .Values.externalProxy.type) "http" }}
+  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
+  {{- else if eq (lower .Values.externalProxy.type) "https" }}
+  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
+  {{- end }}
+  {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
+  NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  {{- end }}
+  {{- if .Values.externalProxy.sslCA }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/cdn-invalidator-sub/configmap.yaml
+++ b/chart/templates/cdn-invalidator-sub/configmap.yaml
@@ -35,7 +35,7 @@ data:
   no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
+  NODE_EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/cdn-invalidator-sub/configmap.yaml
+++ b/chart/templates/cdn-invalidator-sub/configmap.yaml
@@ -25,17 +25,14 @@ data:
   {{- end }}
   PUBSUB_PROJECT_ID: {{ .Values.cartoConfigValues.selfHostedGcpProjectId | quote }}
   {{- if .Values.externalProxy.enabled }}
-  {{- if eq (lower .Values.externalProxy.type) "http" }}
-  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
-  {{- else if eq (lower .Values.externalProxy.type) "https" }}
-  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
-  {{- end }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/cdn-invalidator-sub/configmap.yaml
+++ b/chart/templates/cdn-invalidator-sub/configmap.yaml
@@ -26,10 +26,13 @@ data:
   PUBSUB_PROJECT_ID: {{ .Values.cartoConfigValues.selfHostedGcpProjectId | quote }}
   {{- if .Values.externalProxy.enabled }}
   HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
   EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}

--- a/chart/templates/cdn-invalidator-sub/deployment.yaml
+++ b/chart/templates/cdn-invalidator-sub/deployment.yaml
@@ -163,6 +163,11 @@ spec:
             - name: gcp-default-service-account-key
               mountPath: {{ include "carto.google.secretMountDir" . }}
               readOnly: true
+            {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+            - name: proxy-ssl-ca
+              mountPath: {{ include "carto.proxy.configMapMountDir" . }}
+              readOnly: true
+            {{- end }}
           {{- if .Values.cdnInvalidatorSub.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.cdnInvalidatorSub.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -176,6 +181,11 @@ spec:
             items:
               - key: {{ include "carto.google.secretKey" . }}
                 path: {{ include "carto.google.secretMountFilename" . }}
+        {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+        - name: proxy-ssl-ca
+          configMap:
+            name: {{ include "carto.proxy.configMapName" . }}
+        {{- end }}
         {{- if .Values.cdnInvalidatorSub.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.cdnInvalidatorSub.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/chart/templates/externalproxy-configmap.yaml
+++ b/chart/templates/externalproxy-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "carto.proxy.configMapName" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  {{ include "carto.proxy.configMapMountFilename" . }}: {{ .Values.externalProxy.sslCA | quote }}
+{{- end }}

--- a/chart/templates/import-api/configmap.yaml
+++ b/chart/templates/import-api/configmap.yaml
@@ -59,10 +59,13 @@ data:
   {{- end }}
   {{- if .Values.externalProxy.enabled }}
   HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
   EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}

--- a/chart/templates/import-api/configmap.yaml
+++ b/chart/templates/import-api/configmap.yaml
@@ -68,7 +68,7 @@ data:
   no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
+  NODE_EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/import-api/configmap.yaml
+++ b/chart/templates/import-api/configmap.yaml
@@ -62,6 +62,8 @@ data:
   http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
+  GRPC_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  grpc_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}

--- a/chart/templates/import-api/configmap.yaml
+++ b/chart/templates/import-api/configmap.yaml
@@ -58,17 +58,14 @@ data:
   IMPORT_STORAGE_ACCOUNT: {{ .Values.appConfigValues.azureStorageAccount | quote }}
   {{- end }}
   {{- if .Values.externalProxy.enabled }}
-  {{- if eq (lower .Values.externalProxy.type) "http" }}
-  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
-  {{- else if eq (lower .Values.externalProxy.type) "https" }}
-  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
-  {{- end }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/import-api/configmap.yaml
+++ b/chart/templates/import-api/configmap.yaml
@@ -57,4 +57,18 @@ data:
   {{- if eq .Values.appConfigValues.storageProvider "azure-blob" }}
   IMPORT_STORAGE_ACCOUNT: {{ .Values.appConfigValues.azureStorageAccount | quote }}
   {{- end }}
+  {{- if .Values.externalProxy.enabled }}
+  {{- if eq (lower .Values.externalProxy.type) "http" }}
+  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
+  {{- else if eq (lower .Values.externalProxy.type) "https" }}
+  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
+  {{- end }}
+  {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
+  NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  {{- end }}
+  {{- if .Values.externalProxy.sslCA }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/import-api/deployment.yaml
+++ b/chart/templates/import-api/deployment.yaml
@@ -201,6 +201,11 @@ spec:
               mountPath: {{ include "carto.redis.configMapMountDir" . }}
               readOnly: true
             {{- end }}
+            {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+            - name: proxy-ssl-ca
+              mountPath: {{ include "carto.proxy.configMapMountDir" . }}
+              readOnly: true
+            {{- end }}
           {{- if .Values.importApi.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.importApi.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -231,6 +236,11 @@ spec:
         - name: redis-tls-ca
           configMap:
             name: {{ include "carto.redis.configMapName" . }}
+        {{- end }}
+        {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+        - name: proxy-ssl-ca
+          configMap:
+            name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
         {{- if .Values.importApi.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.importApi.extraVolumes "context" $) | nindent 8 }}

--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -64,7 +64,7 @@ data:
   no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
+  NODE_EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -53,4 +53,18 @@ data:
   {{- if eq .Values.appConfigValues.storageProvider "azure-blob" }}
   IMPORT_STORAGE_ACCOUNT: {{ .Values.appConfigValues.azureStorageAccount | quote }}
   {{- end }}
+  {{- if .Values.externalProxy.enabled }}
+  {{- if eq (lower .Values.externalProxy.type) "http" }}
+  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
+  {{- else if eq (lower .Values.externalProxy.type) "https" }}
+  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
+  {{- end }}
+  {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
+  NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  {{- end }}
+  {{- if .Values.externalProxy.sslCA }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -58,6 +58,8 @@ data:
   http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
+  GRPC_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  grpc_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}

--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -54,17 +54,14 @@ data:
   IMPORT_STORAGE_ACCOUNT: {{ .Values.appConfigValues.azureStorageAccount | quote }}
   {{- end }}
   {{- if .Values.externalProxy.enabled }}
-  {{- if eq (lower .Values.externalProxy.type) "http" }}
-  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
-  {{- else if eq (lower .Values.externalProxy.type) "https" }}
-  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
-  {{- end }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -55,10 +55,13 @@ data:
   {{- end }}
   {{- if .Values.externalProxy.enabled }}
   HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
   EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}

--- a/chart/templates/import-worker/deployment.yaml
+++ b/chart/templates/import-worker/deployment.yaml
@@ -176,6 +176,11 @@ spec:
               mountPath: {{ include "carto.postgresql.configMapMountDir" . }}
               readOnly: true
             {{- end }}
+            {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+            - name: proxy-ssl-ca
+              mountPath: {{ include "carto.proxy.configMapMountDir" . }}
+              readOnly: true
+            {{- end }}
           {{- if .Values.importWorker.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.importWorker.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -201,6 +206,11 @@ spec:
         - name: postgresql-ssl-ca
           configMap:
             name: {{ include "carto.postgresql.configMapName" . }}
+        {{- end }}
+        {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+        - name: proxy-ssl-ca
+          configMap:
+            name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
         {{- if .Values.importWorker.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.importWorker.extraVolumes "context" $) | nindent 8 }}

--- a/chart/templates/lds-api/configmap.yaml
+++ b/chart/templates/lds-api/configmap.yaml
@@ -41,4 +41,18 @@ data:
   WORKSPACE_POSTGRES_SSL_CA: {{ include "carto.postgresql.configMapMountAbsolutePath" . }}
   {{- end }}
   LDS_TENANT_ID: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
+  {{- if .Values.externalProxy.enabled }}
+  {{- if eq (lower .Values.externalProxy.type) "http" }}
+  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
+  {{- else if eq (lower .Values.externalProxy.type) "https" }}
+  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
+  {{- end }}
+  {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
+  NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  {{- end }}
+  {{- if .Values.externalProxy.sslCA }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/lds-api/configmap.yaml
+++ b/chart/templates/lds-api/configmap.yaml
@@ -46,6 +46,8 @@ data:
   http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
+  GRPC_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  grpc_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}

--- a/chart/templates/lds-api/configmap.yaml
+++ b/chart/templates/lds-api/configmap.yaml
@@ -42,17 +42,14 @@ data:
   {{- end }}
   LDS_TENANT_ID: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
   {{- if .Values.externalProxy.enabled }}
-  {{- if eq (lower .Values.externalProxy.type) "http" }}
-  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
-  {{- else if eq (lower .Values.externalProxy.type) "https" }}
-  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
-  {{- end }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/lds-api/configmap.yaml
+++ b/chart/templates/lds-api/configmap.yaml
@@ -43,10 +43,13 @@ data:
   LDS_TENANT_ID: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
   {{- if .Values.externalProxy.enabled }}
   HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
   EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}

--- a/chart/templates/lds-api/configmap.yaml
+++ b/chart/templates/lds-api/configmap.yaml
@@ -52,7 +52,7 @@ data:
   no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
+  NODE_EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/lds-api/deployment.yaml
+++ b/chart/templates/lds-api/deployment.yaml
@@ -186,6 +186,11 @@ spec:
               mountPath: {{ include "carto.redis.configMapMountDir" . }}
               readOnly: true
             {{- end }}
+            {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+            - name: proxy-ssl-ca
+              mountPath: {{ include "carto.proxy.configMapMountDir" . }}
+              readOnly: true
+            {{- end }}
           {{- if .Values.ldsApi.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.ldsApi.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -208,6 +213,11 @@ spec:
         - name: redis-tls-ca
           configMap:
             name: {{ include "carto.redis.configMapName" . }}
+        {{- end }}
+        {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+        - name: proxy-ssl-ca
+          configMap:
+            name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
         {{- if .Values.ldsApi.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.ldsApi.extraVolumes "context" $) | nindent 8 }}

--- a/chart/templates/maps-api/configmap.yaml
+++ b/chart/templates/maps-api/configmap.yaml
@@ -53,6 +53,8 @@ data:
   http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
+  GRPC_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  grpc_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}

--- a/chart/templates/maps-api/configmap.yaml
+++ b/chart/templates/maps-api/configmap.yaml
@@ -49,17 +49,14 @@ data:
   WORKSPACE_POSTGRES_SSL_CA: {{ include "carto.postgresql.configMapMountAbsolutePath" . }}
   {{- end }}
   {{- if .Values.externalProxy.enabled }}
-  {{- if eq (lower .Values.externalProxy.type) "http" }}
-  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
-  {{- else if eq (lower .Values.externalProxy.type) "https" }}
-  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
-  {{- end }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/maps-api/configmap.yaml
+++ b/chart/templates/maps-api/configmap.yaml
@@ -50,10 +50,13 @@ data:
   {{- end }}
   {{- if .Values.externalProxy.enabled }}
   HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
   EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}

--- a/chart/templates/maps-api/configmap.yaml
+++ b/chart/templates/maps-api/configmap.yaml
@@ -59,7 +59,7 @@ data:
   no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
+  NODE_EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/maps-api/configmap.yaml
+++ b/chart/templates/maps-api/configmap.yaml
@@ -56,7 +56,7 @@ data:
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- end }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
-  NO_PROXY: {{ join " " .Values.externalProxy.excludedDomains | quote }}
+  NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
   EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}

--- a/chart/templates/maps-api/configmap.yaml
+++ b/chart/templates/maps-api/configmap.yaml
@@ -48,4 +48,18 @@ data:
   {{- if and .Values.externalPostgresql.sslEnabled .Values.externalPostgresql.sslCA  }}
   WORKSPACE_POSTGRES_SSL_CA: {{ include "carto.postgresql.configMapMountAbsolutePath" . }}
   {{- end }}
+  {{- if .Values.externalProxy.enabled }}
+  {{- if eq (lower .Values.externalProxy.type) "http" }}
+  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
+  {{- else if eq (lower .Values.externalProxy.type) "https" }}
+  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
+  {{- end }}
+  {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
+  NO_PROXY: {{ join " " .Values.externalProxy.excludedDomains | quote }}
+  {{- end }}
+  {{- if .Values.externalProxy.sslCA }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/maps-api/deployment.yaml
+++ b/chart/templates/maps-api/deployment.yaml
@@ -188,6 +188,11 @@ spec:
               mountPath: {{ include "carto.redis.configMapMountDir" . }}
               readOnly: true
             {{- end }}
+            {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+            - name: proxy-ssl-ca
+              mountPath: {{ include "carto.proxy.configMapMountDir" . }}
+              readOnly: true
+            {{- end }}
           {{- if .Values.mapsApi.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.mapsApi.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -210,6 +215,11 @@ spec:
         - name: redis-tls-ca
           configMap:
             name: {{ include "carto.redis.configMapName" . }}
+        {{- end }}
+        {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+        - name: proxy-ssl-ca
+          configMap:
+            name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
         {{- if .Values.mapsApi.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.mapsApi.extraVolumes "context" $) | nindent 8 }}

--- a/chart/templates/router/configmap.yaml
+++ b/chart/templates/router/configmap.yaml
@@ -36,10 +36,13 @@ data:
   ROUTER_METRICS_PUBSUB_SUBSCRIPTION_FILTER: "aggregated-selfhosted-metrics"
   {{- if .Values.externalProxy.enabled }}
   HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
   EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}

--- a/chart/templates/router/configmap.yaml
+++ b/chart/templates/router/configmap.yaml
@@ -34,4 +34,14 @@ data:
   ROUTER_METRICS_PUBSUB_TOPIC: "data-updates"
   ROUTER_METRICS_HOST: "localhost"
   ROUTER_METRICS_PUBSUB_SUBSCRIPTION_FILTER: "aggregated-selfhosted-metrics"
+  {{- if .Values.externalProxy.enabled }}
+  {{- if eq (lower .Values.externalProxy.type) "http" }}
+  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
+  {{- else if eq (lower .Values.externalProxy.type) "https" }}
+  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  {{- end }}
+  {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
+  NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/router/configmap.yaml
+++ b/chart/templates/router/configmap.yaml
@@ -35,13 +35,14 @@ data:
   ROUTER_METRICS_HOST: "localhost"
   ROUTER_METRICS_PUBSUB_SUBSCRIPTION_FILTER: "aggregated-selfhosted-metrics"
   {{- if .Values.externalProxy.enabled }}
-  {{- if eq (lower .Values.externalProxy.type) "http" }}
-  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
-  {{- else if eq (lower .Values.externalProxy.type) "https" }}
-  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
-  {{- end }}
+  HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  {{- end }}
+  {{- if .Values.externalProxy.sslCA }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/router/configmap.yaml
+++ b/chart/templates/router/configmap.yaml
@@ -45,7 +45,7 @@ data:
   no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
+  NODE_EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/router/configmap.yaml
+++ b/chart/templates/router/configmap.yaml
@@ -39,6 +39,8 @@ data:
   http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
+  GRPC_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  grpc_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}

--- a/chart/templates/sql-worker/configmap.yaml
+++ b/chart/templates/sql-worker/configmap.yaml
@@ -58,7 +58,7 @@ data:
   no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
+  NODE_EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/sql-worker/configmap.yaml
+++ b/chart/templates/sql-worker/configmap.yaml
@@ -52,6 +52,8 @@ data:
   http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
+  GRPC_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  grpc_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}

--- a/chart/templates/sql-worker/configmap.yaml
+++ b/chart/templates/sql-worker/configmap.yaml
@@ -47,4 +47,18 @@ data:
   WORKSPACE_POSTGRES_SSL_CA: {{ include "carto.postgresql.configMapMountAbsolutePath" . }}
   {{- end }}
   WORKSPACE_TENANT_ID: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
+  {{- if .Values.externalProxy.enabled }}
+  {{- if eq (lower .Values.externalProxy.type) "http" }}
+  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
+  {{- else if eq (lower .Values.externalProxy.type) "https" }}
+  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
+  {{- end }}
+  {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
+  NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  {{- end }}
+  {{- if .Values.externalProxy.sslCA }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/sql-worker/configmap.yaml
+++ b/chart/templates/sql-worker/configmap.yaml
@@ -48,17 +48,14 @@ data:
   {{- end }}
   WORKSPACE_TENANT_ID: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
   {{- if .Values.externalProxy.enabled }}
-  {{- if eq (lower .Values.externalProxy.type) "http" }}
-  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
-  {{- else if eq (lower .Values.externalProxy.type) "https" }}
-  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
-  {{- end }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/sql-worker/configmap.yaml
+++ b/chart/templates/sql-worker/configmap.yaml
@@ -49,10 +49,13 @@ data:
   WORKSPACE_TENANT_ID: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
   {{- if .Values.externalProxy.enabled }}
   HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
   EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}

--- a/chart/templates/sql-worker/deployment.yaml
+++ b/chart/templates/sql-worker/deployment.yaml
@@ -161,6 +161,11 @@ spec:
               mountPath: {{ include "carto.postgresql.configMapMountDir" . }}
               readOnly: true
             {{- end }}
+            {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+            - name: proxy-ssl-ca
+              mountPath: {{ include "carto.proxy.configMapMountDir" . }}
+              readOnly: true
+            {{- end }}
           {{- if .Values.sqlWorker.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.sqlWorker.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -186,6 +191,11 @@ spec:
         - name: postgresql-ssl-ca
           configMap:
             name: {{ include "carto.postgresql.configMapName" . }}
+        {{- end }}
+        {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+        - name: proxy-ssl-ca
+          configMap:
+            name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
         {{- if .Values.sqlWorker.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.sqlWorker.extraVolumes "context" $) | nindent 8 }}

--- a/chart/templates/workspace-api/configmap.yaml
+++ b/chart/templates/workspace-api/configmap.yaml
@@ -88,10 +88,13 @@ data:
   {{- end }}
   {{- if .Values.externalProxy.enabled }}
   HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
   EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}

--- a/chart/templates/workspace-api/configmap.yaml
+++ b/chart/templates/workspace-api/configmap.yaml
@@ -87,17 +87,14 @@ data:
   WORKSPACE_IMPORTS_STORAGE_ACCOUNT: {{ .Values.appConfigValues.azureStorageAccount | quote }}
   {{- end }}
   {{- if .Values.externalProxy.enabled }}
-  {{- if eq (lower .Values.externalProxy.type) "http" }}
-  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
-  {{- else if eq (lower .Values.externalProxy.type) "https" }}
-  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
-  {{- end }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/workspace-api/configmap.yaml
+++ b/chart/templates/workspace-api/configmap.yaml
@@ -91,6 +91,8 @@ data:
   http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
+  GRPC_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  grpc_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}

--- a/chart/templates/workspace-api/configmap.yaml
+++ b/chart/templates/workspace-api/configmap.yaml
@@ -86,4 +86,18 @@ data:
   WORKSPACE_THUMBNAILS_STORAGE_ACCOUNT: {{ .Values.appConfigValues.azureStorageAccount | quote }}
   WORKSPACE_IMPORTS_STORAGE_ACCOUNT: {{ .Values.appConfigValues.azureStorageAccount | quote }}
   {{- end }}
+  {{- if .Values.externalProxy.enabled }}
+  {{- if eq (lower .Values.externalProxy.type) "http" }}
+  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
+  {{- else if eq (lower .Values.externalProxy.type) "https" }}
+  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
+  {{- end }}
+  {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
+  NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  {{- end }}
+  {{- if .Values.externalProxy.sslCA }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/workspace-api/configmap.yaml
+++ b/chart/templates/workspace-api/configmap.yaml
@@ -97,7 +97,7 @@ data:
   no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
+  NODE_EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/workspace-api/deployment.yaml
+++ b/chart/templates/workspace-api/deployment.yaml
@@ -279,6 +279,11 @@ spec:
               mountPath: {{ include "carto.redis.configMapMountDir" . }}
               readOnly: true
             {{- end }}
+            {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+            - name: proxy-ssl-ca
+              mountPath: {{ include "carto.proxy.configMapMountDir" . }}
+              readOnly: true
+            {{- end }}
           {{- if .Values.workspaceApi.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.workspaceApi.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -309,6 +314,11 @@ spec:
         - name: redis-tls-ca
           configMap:
             name: {{ include "carto.redis.configMapName" . }}
+        {{- end }}
+        {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+        - name: proxy-ssl-ca
+          configMap:
+            name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
         {{- if .Values.workspaceApi.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.workspaceApi.extraVolumes "context" $) | nindent 8 }}

--- a/chart/templates/workspace-subscriber/configmap.yaml
+++ b/chart/templates/workspace-subscriber/configmap.yaml
@@ -66,7 +66,7 @@ data:
   no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
+  NODE_EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/workspace-subscriber/configmap.yaml
+++ b/chart/templates/workspace-subscriber/configmap.yaml
@@ -55,4 +55,18 @@ data:
   WORKSPACE_PUBSUB_TENANT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.selfHostedGcpProjectId }}/topics/tenant-bus"
   WORKSPACE_TENANT_ID: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
   WORKSPACE_THUMBNAILS_BUCKET: {{ .Values.appConfigValues.workspaceThumbnailsBucket | quote }}
+  {{- if .Values.externalProxy.enabled }}
+  {{- if eq (lower .Values.externalProxy.type) "http" }}
+  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
+  {{- else if eq (lower .Values.externalProxy.type) "https" }}
+  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
+  {{- end }}
+  {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
+  NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  {{- end }}
+  {{- if .Values.externalProxy.sslCA }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/workspace-subscriber/configmap.yaml
+++ b/chart/templates/workspace-subscriber/configmap.yaml
@@ -57,10 +57,13 @@ data:
   WORKSPACE_THUMBNAILS_BUCKET: {{ .Values.appConfigValues.workspaceThumbnailsBucket | quote }}
   {{- if .Values.externalProxy.enabled }}
   HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
+  no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
   EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}

--- a/chart/templates/workspace-subscriber/configmap.yaml
+++ b/chart/templates/workspace-subscriber/configmap.yaml
@@ -60,6 +60,8 @@ data:
   http_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   https_proxy: {{ include "carto.proxy.connectionString" . | quote }}
+  GRPC_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  grpc_proxy: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}

--- a/chart/templates/workspace-subscriber/configmap.yaml
+++ b/chart/templates/workspace-subscriber/configmap.yaml
@@ -56,17 +56,14 @@ data:
   WORKSPACE_TENANT_ID: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
   WORKSPACE_THUMBNAILS_BUCKET: {{ .Values.appConfigValues.workspaceThumbnailsBucket | quote }}
   {{- if .Values.externalProxy.enabled }}
-  {{- if eq (lower .Values.externalProxy.type) "http" }}
-  HTTP_PROXY: "http://{{ include "carto.proxy.connectionString" . }}"
-  {{- else if eq (lower .Values.externalProxy.type) "https" }}
-  HTTPS_PROXY: "https://{{ include "carto.proxy.connectionString" . }}"
+  HTTP_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
+  HTTPS_PROXY: {{ include "carto.proxy.connectionString" . | quote }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
-  {{- end }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   {{- end }}
   {{- if .Values.externalProxy.sslCA }}
-  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . }}
+  EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/chart/templates/workspace-subscriber/deployment.yaml
+++ b/chart/templates/workspace-subscriber/deployment.yaml
@@ -173,6 +173,11 @@ spec:
               mountPath: {{ include "carto.redis.configMapMountDir" . }}
               readOnly: true
             {{- end }}
+            {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+            - name: proxy-ssl-ca
+              mountPath: {{ include "carto.proxy.configMapMountDir" . }}
+              readOnly: true
+            {{- end }}
           {{- if .Values.workspaceSubscriber.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.workspaceSubscriber.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -195,6 +200,11 @@ spec:
         - name: redis-tls-ca
           configMap:
             name: {{ include "carto.redis.configMapName" . }}
+        {{- end }}
+        {{- if and .Values.externalProxy.enabled .Values.externalProxy.sslCA }}
+        - name: proxy-ssl-ca
+          configMap:
+            name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
         {{- if .Values.workspaceSubscriber.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.workspaceSubscriber.extraVolumes "context" $) | nindent 8 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4435,12 +4435,18 @@ externalPostgresql:
 ## @section External proxy configuration
 ## Configuration for an external proxy provided by the client. Only HTTP and HTTPS proxies are supported
 externalProxy:
+  ## @param externalProxy.enabled Whether the APIs will use an external proxy or not
+  enabled: false
   ## @param externalProxy.host Proxy host
   host:
   ## @param externalProxy.port Proxy port
   port:
   ## @param externalProxy.type Proxy type. Only HTTP and HTTPS proxies are supported
   type: ""
+  ## @param externalProxy.username Proxy username (if required)
+  username:
+  ## @param externalProxy.password Proxy password (if required)
+  password:
   ## @param externalProxy.sslRejectUnauthorized Wheter or not verify the HTTPS proxy SSL certificate
   sslRejectUnauthorized: true
   ## @param externalProxy.sslCA CA for the proxy SSL certificate in case is self-signed or signed by a not well-known CA

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4438,9 +4438,9 @@ externalProxy:
   ## @param externalProxy.enabled Whether the APIs will use an external proxy or not
   enabled: false
   ## @param externalProxy.host Proxy host
-  host:
+  host: ""
   ## @param externalProxy.port Proxy port
-  port:
+  port: ""
   ## @param externalProxy.type Proxy type. Only HTTP and HTTPS proxies are supported
   type: ""
   ## @param externalProxy.username Proxy username (if required)
@@ -4449,7 +4449,7 @@ externalProxy:
   password:
   ## @param externalProxy.excludedDomains List of domains that will bypass the proxy
   excludedDomains: []
-  ## @param externalProxy.sslRejectUnauthorized Wheter or not verify the HTTPS proxy SSL certificate
+  ## @param externalProxy.sslRejectUnauthorized Whether or not verify the HTTPS proxy SSL certificate
   sslRejectUnauthorized: true
   ## @param externalProxy.sslCA CA for the proxy SSL certificate in case is self-signed or signed by a not well-known CA
   sslCA: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -419,7 +419,7 @@ accountsWww:
     capabilities:
       drop:
         - all
-  ## @param accountsWww.podDisruptionBudget defines disruption budget for accounts-www
+  ## @param accountsWww.podDisruptionBudget.enabled defines disruption budget for accounts-www
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   podDisruptionBudget:
@@ -751,7 +751,7 @@ importApi:
     capabilities:
       drop:
         - all
-  ## @param importApi.podDisruptionBudget defines disruption budget for import-api
+  ## @param importApi.podDisruptionBudget.enabled defines disruption budget for import-api
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   podDisruptionBudget:
@@ -1010,7 +1010,7 @@ importWorker:
     capabilities:
       drop:
         - all
-  ## @param importWorker.podDisruptionBudget defines disruption budget for import-worker
+  ## @param importWorker.podDisruptionBudget.enabled defines disruption budget for import-worker
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   podDisruptionBudget:
@@ -1283,7 +1283,7 @@ ldsApi:
     capabilities:
       drop:
         - all
-  ## @param ldsApi.podDisruptionBudget defines disruption budget for lds-api
+  ## @param ldsApi.podDisruptionBudget.enabled defines disruption budget for lds-api
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   podDisruptionBudget:
@@ -1602,7 +1602,7 @@ mapsApi:
     capabilities:
       drop:
         - all
-  ## @param mapsApi.podDisruptionBudget defines disruption budget for maps-api
+  ## @param mapsApi.podDisruptionBudget.enabled defines disruption budget for maps-api
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   podDisruptionBudget:
@@ -1896,7 +1896,7 @@ sqlWorker:
     capabilities:
       drop:
         - all
-  ## @param sqlWorker.podDisruptionBudget defines disruption budget for sql-worker
+  ## @param sqlWorker.podDisruptionBudget.enabled defines disruption budget for sql-worker
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   podDisruptionBudget:
@@ -2165,7 +2165,7 @@ router:
     capabilities:
       drop:
         - all
-  ## @param router.podDisruptionBudget defines disruption budget for router
+  ## @param router.podDisruptionBudget.enabled defines disruption budget for router
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   podDisruptionBudget:
@@ -2565,7 +2565,7 @@ httpCache:
     capabilities:
       drop:
         - all
-  ## @param httpCache.podDisruptionBudget defines disruption budget for http-cache
+  ## @param httpCache.podDisruptionBudget.enabled defines disruption budget for http-cache
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   podDisruptionBudget:
@@ -2879,7 +2879,7 @@ notifier:
     capabilities:
       drop:
         - all
-  ## @param notifier.podDisruptionBudget defines disruption budget for notifier
+  ## @param notifier.podDisruptionBudget.enabled defines disruption budget for notifier
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   podDisruptionBudget:
@@ -3202,7 +3202,7 @@ cdnInvalidatorSub:
     capabilities:
       drop:
         - all
-  ## @param cdnInvalidatorSub.podDisruptionBudget defines disruption budget for cdn-invalidator-sub
+  ## @param cdnInvalidatorSub.podDisruptionBudget.enabled defines disruption budget for cdn-invalidator-sub
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   podDisruptionBudget:
@@ -3523,7 +3523,7 @@ workspaceApi:
     capabilities:
       drop:
         - all
-  ## @param workspaceApi.podDisruptionBudget defines disruption budget for workspace-api
+  ## @param workspaceApi.podDisruptionBudget.enabled defines disruption budget for workspace-api
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   podDisruptionBudget:
@@ -3782,7 +3782,7 @@ workspaceSubscriber:
     capabilities:
       drop:
         - all
-  ## @param workspaceSubscriber.podDisruptionBudget defines disruption budget for workspace-subscriber
+  ## @param workspaceSubscriber.podDisruptionBudget.enabled defines disruption budget for workspace-subscriber
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   podDisruptionBudget:
@@ -4049,7 +4049,7 @@ workspaceWww:
     capabilities:
       drop:
         - all
-  ## @param workspaceWww.podDisruptionBudget defines disruption budget for workspace-www
+  ## @param workspaceWww.podDisruptionBudget.enabled defines disruption budget for workspace-www
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   podDisruptionBudget:
@@ -4584,7 +4584,7 @@ routerMetrics:
     capabilities:
       drop:
         - all
-  ## @param routerMetrics.podDisruptionBudget defines disruption budget for router-metrics
+  ## @param routerMetrics.podDisruptionBudget.enabled defines disruption budget for router-metrics
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
   podDisruptionBudget:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4447,6 +4447,8 @@ externalProxy:
   username:
   ## @param externalProxy.password Proxy password (if required)
   password:
+  ## @param externalProxy.excludedDomains List of domains that will bypass the proxy
+  excludedDomains: []
   ## @param externalProxy.sslRejectUnauthorized Wheter or not verify the HTTPS proxy SSL certificate
   sslRejectUnauthorized: true
   ## @param externalProxy.sslCA CA for the proxy SSL certificate in case is self-signed or signed by a not well-known CA

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4443,11 +4443,7 @@ externalProxy:
   port: ""
   ## @param externalProxy.type Proxy type. Only HTTP and HTTPS proxies are supported
   type: ""
-  ## @param externalProxy.username Proxy username (if required)
-  username:
-  ## @param externalProxy.password Proxy password (if required)
-  password:
-  ## @param externalProxy.excludedDomains List of domains that will bypass the proxy
+  ## @param externalProxy.excludedDomains List of domains that should not be proxied
   excludedDomains: []
   ## @param externalProxy.sslRejectUnauthorized Whether or not verify the HTTPS proxy SSL certificate
   sslRejectUnauthorized: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -51,6 +51,7 @@ cartoConfigValues:
   selfHostedTenantId: ""
   ## @param cartoConfigValues.launchDarklyClientSideId LaunchDarkly ClientSideId (by www) used to enable/disable features.
   launchDarklyClientSideId: ""
+
 ## @section App secret
 ## Global secrets to be edited by the client
 appSecrets:
@@ -4429,6 +4430,20 @@ externalPostgresql:
   database: workspace
   port: 5432
   sslEnabled: false
+  sslCA: ""
+
+## @section External proxy configuration
+## Configuration for an external proxy provided by the client. Only HTTP and HTTPS proxies are supported
+externalProxy:
+  ## @param externalProxy.host Proxy host
+  host:
+  ## @param externalProxy.port Proxy port
+  port:
+  ## @param externalProxy.type Proxy type. Only HTTP and HTTPS proxies are supported
+  type: ""
+  ## @param externalProxy.sslRejectUnauthorized Wheter or not verify the HTTPS proxy SSL certificate
+  sslRejectUnauthorized: true
+  ## @param externalProxy.sslCA CA for the proxy SSL certificate in case is self-signed or signed by a not well-known CA
   sslCA: ""
 
 ## @section Upgrade Check pre hook parameters

--- a/customizations/README.md
+++ b/customizations/README.md
@@ -26,6 +26,7 @@
       - [Setup Redis creating secrets](#setup-redis-creating-secrets)
       - [Setup Redis with automatic secret creation](#setup-redis-with-automatic-secret-creation)
       - [Configure Redis TLS](#configure-redis-tls)
+    - [Configure external proxy](#configure-external-proxy)
     - [Custom Buckets](#custom-buckets)
       - [Pre-requisites](#pre-requisites)
       - [Google Cloud Storage](#google-cloud-storage)
@@ -646,6 +647,18 @@ externalRedis:
     #   ...
     #   -----END CERTIFICATE-----
 ```
+
+### Configure external proxy
+
+CARTO stack supports working behind a HTTP/HTTPS proxy. This proxy is used to connect to external services like Google APIs, Mapbox, etc.
+
+You can find customizations examples for different proxies in the [proxy](./proxy/) directory.
+
+The `externalProxy.excludedDomains` property can contain a list of all the domains that shouldn't be proxied. This is useful for example to avoid proxying the internal services like the internal Redis or Postgresql.
+
+```yaml
+
+> :warning: Your proxy user/password credentials will appear in clear text in the environment variables of the CARTO stack components
 
 ### Custom Buckets
 
@@ -1376,14 +1389,14 @@ If you need to open a support ticket, please execute our [carto-support-tool](..
 
 If you face a problem like the one below while you are updating your CARTO selfhosted installation```
 ```bash
-helm upgrade my-release carto/carto --namespace my namespace -f carto-values.yaml -f carto-secrets.yaml -f customizations.yml 
+helm upgrade my-release carto/carto --namespace my namespace -f carto-values.yaml -f carto-secrets.yaml -f customizations.yml
 Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress
 ```
 
 Probably an upgrade operation wasn't killed gracefully. The fix is to rollback to a previous deployment:
 
 ```bash
-helm history my-release                                                                                                                               
+helm history my-release
 
 REVISION	UPDATED                 	STATUS         	CHART             	APP VERSION	DESCRIPTION
 19      	Fri Aug 26 11:10:20 2022	superseded     	carto-1.40.6-beta 	2022.8.19-2	Upgrade complete
@@ -1396,10 +1409,10 @@ REVISION	UPDATED                 	STATUS         	CHART             	APP VERSION
 26      	Fri Sep 30 14:14:29 2022	superseded     	carto-1.42.10-beta	2022.9.28  	Upgrade complete
 27      	Fri Sep 30 14:37:41 2022	deployed       	carto-1.42.10-beta	2022.9.28  	Upgrade complete
 28      	Fri Sep 30 15:07:06 2022	pending-upgrade	carto-1.42.10-beta	2022.9.28  	Preparing upgrade
-helm rollback my-release 27                                                                                                                                              
+helm rollback my-release 27
 Rollback was a success! Happy Helming!
 
-helm history my-release   
+helm history my-release
 
 REVISION	UPDATED                 	STATUS         	CHART             	APP VERSION	DESCRIPTION
 20      	Fri Sep 16 12:00:57 2022	superseded     	carto-1.42.1-beta 	2022.9.16  	Upgrade complete
@@ -1412,5 +1425,5 @@ REVISION	UPDATED                 	STATUS         	CHART             	APP VERSION
 27      	Fri Sep 30 14:37:41 2022	superseded     	carto-1.42.10-beta	2022.9.28  	Upgrade complete
 28      	Fri Sep 30 15:07:06 2022	pending-upgrade	carto-1.42.10-beta	2022.9.28  	Preparing upgrade
 29      	Tue Oct  4 10:58:22 2022	deployed       	carto-1.42.10-beta	2022.9.28  	Rollback to 27
-``` 
+```
 Now you can run the upgrade operation again

--- a/customizations/proxy/http/customizations.yaml
+++ b/customizations/proxy/http/customizations.yaml
@@ -1,0 +1,6 @@
+externalProxy:
+  enabled: true
+  host: <Proxy IP/Hostname>
+  port: <Proxy port>
+  type: http
+  excludedDomains: []

--- a/customizations/proxy/https/customizations.yaml
+++ b/customizations/proxy/https/customizations.yaml
@@ -1,0 +1,13 @@
+externalProxy:
+  enabled: true
+  host: <Proxy IP/Hostname>
+  port: <Proxy port>
+  type: https
+  excludedDomains: []
+  # Whether or not verify the proxy SSL certificate
+  sslRejectUnauthorized: false
+  # Only applies for self-signed SSL certificates or not well-known CAs
+  # sslCA: |
+  #   -----BEGIN CERTIFICATE-----
+  #   ...
+  #   -----END CERTIFICATE-----


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Shortcut: https://app.shortcut.com/cartoteam/story/310383/enable-proxy-support-for-selfhosted-helm-chart-and-docker

Add the Chart configuration in case CARTO stack runs behind a HTTP or HTTPS proxy

**Benefits**

<!-- What benefits will be realized by the code change? -->

Be able to work behind a proxy :)

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->