### PR TITLE
README: clarify update process

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ If you need to open a support ticket, please execute our [carto-support-tool](to
   helm repo update
   ```
 
-3. Download the latest customer package (containing `carto-values.yaml` and `carto-secrets.yaml` files) using [this tool](tools/carto-download-customer-package.sh).
+3. Download the latest customer package (containing `carto-values.yaml` and `carto-secrets.yaml` files) using the tool described [here](tools/README.md#download-customer-package-tool).
 
 4. Update CARTO
 


### PR DESCRIPTION
Change the link to the Download Customer Package Tool since some users complained it was confusing
