### PR TITLE
delete old proxy env vars in replicated sdk

### DIFF
--- a/manifests/kots-app.yaml
+++ b/manifests/kots-app.yaml
@@ -23,7 +23,7 @@ spec:
     - deployment/carto-workspace-api
     - deployment/carto-workspace-subscriber
     - deployment/carto-workspace-www
-  minKotsVersion: 1.107.4
+  minKotsVersion: 1.117.1
   additionalImages:
     - gcr.io/carto-onprem-artifacts/tenant-requirements-checker:2024.4.17-rc.7
 ---

--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -358,14 +358,6 @@ spec:
           sslRejectUnauthorized: repl{{ if ConfigOptionEquals "externalHttpsProxySslCertificateCheck" "0"}}falserepl{{ else }}truerepl{{ end }}
           sslCA: |
             repl{{ ConfigOptionData "externalHttpsProxySslCa" | nindent 12 }}
-        replicated:
-          extraEnv:
-            - name: HTTP_PROXY
-              value: '{{repl ConfigOption "externalProxyHost" }}'
-            - name: HTTPS_PROXY
-              value: '{{repl ConfigOption "externalProxyHost" }}'
-            - name: NO_PROXY
-              value: '{{repl ConfigOption "externalProxyExcludedDomains" }}'
     - when: '{{repl ConfigOptionEquals "ssoEnabled" "1"}}'
       recursiveMerge: true
       values:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

**Description of the change**

The values provided to the `--http-proxy`, `--https-proxy`, and `--no-proxy` flags for the kots install command are now propagated to the Replicated SDK, so there is no need to add them manually.


