### PR TITLE
fix readme file

### DIFF
--- a/customizations/README.md
+++ b/customizations/README.md
@@ -656,7 +656,7 @@ You can find customizations examples for different proxies in the [proxy](./prox
 
 The `externalProxy.excludedDomains` property can contain a list of all the domains that shouldn't be proxied. This is useful for example to avoid proxying the internal services like the internal Redis or Postgresql.
 
-```yaml
+
 
 > :warning: Your proxy user/password credentials will appear in clear text in the environment variables of the CARTO stack components
 


### PR DESCRIPTION
Just a small fix since it looks like a small mistake in the readme:
![image](https://github.com/CartoDB/carto-selfhosted-helm/assets/35410279/215800a3-5967-4bae-8866-2d4d6b34d4a7)
