### PR TITLE
Revert "Update dependency replicatedhq/embedded-cluster from 2.7.3+k8s-1.31 to 2.8.1+k8s-1.31"

### DIFF
--- a/manifests/embbeded-cluster.yaml
+++ b/manifests/embbeded-cluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: embeddedcluster.replicated.com/v1beta1
 kind: Config
 spec:
-  version: 2.8.1+k8s-1.31
+  version: 2.7.3+k8s-1.31
   domains:
     proxyRegistryDomain: registry.self-hosted.carto.com
     replicatedAppDomain: replicated.self-hosted.carto.com


### PR DESCRIPTION
Reverts CartoDB/carto-selfhosted-helm#747