### PR TITLE
fix proxy connection string

### DIFF
--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -289,7 +289,8 @@ spec:
       values:
         externalProxy:
           enabled: true
-          connectionString: '{{repl ConfigOption "externalProxyHost" }}'
+          type: '{{repl ConfigOption "externalProxyType" }}'
+          host: '{{repl ConfigOption "externalProxyHost" }}'
           excludedDomains: '{{repl ConfigOption "externalProxyExcludedDomains" }}'
           sslRejectUnauthorized: repl{{ if ConfigOptionEquals "externalHttpsProxySslCertificateCheck" "0"}}falserepl{{ else }}truerepl{{ end }}
           sslCA: |


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

- Proxy connection string should be with `<protocol>://<host>:<port>` by default
- We should be able to override this value with the parameter `externalProxy.connectionString`
**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->