### PR TITLE
Add logLevel option to the Helm chart values

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -52,6 +52,7 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `appConfigValues.ldsGeocodingProvider`                             | The default LDS provider for geocoding                                                                                 | `""`                   |
 | `appConfigValues.ldsRoutingProvider`                               | The default LDS provider for routing                                                                                   | `""`                   |
 | `appConfigValues.ldsIsolineProvider`                               | The default LDS provider for isolines                                                                                  | `""`                   |
+| `appConfigValues.logLevel`                                         | The log level used in CARTO application                                                                                | `info`                 |
 
 ### CARTO Replicated parameters
 

--- a/chart/templates/_validators.tpl
+++ b/chart/templates/_validators.tpl
@@ -21,12 +21,23 @@ If internalPostgresql.enabled=false you need to specify the host of an external 
 {{- end -}}
 
 {{/*
+Validate log level
+*/}}
+{{- define "carto.validateValues.logLevel" -}}
+{{- $validLevels := list "info" "debug" "error" -}}
+{{- if not (has $validLevels .Values.appConfigValues.logLevel) -}}
+{{- printf "Invalid logLevel: %s. Must be one of %v" .Values.appConfigValues.logLevel $validLevels -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Compile all warnings into a single message, and call fail.
 */}}
 {{- define "carto.validateValues" -}}
 {{- $messages := list -}}
 {{- $messages := append $messages (include "carto.validateValues.redis" .) -}}
 {{- $messages := append $messages (include "carto.validateValues.postgresql" .) -}}
+{{- $messages := append $messages (include "carto.validateValues.logLevel" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 

--- a/chart/templates/_validators.tpl
+++ b/chart/templates/_validators.tpl
@@ -25,7 +25,7 @@ Validate log level
 */}}
 {{- define "carto.validateValues.logLevel" -}}
 {{- $validLevels := list "info" "debug" "error" -}}
-{{- if not (has $validLevels .Values.appConfigValues.logLevel) -}}
+{{- if not (has .Values.appConfigValues.logLevel $validLevels) -}}
 {{- printf "Invalid logLevel: %s. Must be one of %v" .Values.appConfigValues.logLevel $validLevels -}}
 {{- end -}}
 {{- end -}}

--- a/chart/templates/accounts-www/configmap.yaml
+++ b/chart/templates/accounts-www/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
 data:
   CARTO_DATA_WAREHOUSE_ENABLED: {{ .Values.cartoConfigValues.cartoDataWarehouseEnabled | quote }}
   CARTO_SELFHOSTED_VERSION: {{ .Chart.AppVersion | quote }}
-  LOG_LEVEL: "debug"
+  LOG_LEVEL: {{ .Values.appConfigValues.logLevel | quote }}
   PORT: {{ .Values.accountsWww.containerPorts.http | quote }}
   REACT_APP_ACCOUNTS_API_URL: "https://{{ .Values.cartoConfigValues.cartoAccApiDomain }}"
   REACT_APP_ACCOUNTS_URL: "https://{{ .Values.appConfigValues.selfHostedDomain }}/acc/"

--- a/chart/templates/http-cache/configmap.yaml
+++ b/chart/templates/http-cache/configmap.yaml
@@ -16,6 +16,7 @@ data:
   VARNISH_WORKSPACE_API_INTERNAL_URL: {{ include "carto.workspaceApi.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
   VARNISH_PURGE_ALLOWED_IPS: "0.0.0.0/0"
   VARNISH_REPORT_BASIC_INFORMATION_HEADERS: "true"
+  VARNISH_LOG_LEVEL: {{ .Values.appConfigValues.logLevel | quote }}
   {{- if .Values.httpCache.resources.requests }}
   {{- if .Values.httpCache.resources.requests.memory }}
   VARNISH_SIZE: {{ ( div ( mul ( ( .Values.httpCache.resources.requests.memory ) | replace "Mi" "" | atoi ) 75 ) 100 ) | toString | printf "%sM" | quote }}

--- a/chart/templates/import-api/configmap.yaml
+++ b/chart/templates/import-api/configmap.yaml
@@ -19,13 +19,16 @@ data:
   CARTO_SELFHOSTED_REPLICATED_SDK_DOMAIN: "replicated.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3000"
   {{- end }}
   CARTO_SELFHOSTED_VERSION: {{ .Chart.AppVersion | quote }}
+  {{- if eq .Values.appConfigValues.logLevel "debug" }}
+  CARTO_TRACING_MODE: "local"
+  {{- end }}
   IMPORT_ERROR_RESPONSE_STACK_TRACE: {{ .Values.cartoConfigValues.enableErrorResponseStackTrace | quote }}
   IMPORT_PORT: {{ .Values.importApi.containerPorts.http | quote }}
   IMPORT_PUBSUB_TENANT_BUS_SUBSCRIPTION: "projects/{{ .Values.cartoConfigValues.selfHostedGcpProjectId }}/subscriptions/tenant-bus-import-sub"
   IMPORT_PUBSUB_TENANT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.selfHostedGcpProjectId }}/topics/tenant-bus"
   IMPORT_TENANT_ID: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
   IMPORT_WORKER_PROCESSING_DIR: "/tmp/import-worker"
-  LOG_LEVEL: "debug"
+  LOG_LEVEL: {{ .Values.appConfigValues.logLevel | quote }}
   EVENT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.cartoAccGcpProjectId }}/topics/{{ .Values.cartoConfigValues.cartoAccGcpProjectRegion }}-event-bus"
   PUBSUB_PROJECT_ID: {{ .Values.cartoConfigValues.selfHostedGcpProjectId | quote }}
   {{- if not .Values.commonBackendServiceAccount.enableGCPWorkloadIdentity }}

--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -17,6 +17,9 @@ data:
   CARTO_SELFHOSTED_REPLICATED_SDK_DOMAIN: "replicated.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3000"
   {{- end }}
   CARTO_SELFHOSTED_VERSION: {{ .Chart.AppVersion | quote }}
+  {{- if eq .Values.appConfigValues.logLevel "debug" }}
+  CARTO_TRACING_MODE: "local"
+  {{- end }}
   {{- if not .Values.commonBackendServiceAccount.enableGCPWorkloadIdentity }}
   GOOGLE_APPLICATION_CREDENTIALS: {{ include "carto.google.secretMountAbsolutePath" . }}
   {{- end }}
@@ -25,7 +28,7 @@ data:
   IMPORT_PUBSUB_TENANT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.selfHostedGcpProjectId }}/topics/tenant-bus"
   IMPORT_TENANT_ID: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
   IMPORT_WORKER_PROCESSING_DIR: "/tmp/import-worker"
-  LOG_LEVEL: "debug"
+  LOG_LEVEL: {{ .Values.appConfigValues.logLevel | quote }}
   EVENT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.cartoAccGcpProjectId }}/topics/{{ .Values.cartoConfigValues.cartoAccGcpProjectRegion }}-event-bus"
   NODE_OPTIONS: {{ template "carto.importWorker.nodeOptions" . }}
   PUBSUB_PROJECT_ID: {{ .Values.cartoConfigValues.selfHostedGcpProjectId | quote }}

--- a/chart/templates/lds-api/configmap.yaml
+++ b/chart/templates/lds-api/configmap.yaml
@@ -16,6 +16,9 @@ data:
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
   CARTO_SELFHOSTED_VERSION: {{ .Chart.AppVersion | quote }}
+  {{- if eq .Values.appConfigValues.logLevel "debug" }}
+  CARTO_TRACING_MODE: "local"
+  {{- end }}
   {{- if not .Values.commonBackendServiceAccount.enableGCPWorkloadIdentity }}
   GOOGLE_APPLICATION_CREDENTIALS: {{ include "carto.google.secretMountAbsolutePath" . }}
   {{- end }}
@@ -23,7 +26,7 @@ data:
   EVENT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.cartoAccGcpProjectId }}/topics/{{ .Values.cartoConfigValues.cartoAccGcpProjectRegion }}-event-bus"
   LDS_ERROR_RESPONSE_STACK_TRACE: {{ .Values.cartoConfigValues.enableErrorResponseStackTrace | quote }}
   LDS_PORT: {{ .Values.ldsApi.containerPorts.http | quote }}
-  LOG_LEVEL: "debug"
+  LOG_LEVEL: {{ .Values.appConfigValues.logLevel | quote }}
   {{- if .Values.appConfigValues.ldsGeocodingProvider }}
   LDS_GEOCODING_PROVIDER: {{ .Values.appConfigValues.ldsGeocodingProvider }}
   {{- end }}

--- a/chart/templates/maps-api/configmap.yaml
+++ b/chart/templates/maps-api/configmap.yaml
@@ -23,6 +23,9 @@ data:
   CARTO_SELFHOSTED_REPLICATED_SDK_DOMAIN: "replicated.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3000"
   {{- end }}
   CARTO_SELFHOSTED_VERSION: {{ .Chart.AppVersion | quote }}
+  {{- if eq .Values.appConfigValues.logLevel "debug" }}
+  CARTO_TRACING_MODE: "local"
+  {{- end }}
   EVENT_BUS_PROJECT_ID: {{ .Values.cartoConfigValues.cartoAccGcpProjectId | quote }}
   EVENT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.cartoAccGcpProjectId }}/topics/{{ .Values.cartoConfigValues.cartoAccGcpProjectRegion }}-event-bus"
   EXPORTS_GCS_BUCKET_NAME: {{ .Values.appConfigValues.workspaceExportsBucket | quote }}
@@ -35,7 +38,7 @@ data:
   {{- if not .Values.commonBackendServiceAccount.enableGCPWorkloadIdentity }}
   GOOGLE_APPLICATION_CREDENTIALS: {{ include "carto.google.secretMountAbsolutePath" . }}
   {{- end }}
-  LOG_LEVEL: "debug"
+  LOG_LEVEL: {{ .Values.appConfigValues.logLevel | quote }}
   MAPS_API_V3_ERROR_RESPONSE_STACK_TRACE: {{ .Values.cartoConfigValues.enableErrorResponseStackTrace | quote }}
   MAPS_API_V3_PORT: "{{ .Values.mapsApi.containerPorts.http }}"
   MAPS_API_V3_RESOURCE_URL_ALLOWED_HOSTS: {{ .Values.appConfigValues.selfHostedDomain | quote }}

--- a/chart/templates/sql-worker/configmap.yaml
+++ b/chart/templates/sql-worker/configmap.yaml
@@ -22,6 +22,9 @@ data:
   CARTO_SELFHOSTED_REPLICATED_SDK_DOMAIN: "replicated.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3000"
   {{- end }}
   CARTO_SELFHOSTED_VERSION: {{ .Chart.AppVersion | quote }}
+  {{- if eq .Values.appConfigValues.logLevel "debug" }}
+  CARTO_TRACING_MODE: "local"
+  {{- end }}
   EXPORTS_GCS_BUCKET_NAME: {{ .Values.appConfigValues.workspaceExportsBucket | quote }}
   EXPORTS_S3_BUCKET_NAME: {{ .Values.appConfigValues.awsExportBucket | quote }}
   EXPORTS_S3_BUCKET_REGION: {{ .Values.appConfigValues.awsExportBucketRegion | quote }}
@@ -29,7 +32,7 @@ data:
   {{- if not .Values.commonBackendServiceAccount.enableGCPWorkloadIdentity }}
   GOOGLE_APPLICATION_CREDENTIALS: {{ include "carto.google.secretMountAbsolutePath" . }}
   {{- end }}
-  LOG_LEVEL: "debug"
+  LOG_LEVEL: {{ .Values.appConfigValues.logLevel | quote }}
   EVENT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.cartoAccGcpProjectId }}/topics/{{ .Values.cartoConfigValues.cartoAccGcpProjectRegion }}-event-bus"
   MAPS_API_V3_COMPONENT_NAME: "sql-worker"
   MAPS_API_V3_ERROR_RESPONSE_STACK_TRACE: {{ .Values.cartoConfigValues.enableErrorResponseStackTrace | quote }}

--- a/chart/templates/support-bundle.yaml
+++ b/chart/templates/support-bundle.yaml
@@ -43,7 +43,7 @@ stringData:
             outcomes:
               - fail:
                   when: "false"
-                  message: The debug mode is not enabled. Please follow the [documentation](https://docs.carto.com/carto-self-hosted/maintenance/monitoring#enable-debug-mode-in-carto-self-hosted-deployment) to enable it!
+                  message: The debug mode is not enabled. Please follow the [documentation](https://docs.carto.com/carto-self-hosted/maintenance/monitoring#enable-debug-mode-in-carto-self-hosted-deployment) to enable it before sending the support bundle!
               - pass:
                   when: "true"
                   message: The debug mode is enabled.

--- a/chart/templates/support-bundle.yaml
+++ b/chart/templates/support-bundle.yaml
@@ -36,7 +36,7 @@ stringData:
       analyzers:
     {{- include "carto.replicated.commonChecks.analyzers" . | indent 6 }}
         - yamlCompare:
-            checkName: Debug mode enabled for CARTO Support
+            checkName: Enable debug mode for CARTO Support
             fileName: debug-level.yaml
             path: "logLevel"
             value: "debug"

--- a/chart/templates/support-bundle.yaml
+++ b/chart/templates/support-bundle.yaml
@@ -29,8 +29,24 @@ stringData:
               maxAge: 720h # 30*24
               maxLines: 10000
               maxBytes: 5000000
+        - data:
+            name: debug-level.yaml
+            data: |
+              logLevel: {{ .Values.appConfigValues.logLevel }}
       analyzers:
     {{- include "carto.replicated.commonChecks.analyzers" . | indent 6 }}
+        - yamlCompare:
+            checkName: Debug mode enabled for CARTO Support
+            fileName: debug-level.yaml
+            path: "logLevel"
+            value: "debug"
+            outcomes:
+              - fail:
+                  when: "false"
+                  message: The debug mode is not enabled. Please follow the [documentation](https://docs.carto.com/carto-self-hosted/maintenance/monitoring#enable-debug-mode-in-carto-self-hosted-deployment) to enable it!
+              - pass:
+                  when: "true"
+                  message: The debug mode is enabled.
         - yamlCompare:
             annotations:
               kots.io/installer: "true"

--- a/chart/templates/workspace-api/configmap.yaml
+++ b/chart/templates/workspace-api/configmap.yaml
@@ -29,13 +29,16 @@ data:
   {{- if .Values.replicated.enabled }}
   CARTO_SELFHOSTED_REPLICATED_SDK_DOMAIN: "replicated.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3000"
   {{- end }}
+  {{- if eq .Values.appConfigValues.logLevel "debug" }}
+  CARTO_TRACING_MODE: "local"
+  {{- end }}
   EVENT_BUS_PROJECT_ID: {{ .Values.cartoConfigValues.cartoAccGcpProjectId | quote }}
   EVENT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.cartoAccGcpProjectId }}/topics/{{ .Values.cartoConfigValues.cartoAccGcpProjectRegion }}-event-bus"
   EXPORTS_GCS_BUCKET_NAME: {{ .Values.appConfigValues.workspaceExportsBucket | quote }}
   {{- if not .Values.commonBackendServiceAccount.enableGCPWorkloadIdentity }}
   GOOGLE_APPLICATION_CREDENTIALS: {{ include "carto.google.secretMountAbsolutePath" . }}
   {{- end }}
-  LOG_LEVEL: "debug"
+  LOG_LEVEL: {{ .Values.appConfigValues.logLevel | quote }}
   NODE_OPTIONS: {{ template "carto.workspaceApi.nodeOptions" . }}
   PUBSUB_MODE: "pull"
   PUBSUB_PROJECT_ID: {{ .Values.cartoConfigValues.selfHostedGcpProjectId | quote }}

--- a/chart/templates/workspace-subscriber/configmap.yaml
+++ b/chart/templates/workspace-subscriber/configmap.yaml
@@ -25,6 +25,9 @@ data:
   {{- if .Values.replicated.enabled }}
   CARTO_SELFHOSTED_REPLICATED_SDK_DOMAIN: "replicated.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:3000"
   {{- end }}
+  {{- if eq .Values.appConfigValues.logLevel "debug" }}
+  CARTO_TRACING_MODE: "local"
+  {{- end }}
   COMPUTE_PUBSUB_DATA_UPDATES_SUBSCRIPTION: "projects/{{ .Values.cartoConfigValues.selfHostedGcpProjectId }}/subscriptions/data-updates-compute-sub"
   EVENT_BUS_PROJECT_ID: {{ .Values.cartoConfigValues.cartoAccGcpProjectId | quote }}
   EVENT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.cartoAccGcpProjectId }}/topics/{{ .Values.cartoConfigValues.cartoAccGcpProjectRegion }}-event-bus"
@@ -39,7 +42,7 @@ data:
   {{- if and .Values.externalRedis.tlsEnabled .Values.externalRedis.tlsCA }}
   REDIS_TLS_CA: {{ include "carto.redis.configMapMountAbsolutePath" . }}
   {{- end }}
-  LOG_LEVEL: "debug"
+  LOG_LEVEL: {{ .Values.appConfigValues.logLevel | quote }}
   PUBSUB_DATA_UPDATES_TOPICS_TEMPLATE: "projects/{project_id}/topics/data-updates"
   PUBSUB_MODE: "pull"
   PUBSUB_PROJECT_ID: {{ .Values.cartoConfigValues.selfHostedGcpProjectId | quote }}

--- a/chart/templates/workspace-www/configmap.yaml
+++ b/chart/templates/workspace-www/configmap.yaml
@@ -22,7 +22,7 @@ data:
   REACT_APP_BIGQUERY_OAUTH: "false"
   {{- end }}
   CARTO_SELFHOSTED_VERSION: {{ .Chart.AppVersion | quote }}
-  LOG_LEVEL: "debug"
+  LOG_LEVEL: {{ .Values.appConfigValues.logLevel | quote }}
   REACT_APP_ACCOUNTS_API_URL: "https://{{ .Values.cartoConfigValues.cartoAccApiDomain }}"
   REACT_APP_ACCOUNTS_URL: "https://{{ .Values.appConfigValues.selfHostedDomain }}/acc/"
   REACT_APP_API_BASE_URL: "https://{{ .Values.appConfigValues.selfHostedDomain }}/api"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -76,6 +76,8 @@ appConfigValues:
   ldsRoutingProvider: ""
   ## @param appConfigValues.ldsIsolineProvider The default LDS provider for isolines
   ldsIsolineProvider: ""
+  ## @param appConfigValues.logLevel The log level used in CARTO application
+  logLevel: "info"
 
 ## @section CARTO Replicated parameters
 ## Global configuration for installations using Replicated. If you change something from this section probably your self-hosted is going to stop working.

--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -188,13 +188,13 @@ spec:
   ## Values from Advanced Configuration
   optionalValues:
     ## TEMPORAL PATCHED IMAGES
-    - when: 'true'
-      recursiveMerge: true
-      values:
-        httpCache:
-          image:
-            registry: registry.self-hosted.carto.com/proxy/carto/gcr.io/carto-artifacts
-            tag: "feature_sc_457242_add_an_easier_approach_for_enabling_the_debug"
+    # - when: 'true'
+    #   recursiveMerge: true
+    #   values:
+    #     httpCache:
+    #       image:
+    #         registry: registry.self-hosted.carto.com/proxy/carto/gcr.io/carto-artifacts
+    #         tag: "feature_sc_457242_add_an_easier_approach_for_enabling_the_debug"
     #     httpCache:
     #       image:
     #         registry: registry.self-hosted.carto.com/proxy/carto/gcr.io/carto-artifacts

--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -188,13 +188,13 @@ spec:
   ## Values from Advanced Configuration
   optionalValues:
     ## TEMPORAL PATCHED IMAGES
-    # - when: 'true'
-    #   recursiveMerge: true
-    #   values:
-    #     routerMetrics:
-    #       image:
-    #         registry: registry.self-hosted.carto.com/proxy/carto/gcr.io/carto-artifacts
-    #         tag: "latest"
+    - when: 'true'
+      recursiveMerge: true
+      values:
+        httpCache:
+          image:
+            registry: registry.self-hosted.carto.com/proxy/carto/gcr.io/carto-artifacts
+            tag: "feature_sc_457242_add_an_easier_approach_for_enabling_the_debug"
     #     httpCache:
     #       image:
     #         registry: registry.self-hosted.carto.com/proxy/carto/gcr.io/carto-artifacts
@@ -538,38 +538,8 @@ spec:
     - when: '{{repl ConfigOptionEquals "enablePlatformDebugMode" "1" }}'
       recursiveMerge: true
       values:
-        httpCache:
-          extraEnvVars:
-            - name: VARNISH_LOG_LEVEL
-              value: "DEBUG"
-        importApi:
-          extraEnvVars:
-            - name: CARTO_TRACING_MODE
-              value: "local"
-        importWorker:
-          extraEnvVars:
-            - name: CARTO_TRACING_MODE
-              value: "local"
-        ldsApi:
-          extraEnvVars:
-            - name: CARTO_TRACING_MODE
-              value: "local"
-        mapsApi:
-          extraEnvVars:
-            - name: CARTO_TRACING_MODE
-              value: "local"
-        sqlWorker:
-          extraEnvVars:
-            - name: CARTO_TRACING_MODE
-              value: "local"
-        workspaceApi:
-          extraEnvVars:
-            - name: CARTO_TRACING_MODE
-              value: "local"
-        workspaceSubscriber:
-          extraEnvVars:
-            - name: CARTO_TRACING_MODE
-              value: "local"
+        appConfigValues:
+          logLevel: "debug"
     ## Openshift
     - when: '{{repl ConfigOptionEquals "platformDistribution" "openShift" }}'
       recursiveMerge: true


### PR DESCRIPTION
This PR adds an easier way to enable the debug mode in SH. For installations using Kots, we'll have a checkbox to enable it in the config and we've added a check in the support bundle to notify the user if they've generated a support bundle without enabling the debug mode:

![Screenshot 2024-12-12 at 9 52 09 AM](https://github.com/user-attachments/assets/dd0e9762-dcdc-4ab3-9e9d-735a6cd182ee)

We've also added a validator in the Helm chart to ensure that the customer provides a valid value for the `logLevel`:

```
{"level":"error","ts":"2024-12-12T08:44:30Z","msg":"rewrite directory: failed to write rendered: failed to write helm rendered: failed to template helm chart for rendered dir: failed to run helm install: execution error at (carto/templates/NOTES.txt:113:3): \nVALUES VALIDATION:\nInvalid logLevel: random. Must be one of [info debug error]"}
```