### PR TITLE
Add Kots config for high availability settings

### DIFF
--- a/manifests/kots-config.yaml
+++ b/manifests/kots-config.yaml
@@ -656,6 +656,30 @@ spec:
             repl{{ end }}
             repl{{ toJson $result }}
 
+        ## High Availability
+        - name: customHighAvailabilityConfig
+          title: High Availability
+          help_text: |-
+            Enable if you want to customize the high availability configuration.
+          type: bool
+          default: "0"
+        - name: highAvailabilityMinReplicas
+          title: Min replicas
+          when: '{{repl (ConfigOptionEquals "customHighAvailabilityConfig" "1") }}'
+          help_text: |-
+            Minimum number of replicas to be deployed for each component.
+          type: text
+          required: true
+          default: "2"
+        - name: highAvailabilityMaxReplicas
+          title: Max replicas
+          when: '{{repl (ConfigOptionEquals "customHighAvailabilityConfig" "1") }}'
+          help_text: |-
+            Maximum number of replicas to be deployed for each component.
+          type: text
+          required: true
+          default: "3"
+
         ## Tuning
         - name: enablePlatformAdvancedTuning
           title: Advanced Platform Tuning

--- a/manifests/kots-config.yaml
+++ b/manifests/kots-config.yaml
@@ -633,9 +633,10 @@ spec:
           type: textarea
           default: '{{repl LicenseFieldValue "cartoPlatformDefaultSA" }}'
         - name: cartoPlatformWorkloadIdentityEmail
+          title: CARTO Platform credentials
           type: text
           when: '{{repl (ConfigOptionEquals "enableGoogleWorkloadIdentity" "1") }}'
-          title: |-
+          help_text: |-
             As you enable the Google Workload Identity, this is the Service Account email that is going to be used by the Self-Hosted environment to access CARTO platform services.
             If you want to modify it, do in the Google Workload Identity section.
           readonly: true

--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -150,37 +150,37 @@ spec:
     # High Availability
     importApi:
       autoscaling:
-        enabled: true
+        enabled: repl{{ if ConfigOptionEquals "customHighAvailabilityConfig" "0"}}falserepl{{ else }}truerepl{{ end }}
         minReplicas: '{{repl ConfigOption "highAvailabilityMinReplicas" }}'
         maxReplicas: '{{repl ConfigOption "highAvailabilityMaxReplicas" }}'
     ldsApi:
       autoscaling:
-        enabled: true
+        enabled: repl{{ if ConfigOptionEquals "customHighAvailabilityConfig" "0"}}falserepl{{ else }}truerepl{{ end }}
         minReplicas: '{{repl ConfigOption "highAvailabilityMinReplicas" }}'
         maxReplicas: '{{repl ConfigOption "highAvailabilityMaxReplicas" }}'
     mapsApi:
       autoscaling:
-        enabled: true
+        enabled: repl{{ if ConfigOptionEquals "customHighAvailabilityConfig" "0"}}falserepl{{ else }}truerepl{{ end }}
         minReplicas: '{{repl ConfigOption "highAvailabilityMinReplicas" }}'
         maxReplicas: '{{repl ConfigOption "highAvailabilityMaxReplicas" }}'
     router:
       autoscaling:
-        enabled: true
+        enabled: repl{{ if ConfigOptionEquals "customHighAvailabilityConfig" "0"}}falserepl{{ else }}truerepl{{ end }}
         minReplicas: '{{repl ConfigOption "highAvailabilityMinReplicas" }}'
         maxReplicas: '{{repl ConfigOption "highAvailabilityMaxReplicas" }}'
     workspaceApi:
       autoscaling:
-        enabled: true
+        enabled: repl{{ if ConfigOptionEquals "customHighAvailabilityConfig" "0"}}falserepl{{ else }}truerepl{{ end }}
         minReplicas: '{{repl ConfigOption "highAvailabilityMinReplicas" }}'
         maxReplicas: '{{repl ConfigOption "highAvailabilityMaxReplicas" }}'
     workspaceWww:
       autoscaling:
-        enabled: true
+        enabled: repl{{ if ConfigOptionEquals "customHighAvailabilityConfig" "0"}}falserepl{{ else }}truerepl{{ end }}
         minReplicas: '{{repl ConfigOption "highAvailabilityMinReplicas" }}'
         maxReplicas: '{{repl ConfigOption "highAvailabilityMaxReplicas" }}'
     accountsWww:
       autoscaling:
-        enabled: true
+        enabled: repl{{ if ConfigOptionEquals "customHighAvailabilityConfig" "0"}}falserepl{{ else }}truerepl{{ end }}
         minReplicas: '{{repl ConfigOption "highAvailabilityMinReplicas" }}'
         maxReplicas: '{{repl ConfigOption "highAvailabilityMaxReplicas" }}'
 

--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -147,6 +147,42 @@ spec:
       service:
         type: LoadBalancer
 
+    # High Availability
+    importApi:
+      autoscaling:
+        enabled: true
+        minReplicas: '{{repl ConfigOption "highAvailabilityMinReplicas" }}'
+        maxReplicas: '{{repl ConfigOption "highAvailabilityMaxReplicas" }}'
+    ldsApi:
+      autoscaling:
+        enabled: true
+        minReplicas: '{{repl ConfigOption "highAvailabilityMinReplicas" }}'
+        maxReplicas: '{{repl ConfigOption "highAvailabilityMaxReplicas" }}'
+    mapsApi:
+      autoscaling:
+        enabled: true
+        minReplicas: '{{repl ConfigOption "highAvailabilityMinReplicas" }}'
+        maxReplicas: '{{repl ConfigOption "highAvailabilityMaxReplicas" }}'
+    router:
+      autoscaling:
+        enabled: true
+        minReplicas: '{{repl ConfigOption "highAvailabilityMinReplicas" }}'
+        maxReplicas: '{{repl ConfigOption "highAvailabilityMaxReplicas" }}'
+    workspaceApi:
+      autoscaling:
+        enabled: true
+        minReplicas: '{{repl ConfigOption "highAvailabilityMinReplicas" }}'
+        maxReplicas: '{{repl ConfigOption "highAvailabilityMaxReplicas" }}'
+    workspaceWww:
+      autoscaling:
+        enabled: true
+        minReplicas: '{{repl ConfigOption "highAvailabilityMinReplicas" }}'
+        maxReplicas: '{{repl ConfigOption "highAvailabilityMaxReplicas" }}'
+    accountsWww:
+      autoscaling:
+        enabled: true
+        minReplicas: '{{repl ConfigOption "highAvailabilityMinReplicas" }}'
+        maxReplicas: '{{repl ConfigOption "highAvailabilityMaxReplicas" }}'
 
   # Values from Advanced Configuration
   optionalValues:


### PR DESCRIPTION
**Description of the change**
Add Kots config for hight availability settings. From now on we'll be able to define the min/max number of instances for the pods running in k8s.