### PR TITLE
[329603] selfhosted: fix CLIENT_ID with numeric suffix + improvements

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -72,9 +72,9 @@ This tool can be used to download a newer version of the Carto selfhosted custom
 > $ ./carto-download-customer-package.sh -d /tmp/carto -s k8s
 > ```
 
-> Example output: 
-> 
-> ```
+> Example output:
+>
+> ```console
 > ℹ️ selfhosted mode: k8s
 > ✅ found: /tmp/carto/carto-values.yaml
 > ✅ found: /tmp/carto/carto-secrets.yaml
@@ -83,14 +83,14 @@ This tool can be used to download a newer version of the Carto selfhosted custom
 > / [1 files][  2.6 KiB/  2.6 KiB]
 > Operation completed over 1 objects/2.6 KiB.
 > ✅ downloading: carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip
-> 
+>
 > ##############################################################
 > Current selfhosted version in [carto-values.yaml]: 2023.6.16
 > Latest selfhosted version downloaded: 2023-6-16
 > Downloaded file: carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip
 > Downloaded from: gs://carto-tnt-onp-xxx-client-storage/customer-package/carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip
 > ##############################################################
-> 
+>
 > ✅ finished [0]
 > ```
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -68,12 +68,30 @@ This tool can be used to download a newer version of the Carto selfhosted custom
 > | `-d` | Directory containing the existing `carto-values.yaml` and `carto-secrets.yaml` files. |
 > | `-s` | Carto selfhosted installation mode. Use `k8s`. |
 
-   ```bash
-   $ ./carto-download-customer-package.sh -d /tmp/carto -s k8s
-   Activated service account credentials for: [serv-onp-xxx@carto-tnt-onp-xxx.iam.gserviceaccount.com]
-   Copying gs://carto-tnt-onp-xxx-client-storage/customer-package/carto-selfhosted-k8s-customer-package-xxx-2022-10-18.zip...
-   / [1 files][  3.5 KiB/  3.5 KiB]                                                
-   Operation completed over 1 objects/3.5 KiB.                                      
-   ```
+> ```bash
+> $ ./carto-download-customer-package.sh -d /tmp/carto -s k8s
+> ```
+
+> Example output: 
+> 
+> ```
+> ℹ️ selfhosted mode: k8s
+> ✅ found: /tmp/carto/carto-values.yaml
+> ✅ found: /tmp/carto/carto-secrets.yaml
+> ✅ activating: service account credentials for: [serv-onp-xxx@carto-tnt-onp-xxx.iam.gserviceaccount.com]
+> Copying gs://carto-tnt-onp-xxx-client-storage/customer-package/carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip...
+> / [1 files][  2.6 KiB/  2.6 KiB]
+> Operation completed over 1 objects/2.6 KiB.
+> ✅ downloading: carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip
+> 
+> ##############################################################
+> Current selfhosted version in [carto-values.yaml]: 2023.6.16
+> Latest selfhosted version downloaded: 2023-6-16
+> Downloaded file: carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip
+> Downloaded from: gs://carto-tnt-onp-xxx-client-storage/customer-package/carto-selfhosted-k8s-customer-package-xxx-2023-6-16.zip
+> ##############################################################
+> 
+> ✅ finished [0]
+> ```
 
 2. Unzip your customer package files and use them to update your Carto selfhosted installation.

--- a/tools/carto-download-customer-package.sh
+++ b/tools/carto-download-customer-package.sh
@@ -151,7 +151,7 @@ CARTO_GCP_PROJECT=$(jq -r ".project_id" < "${CARTO_SERVICE_ACCOUNT_FILE}")
 # Download the latest customer package
 STEP="activating: service account credentials for: [${CARTO_SERVICE_ACCOUNT_EMAIL}]"
 if ( gcloud auth activate-service-account "${CARTO_SERVICE_ACCOUNT_EMAIL}" --key-file="${CARTO_SERVICE_ACCOUNT_FILE}" --project="${CARTO_GCP_PROJECT}" &>/dev/null ) ; then
-  _success "${STEP}" ; else _error "${STEP}"
+  _success "${STEP}" ; else _error "${STEP}" 5
 fi
 
 # Get latest customer package version
@@ -162,7 +162,7 @@ SELFHOSTED_VERSION_LATEST="${SELFHOSTED_VERSION_LATEST/#${CLIENT_ID}-}"
 # Download package
 STEP="downloading: $(basename "${CUSTOMER_PACKAGE_FILE_LATEST}")"
 if ( gsutil cp "gs://${CLIENT_STORAGE_BUCKET}/${CUSTOMER_PACKAGE_FOLDER}/${CUSTOMER_PACKAGE_NAME_PREFIX}-${CLIENT_ID}-${SELFHOSTED_VERSION_LATEST}.zip" ./ ) ; then
-  _success "${STEP}" ; else _error "${STEP}"
+  _success "${STEP}" && RC="0" ; else _error "${STEP}" 6
 fi
 
 # Print message
@@ -173,4 +173,4 @@ echo -e "Downloaded file: $(basename "${CUSTOMER_PACKAGE_FILE_LATEST}")"
 echo -e "Downloaded from: ${CUSTOMER_PACKAGE_FILE_LATEST}"
 echo -e "##############################################################\n"
 
-_success "finished [$?]\n"
+_success "finished [${RC}]\n"

--- a/tools/carto-download-customer-package.sh
+++ b/tools/carto-download-customer-package.sh
@@ -12,28 +12,31 @@ CUSTOMER_PACKAGE_NAME_PREFIX="carto-selfhosted-${SELFHOSTED_MODE}-customer-packa
 CUSTOMER_PACKAGE_FOLDER="customer-package"
 ##########################################
 
-function check_deps()
+function _check_deps()
 {
-  for DEP in ${DEPENDENCIES}; do
-    # shellcheck disable=SC2261,SC2210
-    command -v "${DEP}" 2&>1 > /dev/null || \
-      { echo -e "\n[ERROR]: missing dependency <${DEP}>. Please, install it.\n"; exit 1;}
+  for DEP in ${DEPENDENCIES} ; do
+    if ( ! command -v "${DEP}" &>/dev/null ) ; then
+      _error "missing dependency <${DEP}>. Please, install it.\n"
+    fi
   done
 }
 
-function check_input_files()
+function _check_input_files()
 {
   # =================================
-  # $1 -> input file to validate
+  # # ARGV1 = input file to validate
   # =================================
-  if ! [ -e "$1" ]; then
-    echo -e "\n[ERROR]: unable to locate <$1>. Please check that the file exists.\n"
-    usage
-    exit 2
+  # check if the file exists
+  if [ -e "${1}" ] ; then
+    _success "found: ${1}"
+  else
+    _error "unable to locate <${1}>. Please check that the file exists.\n" 3
   fi
+  # check if the file size is greater than zero
+  [ ! -s "${1}" ] && _error "file <${1}> is empty.\n" 4
 }
 
-function usage()
+function _usage()
 {
   cat <<EOF
 
@@ -50,15 +53,25 @@ function usage()
 EOF
 }
 
+function _info() {
+  # ARGV1 = message
+  echo -e "ℹ️  ${1}"
+}
+
+function _success() {
+  # ARGV1 = message
+  echo -e "✅ ${1}"
+}
+
 function _error() {
   # ARGV1 = message
-  # ARGV2 = desired exit code (default is 1)
+  # ARGV2 = arbitrary error code (default is 1)
   local EXIT_CODE="${2:-1}"
   RED="\033[1;31m"
   YELLOW="\033[1;93m"
   NONE="\033[0m"
   echo -e "❌ ${RED}ERROR ${NONE}[${EXIT_CODE}]: ${YELLOW}${1}${NONE}"
-  usage
+  _usage
   exit "${EXIT_CODE}"
 }
 
@@ -72,7 +85,7 @@ while getopts d:s:h OPTS ; do
   case "${OPTS}" in
     d) FILE_DIR="${OPTARG%/}" ;;
     s) SELFHOSTED_MODE="${OPTARG}" ;;
-    h) usage ; exit ;;
+    h) _usage ; exit ;;
     *) _error "Invalid args provided" 1
   esac
 done
@@ -82,47 +95,47 @@ done
 # ==================================================
 
 # Validate provided path
-[ ! -d "${FILE_DIR}" ] && _error "Directory <${FILE_DIR}> does not exist." 2
+[ ! -d "${FILE_DIR}" ] && _error "Directory <${FILE_DIR}> does not exist."
 
 # Validate selfhosted mode
 # shellcheck disable=SC2076
-[[ ! '[ "docker", "k8s" ]' =~ "\"${SELFHOSTED_MODE}\"" ]] && _error "illegal value '${SELFHOSTED_MODE}'" 3
+[[ ! '[ "docker", "k8s" ]' =~ "\"${SELFHOSTED_MODE}\"" ]] && _error "illegal value '${SELFHOSTED_MODE}'" 2
 
 # Check dependencies
-check_deps
-
+_check_deps
 
 # ==================================================
 # main block
 # ==================================================
-# docker
-CARTO_ENV="${FILE_DIR}/customer.env"
-CARTO_SA="${FILE_DIR}/key.json"
-# k8s
-CARTO_VALUES="${FILE_DIR}/carto-values.yaml"
-CARTO_SECRETS="${FILE_DIR}/carto-secrets.yaml"
+
+_info "selfhosted mode: ${SELFHOSTED_MODE}"
+
 # global
 CUSTOMER_PACKAGE_NAME_PREFIX="carto-selfhosted-${SELFHOSTED_MODE}-customer-package"
 
-# Validate selfhosted mode
-if [ "$(echo "${SELFHOSTED_MODE}" | grep -E "docker|k8s")" == "" ]; then
-  echo -e "\n[ERROR]: available selfhosted modes: k8s or docker\n"
-  usage
-  exit 1
-fi
-
-# Check that required files exist
-if [ "${SELFHOSTED_MODE}" = "k8s" ]; then
-  check_input_files "${CARTO_VALUES}"
-  check_input_files "${CARTO_SECRETS}"
-fi
-if [ "${SELFHOSTED_MODE}" = "docker" ]; then
-  check_input_files "${CARTO_ENV}"
-  check_input_files "${CARTO_SA}"
-fi
-
-# Get information from YAML files (k8s) or customer.env file (docker)
-if [ "${SELFHOSTED_MODE}" = "k8s" ]; then
+if [ "${SELFHOSTED_MODE}" == "docker" ] ; then
+  # Check that required files exist
+  CARTO_ENV="${FILE_DIR}/customer.env"
+  CARTO_SA="${FILE_DIR}/key.json"
+  ENV_SOURCE="$(basename "${CARTO_ENV}")"
+  _check_input_files "${CARTO_ENV}"
+  _check_input_files "${CARTO_SA}"
+  # Get information from customer.env file (docker)
+  # shellcheck disable=SC1090
+  source "${CARTO_ENV}"
+  cp "${CARTO_SA}" "${CARTO_SERVICE_ACCOUNT_FILE}"
+  CLIENT_STORAGE_BUCKET="${WORKSPACE_IMPORTS_BUCKET}"
+  TENANT_ID="${SELFHOSTED_TENANT_ID}"
+  CLIENT_ID="${TENANT_ID/#onp-}" # Remove onp- prefix
+  SELFHOSTED_VERSION_CURRENT="${CARTO_SELFHOSTED_CUSTOMER_PACKAGE_VERSION}"
+elif [ "${SELFHOSTED_MODE}" == "k8s" ] ; then
+  # Check that required files exist
+  CARTO_VALUES="${FILE_DIR}/carto-values.yaml"
+  CARTO_SECRETS="${FILE_DIR}/carto-secrets.yaml"
+  ENV_SOURCE="$(basename "${CARTO_VALUES}")"
+  _check_input_files "${CARTO_VALUES}"
+  _check_input_files "${CARTO_SECRETS}"
+  # Get information from YAML files (k8s)
   yq ".cartoSecrets.defaultGoogleServiceAccount.value" < "${CARTO_SECRETS}" | \
     grep -v "^$" > "${CARTO_SERVICE_ACCOUNT_FILE}"
   CLIENT_STORAGE_BUCKET=$(yq -r ".appConfigValues.workspaceImportsBucket" < "${CARTO_VALUES}")
@@ -131,37 +144,33 @@ if [ "${SELFHOSTED_MODE}" = "k8s" ]; then
   SELFHOSTED_VERSION_CURRENT=$(yq -r ".cartoConfigValues.customerPackageVersion" < "${CARTO_VALUES}") 
 fi
 
-# shellcheck disable=SC1090
-if [ "${SELFHOSTED_MODE}" = "docker" ]; then
-  source "${CARTO_ENV}"
-  cp "${CARTO_SA}" "${CARTO_SERVICE_ACCOUNT_FILE}"
-  CLIENT_STORAGE_BUCKET="${WORKSPACE_IMPORTS_BUCKET}"
-  TENANT_ID="${SELFHOSTED_TENANT_ID}"
-  CLIENT_ID="${TENANT_ID/#onp-}" # Remove onp- prefix
-  SELFHOSTED_VERSION_CURRENT="${CARTO_SELFHOSTED_CUSTOMER_PACKAGE_VERSION}"
-fi
-
 # Get information from JSON service account file
 CARTO_SERVICE_ACCOUNT_EMAIL=$(jq -r ".client_email" < "${CARTO_SERVICE_ACCOUNT_FILE}")
 CARTO_GCP_PROJECT=$(jq -r ".project_id" < "${CARTO_SERVICE_ACCOUNT_FILE}")
 
 # Download the latest customer package
-gcloud auth activate-service-account "${CARTO_SERVICE_ACCOUNT_EMAIL}" \
-  --key-file="${CARTO_SERVICE_ACCOUNT_FILE}" \
-  --project="${CARTO_GCP_PROJECT}"
+STEP="activating: service account credentials for: [${CARTO_SERVICE_ACCOUNT_EMAIL}]"
+if ( gcloud auth activate-service-account "${CARTO_SERVICE_ACCOUNT_EMAIL}" --key-file="${CARTO_SERVICE_ACCOUNT_FILE}" --project="${CARTO_GCP_PROJECT}" &>/dev/null ) ; then
+  _success "${STEP}" ; else _error "${STEP}"
+fi
 
 # Get latest customer package version
 CUSTOMER_PACKAGE_FILE_LATEST=$(gsutil ls "gs://${CLIENT_STORAGE_BUCKET}/${CUSTOMER_PACKAGE_FOLDER}/${CUSTOMER_PACKAGE_NAME_PREFIX}-${CLIENT_ID}-*-*-*.zip")
-SELFHOSTED_VERSION_LATEST=$(echo "${CUSTOMER_PACKAGE_FILE_LATEST}" | grep -Eo "[0-9]+-[0-9]+-[0-9]+")
+SELFHOSTED_VERSION_LATEST=$(echo "${CUSTOMER_PACKAGE_FILE_LATEST}" | grep -Eo "${CLIENT_ID}-[0-9]+-[0-9]+-[0-9]+")
+SELFHOSTED_VERSION_LATEST="${SELFHOSTED_VERSION_LATEST/#${CLIENT_ID}-}"
 
 # Download package
-gsutil cp \
-  "gs://${CLIENT_STORAGE_BUCKET}/${CUSTOMER_PACKAGE_FOLDER}/${CUSTOMER_PACKAGE_NAME_PREFIX}-${CLIENT_ID}-${SELFHOSTED_VERSION_LATEST}.zip" .
+STEP="downloading: $(basename "${CUSTOMER_PACKAGE_FILE_LATEST}")"
+if ( gsutil cp "gs://${CLIENT_STORAGE_BUCKET}/${CUSTOMER_PACKAGE_FOLDER}/${CUSTOMER_PACKAGE_NAME_PREFIX}-${CLIENT_ID}-${SELFHOSTED_VERSION_LATEST}.zip" ./ ) ; then
+  _success "${STEP}" ; else _error "${STEP}"
+fi
 
 # Print message
 echo -e "\n##############################################################"
-echo -e "Current selfhosted version in [carto-values.yaml]: ${SELFHOSTED_VERSION_CURRENT}"
+echo -e "Current selfhosted version in [${ENV_SOURCE}]: ${SELFHOSTED_VERSION_CURRENT}"
 echo -e "Latest selfhosted version downloaded: ${SELFHOSTED_VERSION_LATEST}"
 echo -e "Downloaded file: $(basename "${CUSTOMER_PACKAGE_FILE_LATEST}")"
 echo -e "Downloaded from: ${CUSTOMER_PACKAGE_FILE_LATEST}"
 echo -e "##############################################################\n"
+
+_success "finished [$?]\n"


### PR DESCRIPTION
## Shortcut

- Story: https://app.shortcut.com/cartoteam/story/329603/fix-selfhosted-download-customer-package
- Autolink: [sc-329603]

## Description of the change

1. Make `carto-download-customer-package.sh` work when CLIENT_ID suffix ends with "`-<numbers>`"
2. Consolidate all actions required for docker/k8s in a single block
3. Add minor improvements for input validations, stdout messages and some functions
4. Abort execution on error providing feedback

## Applicable issues

  - fixes #329603
