### PR TITLE
Use new bucket to download customer package

### DIFF
--- a/tools/carto-download-customer-package.sh
+++ b/tools/carto-download-customer-package.sh
@@ -154,8 +154,8 @@ fi
 # Get information from JSON service account file
 CARTO_SERVICE_ACCOUNT_EMAIL="$(jq -r ".client_email" < "${CARTO_SERVICE_ACCOUNT_FILE}")"
 
-# Use carto project GCP bucket for custoemr package
-CLIENT_STORAGE_BUCKET="${GCP_PROJECT_ID}-client-storage"
+# Use carto project GCP bucket for customer package
+CLIENT_STORAGE_BUCKET="${GCP_PROJECT_ID}-customer-package-storage"
 
 # Download the latest customer package
 STEP="activating: service account credentials for: [${CARTO_SERVICE_ACCOUNT_EMAIL}]"


### PR DESCRIPTION
**Description of the change**

We created a new bucket in the tenants project to store the customer package, so this change will make the download customer package script use the new bucket.