### PR TITLE
Upgrade ubuntu-20.04 to ubuntu-24.04 runner version

### DIFF
--- a/.github/workflows/check-helm-chart-resources.yaml
+++ b/.github/workflows/check-helm-chart-resources.yaml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   check-helm-resources-changed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/lint-codebase.yaml
+++ b/.github/workflows/lint-codebase.yaml
@@ -2,7 +2,7 @@ name: Lint codebase
 on: [pull_request]
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
 
@@ -25,7 +25,7 @@ jobs:
           FILTER_REGEX_EXCLUDE: ".*doc/.*|.*github/.*"
 
   check-helm-resources-changed:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -54,7 +54,7 @@ jobs:
             :warning: Helm Chart resources have changed. Please make sure to update the documentation accordingly. You can find more information [here](https://cartodb.getoutline.com/doc/helm-chart-yJ3vxi6icN#h-deployment-resources).
 
   helm-readme-generator:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/release-autotag.yaml
+++ b/.github/workflows/release-autotag.yaml
@@ -7,7 +7,7 @@ on:
       - VERSION
 jobs:
   create-tag:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/470573
- Autolink: [sc-470573]

In order to avoid deprecation and our CI/CD not running because we are using runners deprecated upgrade to the latest version available.