### PR TITLE
warn using a list and add the conditionals. 1st iteration

### DIFF
--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -261,6 +261,26 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
       "EgressRequirementsValidator" (list "Check_CARTO_Auth_connectivity" "Check_PubSub_connectivity" "Check_Google_Storage_connectivity" "Check_release_channels_connectivity" "Check_Google_Storage_connectivity" "Check_CARTO_images_registry_connectivity" "Check_TomTom_connectivity" "Check_TravelTime_connectivity")
       "PubSubValidator" (list "Check_publish_and_listen_to_topic")
   }}
+{{/* Add optional analyzers to the preflightsDict */}}
+
+{{- $preflightOptionalList := list }}
+
+{{- if not .Values.TravelTime.ldsTravelTimeApiKey }}
+  {{- $preflightOptionalList = append $preflightOptionalList "Check_TravelTime_connectivity" }}
+{{- end }}
+
+{{- if not .Values.TomTom.ldsTomTomApiKey }}
+  {{- $preflightOptionalList = append $preflightOptionalList "Check_TomTom_connectivity" }}
+{{- end }}
+
+{{- if not .Values.appConfigValues.workspaceImportsBucket }}
+  {{- $preflightOptionalList = append $preflightOptionalList "Check_temp_bucket" }}
+{{- end }}
+
+{{- if not .Values.appConfigValues.workspaceThumbnailsBucket }}
+  {{- $preflightOptionalList = append $preflightOptionalList "Check_assets_bucket" }}
+{{- end }}
+
   {{/*
   We push conditionally new analyzers for the feature flags if the customer defined overridden feature flags
   */}}
@@ -300,12 +320,18 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
       value: |
         "passed"
       outcomes:
-        - fail:
-            when: "false"
-            message: "{{ printf "{{ .%s.%s.info }}" $preflight $preflightCheckName }}"
         - pass:
             when: "true"
             message: "{{ printf "{{ .%s.%s.info }}" $preflight $preflightCheckName }}"
+      {{- if has $preflightCheckName $preflightOptionalList}}
+        - warn:
+            when: "false"
+            message: "{{ printf "{{ .%s.%s.info }}" $preflight $preflightCheckName }}"
+      {{- else }}
+        - fail:
+            when: "false"
+            message: "{{ printf "{{ .%s.%s.info }}" $preflight $preflightCheckName }}"
+      {{- end }}  
   {{- end }}
   {{- end }}
   {{/*


### PR DESCRIPTION
**Description of the change**

Marks some preflight checks as warnings instead of failures when related features (e.g., TravelTime, TomTom, buckets) are not configured in `values.yaml`. Uses a list to track optional checks.

**Benefits**

- Avoids false negatives in minimal setups.
- Clearer UX for users not using all external services.
- Simplifies logic with a cleaner list-based approach.

**Possible drawbacks**

- Only supports a single optional level (`warn`), not more granular outcomes.

**Applicable issues**

- fixes #1827

**Additional information**

Tested with and without optional values to confirm expected `warn` vs `fail` outcomes.
