### PR TITLE
Move url construct to Litellm Docker entrypoint

### DIFF
--- a/chart/templates/litellm/configmap.yaml
+++ b/chart/templates/litellm/configmap.yaml
@@ -18,9 +18,11 @@ data:
   AUTH0_NAMESPACE: "http://app.carto.com"
   AI_API_URL: "http://{{ include "carto.aiApi.fullname" . }}:{{ .Values.aiApi.service.ports.http }}"
   DATABASE_HOST: {{ include "carto.postgresql.host" . | quote }}
-  DATABASE_NAME: "litellm"
+  DATABASE_NAME: {{ .Values.externalPostgresql.aiDatabaseName | quote }}
   DATABASE_PORT: {{ include "carto.postgresql.port" . | quote }}
   DATABASE_SSL_MODE: {{ include "carto.litellm.databaseSslMode" . | quote }}
+  DATABASE_SSL_PATH: {{ include "carto.postgresql.configMapMountAbsolutePath" . | quote }}
+  DATABASE_SSL_CA: {{ ternary "true" "false" .Values.externalPostgresql.sslCA | quote }}
   DATABASE_USERNAME: {{ include "carto.postgresql.user" . | quote }}
   {{- if .Values.externalProxy.enabled }}
   HTTP_PROXY: {{ include "carto.proxy.computedConnectionString" . | quote }}
@@ -47,6 +49,7 @@ data:
   REDIS_DB: "1"
   REDIS_HOST: {{ include "carto.redis.host" . | quote }}
   REDIS_PORT: {{ include "carto.redis.port" . | quote }}
+  REDIS_TLS_ENABLED: {{ .Values.externalRedis.tlsEnabled | quote }}
   STORE_MODEL_IN_DB: "True"
   USE_PRISMA_MIGRATE: "True"
   PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING: "1"

--- a/chart/templates/litellm/configmap.yaml
+++ b/chart/templates/litellm/configmap.yaml
@@ -18,12 +18,11 @@ data:
   AUTH0_NAMESPACE: "http://app.carto.com"
   AI_API_URL: "http://{{ include "carto.aiApi.fullname" . }}:{{ .Values.aiApi.service.ports.http }}"
   DATABASE_HOST: {{ include "carto.postgresql.host" . | quote }}
+  DATABASE_USERNAME: {{ include "carto.postgresql.user" . | quote }}
   DATABASE_NAME: "litellm"
   DATABASE_PORT: {{ include "carto.postgresql.port" . | quote }}
   DATABASE_SSL_MODE: {{ include "carto.litellm.databaseSslMode" . | quote }}
   DATABASE_SSL_PATH: {{ include "carto.postgresql.configMapMountAbsolutePath" . | quote }}
-  DATABASE_SSL_CA: {{ ternary "true" "false" .Values.externalPostgresql.sslCA | quote }}
-  DATABASE_USERNAME: {{ include "carto.postgresql.user" . | quote }}
   {{- if .Values.externalProxy.enabled }}
   HTTP_PROXY: {{ include "carto.proxy.computedConnectionString" . | quote }}
   http_proxy: {{ include "carto.proxy.computedConnectionString" . | quote }}

--- a/chart/templates/litellm/configmap.yaml
+++ b/chart/templates/litellm/configmap.yaml
@@ -18,7 +18,7 @@ data:
   AUTH0_NAMESPACE: "http://app.carto.com"
   AI_API_URL: "http://{{ include "carto.aiApi.fullname" . }}:{{ .Values.aiApi.service.ports.http }}"
   DATABASE_HOST: {{ include "carto.postgresql.host" . | quote }}
-  DATABASE_NAME: {{ .Values.externalPostgresql.aiDatabaseName | quote }}
+  DATABASE_NAME: "litellm"
   DATABASE_PORT: {{ include "carto.postgresql.port" . | quote }}
   DATABASE_SSL_MODE: {{ include "carto.litellm.databaseSslMode" . | quote }}
   DATABASE_SSL_PATH: {{ include "carto.postgresql.configMapMountAbsolutePath" . | quote }}

--- a/chart/templates/litellm/deployment.yaml
+++ b/chart/templates/litellm/deployment.yaml
@@ -83,23 +83,11 @@ spec:
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
           {{- else if .Values.litellm.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.litellm.command "context" $) | nindent 12 }}
-          {{- else }}
-          command:
-            - /bin/sh
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
           {{- else if .Values.litellm.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.litellm.args "context" $) | nindent 12 }}
-          {{- else }}
-          args:
-            - -c
-            - |
-              # Construct DATABASE_URL from the individual environment variables
-              export DATABASE_URL="postgresql://$DATABASE_USERNAME:$DATABASE_PASSWORD@$DATABASE_HOST:$DATABASE_PORT/$DATABASE_NAME?sslmode=${DATABASE_SSL_MODE}"{{- if and (.Values.externalPostgresql.sslEnabled) (.Values.externalPostgresql.sslCA) }}&sslrootcert=${DATABASE_SSL_PATH}{{- end }}""
-              # Construct REDIS_URL from the individual environment variables
-              export REDIS_URL="{{- if and ( .Values.externalRedis.host ) ( .Values.externalRedis.tlsEnabled) -}}rediss{{- else -}}redis{{- end -}}://:$REDIS_PASSWORD@$REDIS_HOST:$REDIS_PORT/$REDIS_DB{{- if and ( .Values.externalRedis.host ) ( .Values.externalRedis.tlsEnabled) -}}&ssl_cert_reqs=none{{- end -}}"
-              exec litellm --config /app/config.yaml
           {{- end }}
           env:
             - name: DATABASE_PASSWORD

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5167,6 +5167,7 @@ externalPostgresql:
   sslCA: ""
   awsEksPodIdentityEnabled: false
   awsRdsRegion: ""
+  aiDatabaseName: "llmProxy"
 
 ## @section External proxy configuration
 ## Configuration for an external proxy provided by the client. Only HTTP and HTTPS proxies are supported

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5167,7 +5167,6 @@ externalPostgresql:
   sslCA: ""
   awsEksPodIdentityEnabled: false
   awsRdsRegion: ""
-  aiDatabaseName: "llmProxy"
 
 ## @section External proxy configuration
 ## Configuration for an external proxy provided by the client. Only HTTP and HTTPS proxies are supported


### PR DESCRIPTION
# Description

Shortcut

- Story:https://app.shortcut.com/cartoteam/story/506249/add-entrypoint-to-litellm-dockerfile?vc_group_by=day&ct_workflow=all&cf_workflow=500193639
- Autolink: [[506249](https://app.shortcut.com/cartoteam/story/506249/add-entrypoint-to-litellm-dockerfile?vc_group_by=day&ct_workflow=all&cf_workflow=500193639)]

To standarize the enviroments we are going to migreate the URL construction from env vars handling in terraform / helm to a Docker entrypoint. 

## Type of change

- [ ] Fix
- [X] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Documentation
- [ ] Security
- [ ] Chore

## Acceptance

1. Test entrypoint.sh locally 
2. Test in both environment SaaS & K8s

## Basic checklist

- [ ] Good PR name
- [ ] Shortcut link
- [ ] Just one issue per PR
- [ ] GitHub labels
- [ ] Proper status & reviewers
- [ ] Tests
- [ ] Documentation
