### PR TITLE
:elephant: Add support for non-default Postgresql's postgres database and non-default port for self-hosted deployments

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -998,6 +998,13 @@ Add environment variables to configure database values
 {{/*
 Add environment variables to configure database values
 */}}
+{{- define "carto.postgresql.adminDatabase" -}}
+{{- ternary "postgres" .Values.externalPostgresql.adminDatabase .Values.internalPostgresql.enabled | quote -}}
+{{- end -}}
+
+{{/*
+Add environment variables to configure database values
+*/}}
 {{- define "carto.postgresql.databaseName" -}}
 {{- ternary .Values.internalPostgresql.auth.database .Values.externalPostgresql.database .Values.internalPostgresql.enabled | quote -}}
 {{- end -}}

--- a/chart/templates/workspace-api/deployment.yaml
+++ b/chart/templates/workspace-api/deployment.yaml
@@ -103,6 +103,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "carto.postgresql.secretName" . }}
                   key: {{ include "carto.postgresql.secret.adminKey" . }}
+            - name: POSTGRES_ADMIN_DB
+              value: {{ include "carto.postgresql.adminDatabase" . }}
             - name: WORKSPACE_POSTGRES_INTERNAL_USER
               value: {{ include "carto.postgresql.internalUser" . }}
             - name: WORKSPACE_POSTGRES_PASSWORD

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4448,6 +4448,7 @@ internalPostgresql:
 ## @param externalPostgresql.adminUser Database admin user (seen from outside the database)
 ## @param externalPostgresql.internalAdminUser Database admin user (seen from inside the database). If this value is not defined, `externalPostgresql.adminUser` is used.
 ## @param externalPostgresql.adminPassword Database admin password
+## @param externalPostgresql.adminDatabase Admin database to connect to create the CARTO database (usually postgres)
 ## @param externalPostgresql.existingSecret Name of an existing secret resource containing the DB password
 ## @param externalPostgresql.existingSecretPasswordKey Name of the key inside the secret containing the DB password
 ## @param externalPostgresql.existingSecretAdminPasswordKey Name of the key inside the secret containing the DB admin password
@@ -4464,6 +4465,7 @@ externalPostgresql:
   adminUser: postgres
   internalAdminUser: ""
   adminPassword: ""
+  adminDatabase: "postgres"
   existingSecret: ""
   existingSecretPasswordKey: ""
   existingSecretAdminPasswordKey: ""

--- a/customizations/README.md
+++ b/customizations/README.md
@@ -344,7 +344,11 @@ from the configuration, or let the chart to create the [secrets automatically](#
      --from-literal=admin-password=<password>
    ```
 
-> Note: `externalPostgresql.user` and `externalPostgresql.database` inside the Postgres instance are going to be created automatically during the installation process. Do not create then manually.
+> **Note**
+> The `externalPostgresql.user` and `externalPostgresql.database` inside the Postgres instance are going to be created automatically during the installation process. Do not create then manually.
+
+> **Note**
+> By default, CARTO will try to connect to the `postgres` database with the `postgres` user. If you want to use a different user, you can configure it via the `externalPostgresql.adminUser`, and `externalPostgresql.adminDatabase` parameters.
 
 2. Configure the package:
    Add the following lines to your `customizations.yaml` to connect to the external Postgres:

--- a/customizations/external_postgresql/customizations.yaml
+++ b/customizations/external_postgresql/customizations.yaml
@@ -6,6 +6,7 @@ externalPostgresql:
   password: ""
   adminUser: "postgres"
   adminPassword: ""
+  adminDatabase: "postgres"
   database: "workspace"
   port: "5432"
   sslEnabled: true


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/cartoteam/story/338514/allow-nondefault-root-database-and-admin-user-in-selfhosted-init-db-script

The default Postgresql's `postgres` database is hard-coded in the init-db (`workspace-migrator`) script, and so does the default port (5432). We are adding support for a custom root  database and port for this script