### PR TITLE
Add missing `podSecurityContext` and `containerSecurityContext` in the pre-hook install job

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4528,6 +4528,7 @@ upgradeCheck:
   podSecurityContext:
     enabled: true
     fsGroup: 1000
+    supplementalGroups: [2345]
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param upgradeCheck.containerSecurityContext.enabled Enabled Upgrade Check pre-hook containers' Security Context
@@ -4538,7 +4539,9 @@ upgradeCheck:
   containerSecurityContext:
     enabled: true
     runAsUser: 1000
+    runAsGroup: 1000
     runAsNonRoot: false
+    allowPrivilegeEscalation: false
     capabilities:
       drop:
         - all


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Allow running the pre-hook install job in environments with Gatekeeper policies enforced

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->