### PR TITLE
Add needed values for enabling https/http access in embedded cluster

### DIFF
--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -154,10 +154,13 @@ spec:
       customPrivateKeyValue: '{{repl ConfigOption "accessToSHCustomTLSTerminationKeyFile" }}'
       generateManagedCerts: repl{{ if ConfigOptionEquals "accessToCartoDefaultAccessCertificates" "tls_managed_certificates"}}truerepl{{ else }}falserepl{{ end }}
 
-    ## Access to Carto
+    ## Access to Carto in embedded cluster
     router:
       service:
-        type: LoadBalancer
+        type: NodePort
+        nodePorts:
+          http: '80'
+          https: '443'
 
   # Values from Advanced Configuration
   optionalValues:


### PR DESCRIPTION
These are the only needed values that should be configured to allow the access via HTTP/HTTPS ports in an embedded cluster 😄 

You'll also have to apply the following custom config to the installation:

```
apiVersion: embeddedcluster.replicated.com/v1beta1
kind: Config
spec:
  version: 1.28.6+ec.0
  unsupportedOverrides:
    k0s: |
      config:
        spec:
          api:
            extraArgs:
              service-node-port-range: 80-443
```

Just create a `config.yaml` file and install the embedded cluster in your machine using the following command:

```
./carto install --overrrides ./config.yaml
```