### PR TITLE
Fix typos in download-customer-package code

### DIFF
--- a/tools/carto-download-customer-package.sh
+++ b/tools/carto-download-customer-package.sh
@@ -16,7 +16,7 @@ function check_deps()
 {
   for DEP in ${DEPENDENCIES}; do
     # shellcheck disable=SC2261,SC2210
-    command -v "${DEP}" 2&>1 > /dev/null || \
+    command -v "${DEP}" 2>&1 > /dev/null || \
       { echo -e "\n[ERROR]: missing dependency <${DEP}>. Please, install it.\n"; exit 1;}
   done
 }
@@ -57,7 +57,7 @@ PROGNAME="$(basename "$0")"
 # use getopt and store the output into $OPTS
 # note the use of -o for the short options, --long for the long name options
 # and a : for any option that takes a parameter
-OPTS=$(getopt -o "hd:s" --long "help,dir,selfhosted-mode" -n "$PROGNAME" -- "$@")
+OPTS=$(getopt -o "hd:s:" --long "help,dir:,selfhosted-mode:" -n "$PROGNAME" -- "$@")
 
 # Check getopt errors
 # shellcheck disable=SC2166,SC2181
@@ -77,7 +77,7 @@ while true; do
   case "$1" in
     -h | --help ) usage; exit; ;;
     -d | --dir) FILE_DIR="${2%/}"; shift 2 ;;
-    -s | --selfhosted-mode) SELFHOSTED_MODE="$3"; shift 2 ;;
+    -s | --selfhosted-mode) SELFHOSTED_MODE="$2"; shift 2 ;;
     -- ) shift ;;
     * ) break ;;
   esac

--- a/tools/carto-download-customer-package.sh
+++ b/tools/carto-download-customer-package.sh
@@ -16,7 +16,7 @@ function check_deps()
 {
   for DEP in ${DEPENDENCIES}; do
     # shellcheck disable=SC2261,SC2210
-    command -v "${DEP}" 2>&1 > /dev/null || \
+    command -v "${DEP}" > /dev/null 2>&1 || \
       { echo -e "\n[ERROR]: missing dependency <${DEP}>. Please, install it.\n"; exit 1;}
   done
 }


### PR DESCRIPTION
**Description of the change**

- Discovered a typo that created a file called `1` every time we execute the tool.
  - Fixed changing `2&>1` to `2>&1`.
- Added the required ":" to the options with parameters in `getopt`.

**Benefits**

Avoid creating an extra file when executing the tool.

`getopt` will work properly with the long options.

**Possible drawbacks**

There shouldn't be any

**Additional information**

While debugging this, we found out the following:
- We create a file for the customer service account that we might be interested in removing at the end of the script.
- This script won't work on MAC because it uses a different `getopt`.
  - It will work if we install `gnu-getopt` over the default `getopt`.
  - We can create a warning in the documentation (even though we specifically require a Linux machine to execute this script).