### PR TITLE
bigquery oauth variables for import-worker

### DIFF
--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -12,6 +12,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
+  BIGQUERY_OAUTH2_CLIENT_ID: {{ .Values.appConfigValues.bigqueryOauth2ClientId | quote }}
   {{- if not .Values.commonBackendServiceAccount.enableGCPWorkloadIdentity }}
   GOOGLE_APPLICATION_CREDENTIALS: {{ include "carto.google.secretMountAbsolutePath" . }}
   {{- end }}

--- a/chart/templates/import-worker/deployment.yaml
+++ b/chart/templates/import-worker/deployment.yaml
@@ -110,6 +110,7 @@ spec:
                   name: {{ include "carto.postgresql.secretName" . }}
                   key: {{ include "carto.postgresql.secret.key" . }}
             {{- include "carto._utils.generateSecretDefs" (dict "vars" (list
+              "BIGQUERY_OAUTH2_CLIENT_SECRET"
               "ENCRYPTION_SECRET_KEY"
               "IMPORT_JWT_SECRET"
               "IMPORT_AWS_ACCESS_KEY_ID"
@@ -125,6 +126,7 @@ spec:
             - configMapRef:
                 name: {{ template "carto.importWorker.configmapName" . }}
             {{- $secretContent := include "carto._utils.generateSecretObjects" (dict "vars" (list
+              "BIGQUERY_OAUTH2_CLIENT_SECRET"
               "ENCRYPTION_SECRET_KEY"
               "IMPORT_JWT_SECRET"
               "IMPORT_AWS_ACCESS_KEY_ID"

--- a/chart/templates/import-worker/secret.yaml
+++ b/chart/templates/import-worker/secret.yaml
@@ -1,4 +1,5 @@
 {{ $secretContent := include "carto._utils.generateSecretObjects" (dict "vars" (list
+  "BIGQUERY_OAUTH2_CLIENT_SECRET"
   "ENCRYPTION_SECRET_KEY"
   "IMPORT_JWT_SECRET"
   "IMPORT_ACCESSKEYID"


### PR DESCRIPTION
- Add missing variables to import-worker component in order to enable imports with Bigquery Oauth connections.