### PR TITLE
Activate data synchronizing between SH and Accounts

### DIFF
--- a/chart/templates/workspace-subscriber/configmap.yaml
+++ b/chart/templates/workspace-subscriber/configmap.yaml
@@ -39,6 +39,7 @@ data:
   PUBSUB_PROJECT_ID: {{ .Values.cartoConfigValues.selfHostedGcpProjectId | quote }}
   SELFHOSTED_GCP_PROJECT_ID: {{ .Values.cartoConfigValues.selfHostedGcpProjectId | quote }}
   WORKSPACE_ERROR_RESPONSE_STACK_TRACE: {{ .Values.cartoConfigValues.enableErrorResponseStackTrace | quote }}
+  WORKSPACE_SYNC_DATA_ENABLED: "true"
   WORKSPACE_IMPORTS_BUCKET: {{ .Values.appConfigValues.workspaceImportsBucket | quote }}
   WORKSPACE_POSTGRES_DB: {{ include "carto.postgresql.databaseName" . }}
   WORKSPACE_POSTGRES_HOST: {{ include "carto.postgresql.host" . }}


### PR DESCRIPTION
**Description of the change**
With this change, we'll enable the data synchronizing between a SH installation and our Accounts part. Each time that the workspace subscriber is started, we'll check if there is any pending change to be done.