### PR TITLE
Create 2025.7.16-patch1

### DIFF
--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -177,7 +177,7 @@ spec:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "registry.self-hosted.carto.com/proxy/carto/gcr.io/carto-onprem-artifacts" }}'
     workspaceWww:
       image:
-        tag: "2025.7.16-patch1"
+        tag: "2025.7.16-patch1" #https://app.shortcut.com/cartoteam/story/502436/create-2025-7-16-patch1-for-waltmart-and-telus
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "registry.self-hosted.carto.com/proxy/carto/gcr.io/carto-onprem-artifacts" }}'
     workspaceMigrations:
       image:


### PR DESCRIPTION
Create 2025.7.16-patch1 
We need to deliver a patch for the following tickets:

[Formerly working maps crashing to 500 error](https://app.shortcut.com/cartoteam/story/499839/telus-gis-formerly-working-maps-crashing-to-500-error)
[Custom marker access token not refreshing](https://app.shortcut.com/cartoteam/story/488591/carto-wmt-sh-custom-marker-access-token-not-refreshing#activity-501494)
Patch name: 2025.7.16-patch1

The fixes only affect the workspace-www image as you can see in the PR: https://github.com/CartoDB/cloud-native/pull/20799

Fixes to be included specified by @zbigniewzagrski: https://cartoteam.slack.com/archives/C02PADFM0E4/p1753868088592839?thread_ts=1753795617.599549&cid=C02PADFM0E4