### PR TITLE
📦 Add env vars for Google GenAI

### DIFF
--- a/chart/templates/workspace-www/configmap.yaml
+++ b/chart/templates/workspace-www/configmap.yaml
@@ -35,5 +35,6 @@ data:
   THUMBNAILS_BUCKET_EXTERNAL_URL: {{ .Values.appConfigValues.thumbnailsBucketExternalURL | quote }}
   REACT_APP_WORKSPACE_WWW_ENABLE_TRACKJS: {{ .Values.appConfigValues.enableTrackJS | quote }}
   REACT_APP_WORKSPACE_WWW_ENABLE_EXPORTS: "false"
+  REACT_APP_WORKSPACE_WWW_ENABLE_GENAI: "false"
   REACT_APP_ASKNICELY_MIN_HOURS_ACCOUNT_OLD_ENOUGH: "1920"
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Shortcut: https://app.shortcut.com/cartoteam/story/347069/generativeai-palm-api-key-request

- [x] Add env var for `workspace-www` - `REACT_APP_WORKSPACE_WWW_ENABLE_GENAI`
- [x] ~~Add env var for `workspace-api` - `GOOGLE_GENAI_API_KEY`~~ Not required as this feature is not enabled in self-hosted

Related PRs
- https://github.com/CartoDB/cloud-native/pull/13884