### PR TITLE
Update carto-download-customer-package.sh

### DIFF
--- a/tools/carto-download-customer-package.sh
+++ b/tools/carto-download-customer-package.sh
@@ -146,7 +146,7 @@ gcloud auth activate-service-account "${CARTO_SERVICE_ACCOUNT_EMAIL}" \
 
 # Get latest customer package version
 CUSTOMER_PACKAGE_FILE_LATEST=$(gsutil ls "gs://${CLIENT_STORAGE_BUCKET}/${CUSTOMER_PACKAGE_FOLDER}/${CUSTOMER_PACKAGE_NAME_PREFIX}-${CLIENT_ID}-*-*-*.zip")
-SELFHOSTED_VERSION_LATEST=$(echo "${CUSTOMER_PACKAGE_FILE_LATEST}" | grep -Eo "[0-9]+-[0-9]+-[0-9]+")
+SELFHOSTED_VERSION_LATEST=$(echo "${CUSTOMER_PACKAGE_FILE_LATEST}" | grep -Eo "[0-9]+-[0-9]+-[0-9]+(-rc-[0-9])?")
 
 # Download package
 gsutil cp \


### PR DESCRIPTION
- Adding support for RC versions in the download customer package script

- Tested locally for both stable and rc releases:
```
$ ./carto-download-customer-package.sh -d qa-xxx-gke -s k8s
Activated service account credentials for: [serv-onp-qa-xxx-gke@xxx.gserviceaccount.com]
Copying gs://onp-qa-xxx-gke-client-storage/customer-package/carto-selfhosted-k8s-customer-package-qa-xxxx-gke-2023-5-12-rc-1.zip...
/ [1 files][  2.6 KiB/  2.6 KiB]                                                
Operation completed over 1 objects/2.6 KiB.                                      

##############################################################
Current selfhosted version in [carto-values.yaml]: 2023.5.12-rc.1
Latest selfhosted version downloaded: 2023-5-12-rc-1
Downloaded file: carto-selfhosted-k8s-customer-package-qa-xxxx-gke-2023-5-12-rc-1.zip
Downloaded from: gs://xxxx-qa-xxxx-gke-client-storage/customer-package/carto-selfhosted-k8s-customer-package-qa-xxxx-gke-2023-5-12-rc-1.zip
##############################################################
```