### PR TITLE
Include support bundle & preflight checks in helm installation

### DIFF
--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -62,13 +62,29 @@ Return common collectors for preflights and support-bundle
                 done
             env:
               {{- if not .Values.commonBackendServiceAccount.enableGCPWorkloadIdentity }}
+              {{- if eq .Values.cartoSecrets.defaultGoogleServiceAccount.existingSecret.name "" -}}
               - name: DEFAULT_SERVICE_ACCOUNT_KEY__FILE_CONTENT
                 value: {{ .Values.cartoSecrets.defaultGoogleServiceAccount.value | b64enc | quote }}
+              {{- else -}}
+              - name: DEFAULT_SERVICE_ACCOUNT_KEY__FILE_CONTENT
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.cartoSecrets.defaultGoogleServiceAccount.existingSecret.name | quote }}
+                    key: {{ .Values.cartoSecrets.defaultGoogleServiceAccount.existingSecret.key | quote }}
+              {{- end -}}
               - name: DEFAULT_SERVICE_ACCOUNT_KEY__FILE_PATH
                 value: {{ include "carto.google.secretMountAbsolutePath" . }}
               {{- if ( include "carto.googleCloudStorageServiceAccountKey.used" . ) }}
+              {{- if eq .Values.appSecrets.googleCloudStorageServiceAccountKey.existingSecret.name "" -}}
               - name: STORAGE_SERVICE_ACCOUNT_KEY__FILE_CONTENT
                 value: {{ .Values.appSecrets.googleCloudStorageServiceAccountKey.value | b64enc | quote }}
+              {{- else -}}
+              - name: STORAGE_SERVICE_ACCOUNT_KEY__FILE_CONTENT
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.appSecrets.googleCloudStorageServiceAccountKey.existingSecret.name | quote }}
+                    key: {{ .Values.appSecrets.googleCloudStorageServiceAccountKey.existingSecret.key | quote }}
+              {{- end -}}
               - name: STORAGE_SERVICE_ACCOUNT_KEY__FILE_PATH
                 value: {{ include "carto.googleCloudStorageServiceAccountKey.secretMountAbsolutePath" . }}
               {{- end }}
@@ -510,27 +526,73 @@ Return customer values to use in preflights and support-bundle
 Return customer secrets to use in preflights and support-bundle
 */}}
 {{- define "carto.replicated.tenantRequirementsChecker.customerSecrets" }}
+  {{- if eq .Values.externalPostgresql.existingSecret "" }}
   - name: WORKSPACE_POSTGRES_PASSWORD
     value: {{ .Values.externalPostgresql.password | quote }}
+  {{- else }}
+  - name: WORKSPACE_POSTGRES_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: {{ include "carto.postgresql.secretName" . }}
+        key: {{ include "carto.postgresql.secret.key" . }}
+  {{- end -}}
+
+  {{- if eq .Values.externalRedis.existingSecret "" -}}
   - name: REDIS_PASSWORD
     value: {{ .Values.externalRedis.password | quote }}
+  {{- else }}
+  - name: REDIS_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: {{ include "carto.redis.secretName" . }}
+        key: {{ include "carto.redis.existingsecret.key" . | quote }}
+  {{- end -}}
+
+  {{- if eq .Values.cartoSecrets.launchDarklySdkKey.existingSecret.name "" -}}
   - name: LAUNCHDARKLY_SDK_KEY
     value: {{ .Values.cartoSecrets.launchDarklySdkKey.value | quote }}
+  {{- else -}}
+  {{ include "carto._utils.generateSecretDef" (dict "var" "LAUNCHDARKLY_SDK_KEY" "context" .) | nindent 2 }}
+  {{- end -}}
   {{- if eq .Values.appConfigValues.storageProvider "s3" }}
+  {{- if eq .Values.appSecrets.awsAccessKeyId.existingSecret.name "" -}}
   - name: WORKSPACE_THUMBNAILS_ACCESSKEYID
     value: {{ .Values.appSecrets.awsAccessKeyId.value | quote }}
+  {{- else -}}
+  {{ include "carto._utils.generateSecretDef" (dict "var" "WORKSPACE_THUMBNAILS_ACCESSKEYID" "context" .) | nindent 2 }}
+  {{- end -}}
+  {{- if eq .Values.appSecrets.awsAccessKeyId.existingSecret.name "" -}}
   - name: WORKSPACE_IMPORTS_ACCESSKEYID
     value: {{ .Values.appSecrets.awsAccessKeyId.value | quote }}
+  {{- else -}}
+  {{ include "carto._utils.generateSecretDef" (dict "var" "WORKSPACE_IMPORTS_ACCESSKEYID" "context" .) | nindent 2 }}
+  {{- end -}}
+  {{- if eq .Values.appSecrets.awsAccessKeySecret.existingSecret.name "" -}}
   - name: WORKSPACE_THUMBNAILS_SECRETACCESSKEY
     value: {{ .Values.appSecrets.awsAccessKeySecret.value | quote }}
+  {{- else -}}
+  {{ include "carto._utils.generateSecretDef" (dict "var" "WORKSPACE_THUMBNAILS_SECRETACCESSKEY" "context" .) | nindent 2 }}
+  {{- end -}}
+  {{- if eq .Values.appSecrets.awsAccessKeySecret.existingSecret.name "" -}}
   - name: WORKSPACE_IMPORTS_SECRETACCESSKEY
     value: {{ .Values.appSecrets.awsAccessKeySecret.value | quote }}
+  {{- else -}}
+  {{ include "carto._utils.generateSecretDef" (dict "var" "WORKSPACE_IMPORTS_SECRETACCESSKEY" "context" .) | nindent 2 }}
+  {{- end -}}
   {{- end }}
   {{- if eq .Values.appConfigValues.storageProvider "azure-blob" }}
+  {{- if eq .Values.appSecrets.azureStorageAccessKey.existingSecret.name "" -}}
   - name: WORKSPACE_THUMBNAILS_STORAGE_ACCESSKEY
     value: {{ .Values.appSecrets.azureStorageAccessKey.value | quote }}
+  {{- else -}}
+  {{ include "carto._utils.generateSecretDef" (dict "var" "WORKSPACE_THUMBNAILS_STORAGE_ACCESSKEY" "context" .) | nindent 2 }}
+  {{- end -}}
+  {{- if eq .Values.appSecrets.azureStorageAccessKey.existingSecret.name "" -}}
   - name: WORKSPACE_IMPORTS_STORAGE_ACCESSKEY
     value: {{ .Values.appSecrets.azureStorageAccessKey.value | quote }}
+  {{- else -}}
+  {{ include "carto._utils.generateSecretDef" (dict "var" "WORKSPACE_IMPORTS_STORAGE_ACCESSKEY" "context" .) | nindent 2 }}
+  {{- end -}}
   {{- end }}
 {{- end -}}
 

--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -62,29 +62,29 @@ Return common collectors for preflights and support-bundle
                 done
             env:
               {{- if not .Values.commonBackendServiceAccount.enableGCPWorkloadIdentity }}
-              {{- if eq .Values.cartoSecrets.defaultGoogleServiceAccount.existingSecret.name "" -}}
+              {{- if eq .Values.cartoSecrets.defaultGoogleServiceAccount.existingSecret.name "" }}
               - name: DEFAULT_SERVICE_ACCOUNT_KEY__FILE_CONTENT
                 value: {{ .Values.cartoSecrets.defaultGoogleServiceAccount.value | b64enc | quote }}
-              {{- else -}}
+              {{- else }}
               - name: DEFAULT_SERVICE_ACCOUNT_KEY__FILE_CONTENT
                 valueFrom:
                   secretKeyRef:
                     name: {{ .Values.cartoSecrets.defaultGoogleServiceAccount.existingSecret.name | quote }}
                     key: {{ .Values.cartoSecrets.defaultGoogleServiceAccount.existingSecret.key | quote }}
-              {{- end -}}
+              {{- end }}
               - name: DEFAULT_SERVICE_ACCOUNT_KEY__FILE_PATH
                 value: {{ include "carto.google.secretMountAbsolutePath" . }}
               {{- if ( include "carto.googleCloudStorageServiceAccountKey.used" . ) }}
-              {{- if eq .Values.appSecrets.googleCloudStorageServiceAccountKey.existingSecret.name "" -}}
+              {{- if eq .Values.appSecrets.googleCloudStorageServiceAccountKey.existingSecret.name "" }}
               - name: STORAGE_SERVICE_ACCOUNT_KEY__FILE_CONTENT
                 value: {{ .Values.appSecrets.googleCloudStorageServiceAccountKey.value | b64enc | quote }}
-              {{- else -}}
+              {{- else }}
               - name: STORAGE_SERVICE_ACCOUNT_KEY__FILE_CONTENT
                 valueFrom:
                   secretKeyRef:
                     name: {{ .Values.appSecrets.googleCloudStorageServiceAccountKey.existingSecret.name | quote }}
                     key: {{ .Values.appSecrets.googleCloudStorageServiceAccountKey.existingSecret.key | quote }}
-              {{- end -}}
+              {{- end }}
               - name: STORAGE_SERVICE_ACCOUNT_KEY__FILE_PATH
                 value: {{ include "carto.googleCloudStorageServiceAccountKey.secretMountAbsolutePath" . }}
               {{- end }}
@@ -526,7 +526,7 @@ Return customer values to use in preflights and support-bundle
 Return customer secrets to use in preflights and support-bundle
 */}}
 {{- define "carto.replicated.tenantRequirementsChecker.customerSecrets" }}
-  {{- if eq .Values.externalPostgresql.existingSecret "" }}
+  {{- if eq .Values.externalPostgresql.existingSecret "" -}}
   - name: WORKSPACE_POSTGRES_PASSWORD
     value: {{ .Values.externalPostgresql.password | quote }}
   {{- else }}
@@ -536,7 +536,6 @@ Return customer secrets to use in preflights and support-bundle
         name: {{ include "carto.postgresql.secretName" . }}
         key: {{ include "carto.postgresql.secret.key" . }}
   {{- end -}}
-
   {{- if eq .Values.externalRedis.existingSecret "" -}}
   - name: REDIS_PASSWORD
     value: {{ .Values.externalRedis.password | quote }}
@@ -547,53 +546,52 @@ Return customer secrets to use in preflights and support-bundle
         name: {{ include "carto.redis.secretName" . }}
         key: {{ include "carto.redis.existingsecret.key" . | quote }}
   {{- end -}}
-
-  {{- if eq .Values.cartoSecrets.launchDarklySdkKey.existingSecret.name "" -}}
+  {{- if eq .Values.cartoSecrets.launchDarklySdkKey.existingSecret.name "" }}
   - name: LAUNCHDARKLY_SDK_KEY
     value: {{ .Values.cartoSecrets.launchDarklySdkKey.value | quote }}
   {{- else -}}
   {{ include "carto._utils.generateSecretDef" (dict "var" "LAUNCHDARKLY_SDK_KEY" "context" .) | nindent 2 }}
   {{- end -}}
-  {{- if eq .Values.appConfigValues.storageProvider "s3" }}
-  {{- if eq .Values.appSecrets.awsAccessKeyId.existingSecret.name "" -}}
+  {{- if eq .Values.appConfigValues.storageProvider "s3" -}}
+  {{- if eq .Values.appSecrets.awsAccessKeyId.existingSecret.name "" }}
   - name: WORKSPACE_THUMBNAILS_ACCESSKEYID
     value: {{ .Values.appSecrets.awsAccessKeyId.value | quote }}
   {{- else -}}
   {{ include "carto._utils.generateSecretDef" (dict "var" "WORKSPACE_THUMBNAILS_ACCESSKEYID" "context" .) | nindent 2 }}
   {{- end -}}
-  {{- if eq .Values.appSecrets.awsAccessKeyId.existingSecret.name "" -}}
+  {{- if eq .Values.appSecrets.awsAccessKeyId.existingSecret.name "" }}
   - name: WORKSPACE_IMPORTS_ACCESSKEYID
     value: {{ .Values.appSecrets.awsAccessKeyId.value | quote }}
   {{- else -}}
   {{ include "carto._utils.generateSecretDef" (dict "var" "WORKSPACE_IMPORTS_ACCESSKEYID" "context" .) | nindent 2 }}
   {{- end -}}
-  {{- if eq .Values.appSecrets.awsAccessKeySecret.existingSecret.name "" -}}
+  {{- if eq .Values.appSecrets.awsAccessKeySecret.existingSecret.name "" }}
   - name: WORKSPACE_THUMBNAILS_SECRETACCESSKEY
     value: {{ .Values.appSecrets.awsAccessKeySecret.value | quote }}
   {{- else -}}
   {{ include "carto._utils.generateSecretDef" (dict "var" "WORKSPACE_THUMBNAILS_SECRETACCESSKEY" "context" .) | nindent 2 }}
   {{- end -}}
-  {{- if eq .Values.appSecrets.awsAccessKeySecret.existingSecret.name "" -}}
+  {{- if eq .Values.appSecrets.awsAccessKeySecret.existingSecret.name "" }}
   - name: WORKSPACE_IMPORTS_SECRETACCESSKEY
     value: {{ .Values.appSecrets.awsAccessKeySecret.value | quote }}
   {{- else -}}
   {{ include "carto._utils.generateSecretDef" (dict "var" "WORKSPACE_IMPORTS_SECRETACCESSKEY" "context" .) | nindent 2 }}
   {{- end -}}
-  {{- end }}
+  {{- end -}}
   {{- if eq .Values.appConfigValues.storageProvider "azure-blob" }}
-  {{- if eq .Values.appSecrets.azureStorageAccessKey.existingSecret.name "" -}}
+  {{- if eq .Values.appSecrets.azureStorageAccessKey.existingSecret.name "" }}
   - name: WORKSPACE_THUMBNAILS_STORAGE_ACCESSKEY
     value: {{ .Values.appSecrets.azureStorageAccessKey.value | quote }}
   {{- else -}}
   {{ include "carto._utils.generateSecretDef" (dict "var" "WORKSPACE_THUMBNAILS_STORAGE_ACCESSKEY" "context" .) | nindent 2 }}
   {{- end -}}
-  {{- if eq .Values.appSecrets.azureStorageAccessKey.existingSecret.name "" -}}
+  {{- if eq .Values.appSecrets.azureStorageAccessKey.existingSecret.name "" }}
   - name: WORKSPACE_IMPORTS_STORAGE_ACCESSKEY
     value: {{ .Values.appSecrets.azureStorageAccessKey.value | quote }}
   {{- else -}}
   {{ include "carto._utils.generateSecretDef" (dict "var" "WORKSPACE_IMPORTS_STORAGE_ACCESSKEY" "context" .) | nindent 2 }}
   {{- end -}}
-  {{- end }}
+  {{- end -}}
 {{- end -}}
 
 

--- a/chart/templates/preflight.yaml
+++ b/chart/templates/preflight.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.replicated.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,4 +17,3 @@ stringData:
     {{- include "carto.replicated.commonChecks.collectors" . | indent 6 }}
       analyzers:
     {{- include "carto.replicated.commonChecks.analyzers" . | indent 6 }}
-{{- end }}

--- a/chart/templates/support-bundle.yaml
+++ b/chart/templates/support-bundle.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.replicated.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -71,4 +70,3 @@ stringData:
                 when: "!= Healthy" # Catch all unhealthy pods. A pod is considered healthy if it has a status of Completed, or Running and all of its containers are ready.
                 # {{ printf "{{ .Status.Reason }}" }} displays the current status of the pod, while {{ printf "{{ .Status.Message }}" }} provides a detailed explanation of why the pod is unhealthy, based on logged events.
                 message: Pod {{ printf "{{ .Namespace }}" }}/{{ printf "{{ .Name }}" }} is unhealthy with a status of {{ printf "{{ .Status.Reason }}" }}. Message is {{ printf "{{ .Status.Message }}" }} 
-{{- end }}


### PR DESCRIPTION
Create the support bundle and the preflights secret in both the Kots and the Helm installation by default, and adapted the checks to use existing secrets in the Helm chart deployment. Now we support existing secrets for:

- `cartoSecrets.defaultGoogleServiceAccount`
- `appSecrets.awsAccessKeyId`
- `appSecrets.awsAccessKeySecret`
- `appSecrets.azureStorageAccessKey`
- `appSecrets.googleCloudStorageServiceAccountKey`
- `externalPostgresql`
- `externalRedis`
- `launchDarklySdkKey`