### PR TITLE
Feature/openshift deploy

### DIFF
--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -174,6 +174,9 @@ Return common analyzers for preflights and support-bundle
         - pass:
             when: "== aks"
             message: AKS is a supported distribution.
+        - pass:
+            when: "== openShift"
+            message: OpenShift is a supported distribution.
         # Will be supported in the future
         - pass:
             when: "== k0s"

--- a/manifests/kots-config.yaml
+++ b/manifests/kots-config.yaml
@@ -838,6 +838,14 @@ spec:
           required: true
           type: text
 
+        ## OpenShift cluster deploy
+        - name: isOpenShiftCluster
+          title: OpenShift Cluster Deploy
+          when: '{{repl (ConfigOptionEquals "isOpenShiftCluster" "true") }}'
+          default: false
+          hidden: true
+          type: text
+
         ## Carto Platform Credentials
         - name: cartoPlatformGoogleSA
           title: CARTO Platform credentials

--- a/manifests/kots-config.yaml
+++ b/manifests/kots-config.yaml
@@ -840,9 +840,9 @@ spec:
 
         ## OpenShift cluster deploy
         - name: isOpenShiftCluster
-          title: OpenShift Cluster Deploy
+          title: OpenShift cluster deploy
           help_text: |-
-            Enable if you want to deploy in OpenShift.
+            Enable if you want to deploy in OpenShift cluster.
           type: bool
           default: "0"
 

--- a/manifests/kots-config.yaml
+++ b/manifests/kots-config.yaml
@@ -841,10 +841,10 @@ spec:
         ## OpenShift cluster deploy
         - name: isOpenShiftCluster
           title: OpenShift Cluster Deploy
-          when: '{{repl (ConfigOptionEquals "isOpenShiftCluster" "true") }}'
-          default: false
-          hidden: true
-          type: text
+          help_text: |-
+            Enable if you want to deploy in OpenShift.
+          type: bool
+          default: "0"
 
         ## Carto Platform Credentials
         - name: cartoPlatformGoogleSA

--- a/manifests/kots-config.yaml
+++ b/manifests/kots-config.yaml
@@ -838,14 +838,6 @@ spec:
           required: true
           type: text
 
-        ## OpenShift cluster deploy
-        - name: isOpenShiftCluster
-          title: OpenShift cluster deploy
-          help_text: |-
-            Enable if you want to deploy in OpenShift cluster.
-          type: bool
-          default: "0"
-
         ## Carto Platform Credentials
         - name: cartoPlatformGoogleSA
           title: CARTO Platform credentials

--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -357,3 +357,32 @@ spec:
     - when: '{{repl not (empty (ConfigOption "platformAdvancedTuningValues")) }}'
       recursiveMerge: true
       values: repl{{ ConfigOption "platformAdvancedTuningValues" | nindent 8 }}
+
+    ## Openshift
+    - when: '{{repl ConfigOptionEquals "isOpenShiftCluster" "true" }}'
+      recursiveMerge: true
+      values:
+        accountsWww: &customSecurityContext
+          # By not explicitly setting PodSecurityContext and ContainerSecurityContext
+          #   OpenShift sets a random uid (1000700000/10000) with permissions
+          podSecurityContext:
+            enabled: false
+          containerSecurityContext:
+            enabled: false
+        importApi: *customSecurityContext
+        importWorker: *customSecurityContext
+        ldsApi: *customSecurityContext
+        mapsApi: *customSecurityContext
+        sqlWorker: *customSecurityContext
+        router: *customSecurityContext
+        routerMetrics: *customSecurityContext
+        httpCache: *customSecurityContext
+        notifier: *customSecurityContext
+        cdnInvalidatorSub: *customSecurityContext
+        workspaceApi: *customSecurityContext
+        workspaceSubscriber: *customSecurityContext
+        workspaceWww: *customSecurityContext
+        workspaceMigrations: *customSecurityContext
+        tenantRequirementsChecker: *customSecurityContext
+        internalPostgresql: *customSecurityContext
+        upgradeCheck: *customSecurityContext

--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -359,7 +359,7 @@ spec:
       values: repl{{ ConfigOption "platformAdvancedTuningValues" | nindent 8 }}
 
     ## Openshift
-    - when: '{{repl ConfigOptionEquals "isOpenShiftCluster" "1" }}'
+    - when: '{{repl ConfigOptionEquals "platformDistribution" "openShift" }}'
       recursiveMerge: true
       values:
         accountsWww: &customSecurityContext

--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -359,7 +359,7 @@ spec:
       values: repl{{ ConfigOption "platformAdvancedTuningValues" | nindent 8 }}
 
     ## Openshift
-    - when: '{{repl ConfigOptionEquals "isOpenShiftCluster" "true" }}'
+    - when: '{{repl ConfigOptionEquals "isOpenShiftCluster" "1" }}'
       recursiveMerge: true
       values:
         accountsWww: &customSecurityContext

--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -181,6 +181,13 @@ spec:
   # Optional Values
   ## Values from Advanced Configuration
   optionalValues:
+    ## Temporal fix to change routerMetrics image until next release
+    - when: 'true'
+      recursiveMerge: true
+      values:
+        routerMetrics:
+          image:
+            tag: fix_nonroot_router_metrics
     ## BigQuery exports
     - when: '{{repl not (empty (ConfigOption "storageBucketsExportGcp"))}}'
       recursiveMerge: true


### PR DESCRIPTION
**Description of the change**

# Description

Enable installation in OpenShift

## router-metrics working with changes: https://github.com/CartoDB/cloud-native/pull/15820
```
20-carto-templates.sh: Running dockerize -template on /usr/share/logstash/templates/pipeline/pipeline-logstash.conf.tmpl to /usr/share/logstash/pipeline/pipeline-logstash.conf
20-carto-templates.sh: Running dockerize -template on /usr/share/logstash/templates/config/logstash.yml.tmpl to /usr/share/logstash/config/logstash.yml
Using bundled JDK: /usr/share/logstash/jdk
Sending Logstash logs to /usr/share/logstash/logs which is now configured via log4j2.properties
[2024-03-18T13:50:24,290][INFO ][logstash.runner          ] Log4j configuration path used is: /usr/share/logstash/config/log4j2.properties
[2024-03-18T13:50:24,375][INFO ][logstash.runner          ] Starting Logstash {"logstash.version"=>"8.6.0", "jruby.version"=>"jruby 9.3.8.0 (2.6.8) 2022-09-13 98d69c9461 OpenJDK 64-Bit Server VM 17.0.5+8 on 17.0.5+8 +indy +jit [x86_64-linux]"}
[2024-03-18T13:50:24,378][INFO ][logstash.runner          ] JVM bootstrap flags: [-Xms1g, -Xmx1g, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djruby.compile.invokedynamic=true, -XX:+HeapDumpOnOutOfMemoryError, -Djava.security.egd=file:/dev/urandom, -Dlog4j2.isThreadContextMapInheritable=true, -Xms512m, -Xmx1024m, -Djruby.regexp.interruptible=true, -Djdk.io.File.enableADS=true, --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED, --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED, --add-opens=java.base/java.security=ALL-UNNAMED, --add-opens=java.base/java.io=ALL-UNNAMED, --add-opens=java.base/java.nio.channels=ALL-UNNAMED, --add-opens=java.base/sun.nio.ch=ALL-UNNAMED, --add-opens=java.management/sun.management=ALL-UNNAMED]
[2024-03-18T13:50:24,390][INFO ][logstash.settings        ] Creating directory {:setting=>"path.queue", :path=>"/usr/share/logstash/data/queue"}
[2024-03-18T13:50:24,392][INFO ][logstash.settings        ] Creating directory {:setting=>"path.dead_letter_queue", :path=>"/usr/share/logstash/data/dead_letter_queue"}
[2024-03-18T13:50:25,677][INFO ][logstash.agent           ] No persistent UUID file found. Generating new UUID {:uuid=>"6868a2f1-3c88-414d-bb92-f6f22474bc0f", :path=>"/usr/share/logstash/data/uuid"}
[2024-03-18T13:50:29,883][INFO ][logstash.agent           ] Successfully started Logstash API endpoint {:port=>9600, :ssl_enabled=>false}
[2024-03-18T13:50:37,981][INFO ][org.reflections.Reflections] Reflections took 990 ms to scan 1 urls, producing 127 keys and 444 values
[2024-03-18T13:50:42,282][INFO ][logstash.codecs.json     ] ECS compatibility is enabled but `target` option was not specified. This may cause fields to be set at the top-level of the event where they are likely to clash with the Elastic Common Schema. It is recommended to set the `target` option to avoid potential schema conflicts (if your data is ECS compliant or non-conflicting, feel free to ignore this message)
[2024-03-18T13:50:43,091][INFO ][logstash.javapipeline    ] Pipeline `main` is configured with `pipeline.ecs_compatibility: v8` setting. All plugins in this pipeline will default to `ecs_compatibility => v8` unless explicitly configured otherwise.
[2024-03-18T13:50:43,178][INFO ][logstash.outputs.googlepubsub][main] Registering Google PubSub Output plugin: projects/carto-tnt-onp-jmtd-customer/topics/data-updates
[2024-03-18T13:50:43,279][INFO ][logstash.outputs.googlepubsub][main] Initializing Google API client on projects/carto-tnt-onp-jmtd-customer/topics/data-updates key: /usr/src/certs/gcp-default-service-account/key.json
[2024-03-18T13:50:48,983][INFO ][logstash.filters.json    ][main] ECS compatibility is enabled but `target` option was not specified. This may cause fields to be set at the top-level of the event where they are likely to clash with the Elastic Common Schema. It is recommended to set the `target` option to avoid potential schema conflicts (if your data is ECS compliant or non-conflicting, feel free to ignore this message)
[2024-03-18T13:50:48,985][WARN ][logstash.javapipeline    ][main] 'pipeline.ordered' is enabled and is likely less efficient, consider disabling if preserving event order is not necessary
[2024-03-18T13:50:49,178][INFO ][logstash.javapipeline    ][main] Starting pipeline {:pipeline_id=>"main", "pipeline.workers"=>1, "pipeline.batch.size"=>125, "pipeline.batch.delay"=>50, "pipeline.max_inflight"=>125, "pipeline.sources"=>["/usr/share/logstash/pipeline/pipeline-logstash.conf"], :thread=>"#<Thread:0x503289fb@/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:131 run>"}
[2024-03-18T13:50:55,885][INFO ][logstash.javapipeline    ][main] Pipeline Java execution initialization time {"seconds"=>6.71}
[2024-03-18T13:50:55,890][WARN ][logstash.filters.grok    ][main] ECS v8 support is a preview of the unreleased ECS v8, and uses the v1 patterns. When Version 8 of the Elastic Common Schema becomes available, this plugin will need to be updated
[2024-03-18T13:50:56,779][INFO ][logstash.javapipeline    ][main] Pipeline started {"pipeline.id"=>"main"}
[2024-03-18T13:50:56,786][INFO ][logstash.inputs.syslog   ][main][e0455bd0125194be71649c6d6bba59d3727915d66dd3db5711a3b719beafc928] Starting syslog udp listener {:address=>"0.0.0.0:5447"}
[2024-03-18T13:50:56,786][INFO ][logstash.inputs.syslog   ][main][e0455bd0125194be71649c6d6bba59d3727915d66dd3db5711a3b719beafc928] Starting syslog tcp listener {:address=>"0.0.0.0:5447"}
[2024-03-18T13:50:56,982][INFO ][logstash.agent           ] Pipelines running {:count=>1, :running_pipelines=>[:main], :non_running_pipelines=>[]}
```

## Shortcut

- Story: https://app.shortcut.com/cartoteam/story/385025/test-on-openshift
- Autolink: [sc-385025]

## Type of change

- [x] Feature
