### PR TITLE
[324925] correct tools/README.md

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -62,8 +62,11 @@ This tool can be used to download a newer version of the Carto selfhosted custom
 ### How to download the latest customer package
 
 1. Run the script passing the following arguments:
-   - |  `-d` | Directory containing the existing `carto-values.yaml` and `carto-secrets.yaml` files. |
-   - | `-s` | Carto selfhosted installation mode. Use `k8s`. |
+
+> | flag | description |
+> |:----:|:------------|
+> | `-d` | Directory containing the existing `carto-values.yaml` and `carto-secrets.yaml` files. |
+> | `-s` | Carto selfhosted installation mode. Use `k8s`. |
 
    ```bash
    $ ./carto-download-customer-package.sh -d /tmp/carto -s k8s

--- a/tools/README.md
+++ b/tools/README.md
@@ -62,8 +62,8 @@ This tool can be used to download a newer version of the Carto selfhosted custom
 ### How to download the latest customer package
 
 1. Run the script passing the following arguments:
-   - `-d | --dir` Directory containing the existing `carto-values.yaml` and `carto-secrets.yaml` files.
-   - `-s | --selfhosted-mode` Carto selfhosted installation mode. Use `k8s`.
+   - |  `-d` | Directory containing the existing `carto-values.yaml` and `carto-secrets.yaml` files. |
+   - | `-s` | Carto selfhosted installation mode. Use `k8s`. |
 
    ```bash
    $ ./carto-download-customer-package.sh -d /tmp/carto -s k8s


### PR DESCRIPTION
**Description of the change**

Fix `tools/README.md` after https://github.com/CartoDB/carto-selfhosted-helm/pull/378

**Benefits**

Tailor user documentation

**Possible drawbacks**

N/A

**Applicable issues**

  - complementary change for #324925
