### PR TITLE
:rocket: Update to `1.174.1-2025.4.9-bump-workflow-engine`

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-2025.4.9-rc.1
+2025.4.9-bump-workflow-engine

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2025.4.9-rc.1
+appVersion: 2025.4.9-bump-workflow-engine
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -34,4 +34,4 @@ sources:
   - https://carto.com/
 annotations:
   minVersion: "2023.10.25"
-version: 1.172.1
+version: 1.174.1

--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chart:
     name: carto
-    chartVersion: 1.172.1
+    chartVersion: 1.174.1
   builder:
     replicated:
       enabled: true


### PR DESCRIPTION
https://github.com/CartoDB/cloud-native/commit/96ed017844caa02313d1699b0b6066680e002e94