### PR TITLE
chore(helm): :package: migrate the self-hosted Helm repository

### DIFF
--- a/.github/actions/publish-release/action.yaml
+++ b/.github/actions/publish-release/action.yaml
@@ -26,7 +26,7 @@ inputs:
     default: https://helm.carto.com/
   chart-bucket:
     description: "Google Cloud Storage bucket where the Helm chart is stored"
-    default: gs://carto-helm
+    default: gs://carto-selfhosted-helm-repository
   chart-gcp-project-id:
     description: "Google Cloud project ID where the Helm chart is stored"
     default: carto-onprem-artifacts
@@ -49,7 +49,7 @@ runs:
       uses: google-github-actions/setup-gcloud@v2
       with:
         project_id: ${{ inputs.chart-gcp-project-id }}
-    
+
     # Step 3: Install helm
     - name: Install helm
       shell: bash
@@ -86,7 +86,7 @@ runs:
       run: |
         mkdir packages-selfhosted-charts
         gsutil cp -r "${CHARTS_BUCKET}" .
-        mv carto-helm/*.tgz packages-selfhosted-charts/
+        mv ${CHARTS_BUCKET}/*.tgz packages-selfhosted-charts/
         cp carto-${{ inputs.version }}*.tgz packages-selfhosted-charts/
         helm repo index packages-selfhosted-charts --url "${CHARTS_REPOSITORY}"
         gsutil -h "Cache-Control:public,max-age=3600,s-maxage=3600" -m rsync -x "^index.yaml$" -d packages-selfhosted-charts/ "${CHARTS_BUCKET}"


### PR DESCRIPTION
Story — https://app.shortcut.com/cartoteam/story/452515/get-the-self-hosted-helm-repository-out-of-avid-wavelet-844

Update the self-hosted release process to use the new Helm repository Storage Bucket

Related PRs

- https://github.com/CartoDB/cloud-native/pull/19196
- https://github.com/CartoDB/terraform-aws-prod/pull/311