### PR TITLE
:bricks: Increase `maps-api` memory from 2500MB to 4096MB

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1587,7 +1587,7 @@ mapsApi:
   ##
   resources:
     limits:
-      memory: "2500Mi"
+      memory: "4096Mi"
       cpu: "2000m"
     requests:
       memory: "768Mi"


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/cartoteam/story/340678/increase-maps-api-memory-and-cpu-until-dynamictilingv1-is-deprecated

**Reason**

We need to increase maps-api resources until dynamicTilingV1 is fully deprecated or we reduce the load generated by featuresToBinary transformation

**Previous research**

https://app.shortcut.com/cartoteam/story/340417/investigate-oom-issues-with-maps-api-in-asia-tenant