### PR TITLE
feat(preflights): add new egress checks, fix analyzer issues, and improve preflight UX

### DIFF
--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -474,7 +474,7 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
       outcomes:
         - fail:
             when: "sum(memoryAllocatable) < 32Gi"
-            message: The cluster must contain at least 16Gi of RAM memory. ➡️ Ignore if you have auto-scale enabled in your cluster.
+            message: The cluster must contain at least 32Gi of RAM memory. ➡️ Ignore if you have auto-scale enabled in your cluster.
         - pass:
             message: There are at least 32 GiB of RAM memory in the cluster.
   {{- end }}

--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -413,7 +413,7 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
   We only can run the following preflight checks and get the platform distribution when a cluster role is created.
   Otherwise, we cannot obtain this info
   */}}
-  {{- if ne .Values.replicated.platformDistribution "" }}
+  {{- if .Values.replicated.platformDistribution }}
   - clusterVersion:
       docString: |
         CARTO Self-Hosted requires Kubernetes 1.29.0 or later.

--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -12,6 +12,7 @@ Return common collectors for preflights and support-bundle
         serviceAccountName: {{ template "carto.commonSA.serviceAccountName" . }}
         {{- end }}
         restartPolicy: Never
+        {{- include "carto.imagePullSecrets" . | nindent 8 }}
         securityContext: {{- toYaml .Values.tenantRequirementsChecker.podSecurityContext | nindent 10 }}
         initContainers:
           - name: init-tenant-requirements-check
@@ -254,7 +255,12 @@ Return common collectors for preflights and support-bundle
       imagePullSecret:
         name: carto-registry
       images:
+        {{ if not .Values.global.imageRegistry }}
+        - {{ template "carto.tenantRequirementsChecker.image" . }}
+        {{ else }}
         - {{ template "carto.accountsWww.image" . }}
+        - {{ template "carto.aiApi.image" . }}
+        - {{ template "carto.aiProxy.image" . }}
         - {{ template "carto.cdnInvalidatorSub.image" . }}
         - {{ template "carto.httpCache.image" . }}
         - {{ template "carto.importApi.image" . }}
@@ -262,13 +268,17 @@ Return common collectors for preflights and support-bundle
         - {{ template "carto.ldsApi.image" . }}
         - {{ template "carto.mapsApi.image" . }}
         - {{ template "carto.notifier.image" . }}
+        - {{ template "carto.redis.image" . }}
         - {{ template "carto.router.image" . }}
+        - {{ template "carto.routerMetrics.image" . }}
         - {{ template "carto.sqlWorker.image" . }}
+        - {{ template "carto.tenantRequirementsChecker.image" . }}
+        - {{ template "carto.upgradeCheck.image" . }}
         - {{ template "carto.workspaceApi.image" . }}
         - {{ template "carto.workspaceMigrations.image" . }}
         - {{ template "carto.workspaceSubscriber.image" . }}
         - {{ template "carto.workspaceWww.image" . }}
-        - {{ template "carto.tenantRequirementsChecker.image" . }}
+        {{ end }}
 {{- end -}}
 
 {{/*
@@ -277,11 +287,11 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
 */}}
 {{- define "carto.replicated.commonChecks.analyzers" }}
   {{- $preflightsDict := dict
-      "WorkspaceDatabaseValidator" (list "Check_database_connection" "Check_database_encoding" "Check_user_has_right_permissions" "Check_database_version") 
+      "WorkspaceDatabaseValidator" (list "Check_database_connection" "Check_database_encoding" "Check_user_has_right_permissions" "Check_database_version")
       "ServiceAccountValidator" (list "Check_valid_service_account")
       "BucketsValidator" (list "Check_assets_bucket" "Check_temp_bucket")
-      "EgressRequirementsValidator" (list "Check_CARTO_Auth_connectivity" "Check_PubSub_connectivity" "Check_Google_Storage_connectivity" "Check_release_channels_connectivity" "Check_Google_Storage_connectivity" "Check_CARTO_images_registry_connectivity" "Check_TomTom_connectivity" "Check_TravelTime_connectivity")
-      "PubSubValidator" (list "Check_publish_and_listen_to_topic")
+      "EgressRequirementsValidator" (list "Check_CARTO_Auth_connectivity" "Check_PubSub_connectivity" "Check_Google_Storage_connectivity" "Check_release_channels_connectivity" "Check_CARTO_images_registry_connectivity" "Check_BigQuery_connectivity" "Check_TomTom_connectivity" "Check_TravelTime_connectivity" "Check_LaunchDarkly_connectivity")
+      "PubSubValidator" (list "Check_publish_and_listen_to_topic" "Check_publish_and_listen_to_topic_via_REST_API")
   }}
   
   {{/* Add optional analyzers to the preflightsDict */}}
@@ -321,6 +331,23 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
   {{- if not .Values.internalRedis.enabled }}
   {{- $_ := set $preflightsDict "RedisValidator" (list "Check_redis_connection") }}
   {{- end }}
+  {{/* First, check if each validator was skipped due to failed dependencies */}}
+  {{- range $preflight, $preflightChecks := $preflightsDict }}
+  - jsonCompare:
+      checkName: {{ $preflight | replace "Validator" "" }} (skipped)
+      fileName: tenant-requirements-check/tenant-requirements-check.log
+      path: "{{ $preflight }}.{{ $preflight }}.status"
+      value: |
+        "skipped"
+      outcomes:
+        - warn:
+            when: "true"
+            message: "{{ printf "{{ .%s.%s.info }}" $preflight $preflight }}"
+        - pass:
+            when: "false"
+            message: "Validator was not skipped"
+  {{- end }}
+  {{/* Then check individual preflight checks */}}
   {{- range $preflight, $preflightChecks  := $preflightsDict }}
   {{- range $preflightCheckName := $preflightChecks }}
   - jsonCompare:
@@ -341,7 +368,7 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
         - fail:
             when: "false"
             message: "{{ printf "{{ .%s.%s.info }}" $preflight $preflightCheckName }}"
-      {{- end }}  
+      {{- end }}
   {{- end }}
   {{- end }}
   {{/*
@@ -364,6 +391,10 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
   */}}
   {{- if ne .Values.replicated.platformDistribution "" }}
   - clusterVersion:
+      docString: |
+        CARTO Self-Hosted requires Kubernetes 1.29.0 or later.
+        Recommended version: 1.30.0 or later for optimal performance and security patches.
+        Reference: https://docs.carto.com/carto-self-hosted/requirements
       outcomes:
         - fail:
             when: "< 1.29.0"
@@ -376,6 +407,9 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
         - pass:
             message: Your cluster meets the recommended and required versions of Kubernetes.
   - containerRuntime:
+      docString: |
+        CARTO Self-Hosted requires containerd as the container runtime.
+        Other runtimes (Docker, CRI-O) are not supported.
       outcomes:
         - pass:
             when: "== containerd"
@@ -383,6 +417,14 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
         - fail:
             message: Did not find containerd container runtime.
   - distribution:
+      docString: |
+        CARTO Self-Hosted supports the following Kubernetes distributions:
+        - Amazon EKS
+        - Google GKE
+        - Azure AKS
+        - OpenShift
+        - Replicated Embedded Cluster (single VM)
+        Local development clusters (Docker Desktop, minikube, MicroK8s) and DigitalOcean are not supported.
       outcomes:
         - fail:
             when: "== docker-desktop"
@@ -416,6 +458,9 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
             message: Unable to determine the distribution of Kubernetes.
   - nodeResources:
       checkName: The cluster should contain at least 6 cores
+      docString: |
+        CARTO Self-Hosted requires a minimum of 6 CPU cores across the cluster.
+        This requirement can be ignored if cluster autoscaling is enabled.
       outcomes:
         - fail:
             when: "sum(cpuCapacity) < 6"
@@ -423,18 +468,25 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
         - pass:
             message: There are at least 6 cores in the cluster.
   - nodeResources:
-      checkName: The cluster should contain at least 16 Gi of RAM memory
+      checkName: The cluster should contain at least 32 Gi of RAM memory
+      docString: |
+        CARTO Self-Hosted requires a minimum of 32 GiB of allocatable memory across the cluster.
+        This requirement can be ignored if cluster autoscaling is enabled.
       outcomes:
         - fail:
-            when: "sum(memoryAllocatable) < 16Gi"
+            when: "sum(memoryAllocatable) < 32Gi"
             message: The cluster must contain at least 16Gi of RAM memory. ➡️ Ignore if you have auto-scale enabled in your cluster.
         - pass:
-            message: There are at least 16 Gi in the cluster.
+            message: There are at least 32 GiB of RAM memory in the cluster.
   {{- end }}
   {{- if .Values.gateway.enabled }}
   - customResourceDefinition:
       checkName: Gateway API available
       customResourceDefinitionName: gateways.gateway.networking.k8s.io
+      docString: |
+        CARTO Self-Hosted requires the Kubernetes Gateway API when gateway mode is enabled.
+        Install Gateway API CRDs before deploying CARTO.
+        Reference: https://gateway-api.sigs.k8s.io/guides/#installing-gateway-api
       outcomes:
         - fail:
             message: Gateway API is not enabled for your cluster. Please enable it to continue.

--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -353,25 +353,6 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
   {{- if not .Values.internalRedis.enabled }}
   {{- $_ := set $preflightsDict "RedisValidator" (list "Check_redis_connection") }}
   {{- end }}
-  {{/* First, check if each validator was skipped due to failed dependencies */}}
-  {{- range $preflight, $preflightChecks := $preflightsDict }}
-  {{- range $preflightCheckName := $preflightChecks }}
-  - jsonCompare:
-      checkName: {{ $preflightCheckName | replace "_" " " }} (skipped)
-      fileName: tenant-requirements-check/tenant-requirements-check.log
-      path: "{{ $preflight }}.{{ $preflight }}.status"
-      value: |
-        "skipped"
-      outcomes:
-        - warn:
-            when: "true"
-            message: "{{ printf "{{ .%s.%s.info }}" $preflight $preflight }}"
-        - pass:
-            when: "false"
-            message: "Validator was not skipped"
-  {{- end }}
-  {{- end }}
-  {{/* Then check individual preflight checks */}}
   {{- range $preflight, $preflightChecks  := $preflightsDict }}
   {{- range $preflightCheckName := $preflightChecks }}
   - jsonCompare:

--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -259,8 +259,10 @@ Return common collectors for preflights and support-bundle
         - {{ template "carto.tenantRequirementsChecker.image" . }}
         {{ else }}
         - {{ template "carto.accountsWww.image" . }}
+        {{ if .Values.appConfigValues.aiFeaturesEnabled }}
         - {{ template "carto.aiApi.image" . }}
         - {{ template "carto.aiProxy.image" . }}
+        {{ end }}
         - {{ template "carto.cdnInvalidatorSub.image" . }}
         - {{ template "carto.httpCache.image" . }}
         - {{ template "carto.importApi.image" . }}

--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -428,7 +428,7 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
         - Google GKE
         - Azure AKS
         - OpenShift
-        - Replicated Embedded Cluster (single VM)
+        - Single VM (Embedded Cluster)
         Local development clusters (Docker Desktop, minikube, MicroK8s) and DigitalOcean are not supported.
       outcomes:
         - fail:

--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -288,12 +288,35 @@ Return common analyzers for preflights and support-bundle.
 NOTE: Remember that with the ingress testing mode the components are not deployed, so take it into account when adding a new preflight!!
 */}}
 {{- define "carto.replicated.commonChecks.analyzers" }}
+  {{/* Build Preflight Checks conditionals */}}
+  {{/* Build EgressRequirementsValidator checks list */}}
+  {{- $egressChecks := list
+      "Check_CARTO_Auth_connectivity"
+      "Check_PubSub_connectivity"
+      "Check_Google_Storage_connectivity"
+      "Check_release_channels_connectivity"
+      "Check_CARTO_images_registry_connectivity"
+      "Check_BigQuery_connectivity"
+      "Check_TomTom_connectivity"
+      "Check_TravelTime_connectivity"
+  }}
+  {{- if .Values.cartoSecrets.launchDarklySdkKey.value }}
+  {{- $egressChecks = append $egressChecks "Check_LaunchDarkly_connectivity" }}
+  {{- end }}
+  {{/* Build PubSubValidator checks list */}}
+  {{- $pubSubChecks := list
+      "Check_publish_and_listen_to_topic"
+  }}
+  {{- if .Values.cartoConfigValues.usePubSubRestApi }}
+  {{- $pubSubChecks = append $pubSubChecks "Check_publish_and_listen_to_topic_via_REST_API" }}
+  {{- end }}
+  {{/* Assemble the preflights dict */}}
   {{- $preflightsDict := dict
       "WorkspaceDatabaseValidator" (list "Check_database_connection" "Check_database_encoding" "Check_user_has_right_permissions" "Check_database_version")
       "ServiceAccountValidator" (list "Check_valid_service_account")
       "BucketsValidator" (list "Check_assets_bucket" "Check_temp_bucket")
-      "EgressRequirementsValidator" (list "Check_CARTO_Auth_connectivity" "Check_PubSub_connectivity" "Check_Google_Storage_connectivity" "Check_release_channels_connectivity" "Check_CARTO_images_registry_connectivity" "Check_BigQuery_connectivity" "Check_TomTom_connectivity" "Check_TravelTime_connectivity" )
-      "PubSubValidator" (list "Check_publish_and_listen_to_topic" "Check_publish_and_listen_to_topic_via_REST_API")
+      "EgressRequirementsValidator" $egressChecks
+      "PubSubValidator" $pubSubChecks
   }}
   {{/* Add optional analyzers to the preflightsDict */}}
   {{- $preflightOptionalList := list

--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -429,7 +429,7 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
         - Azure AKS
         - OpenShift
         - Replicated Embedded Cluster (single VM)
-        Local development clusters (Docker Desktop, minikube, MicroK8s) and DigitalOcean are not supported.
+        Local development clusters (Docker Desktop, Minikube, MicroK8s) and DigitalOcean are not supported.
       outcomes:
         - fail:
             when: "== docker-desktop"

--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -290,17 +290,14 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
       "WorkspaceDatabaseValidator" (list "Check_database_connection" "Check_database_encoding" "Check_user_has_right_permissions" "Check_database_version")
       "ServiceAccountValidator" (list "Check_valid_service_account")
       "BucketsValidator" (list "Check_assets_bucket" "Check_temp_bucket")
-      "EgressRequirementsValidator" (list "Check_CARTO_Auth_connectivity" "Check_PubSub_connectivity" "Check_Google_Storage_connectivity" "Check_release_channels_connectivity" "Check_CARTO_images_registry_connectivity" "Check_BigQuery_connectivity" "Check_TomTom_connectivity" "Check_TravelTime_connectivity" "Check_LaunchDarkly_connectivity")
+      "EgressRequirementsValidator" (list "Check_CARTO_Auth_connectivity" "Check_PubSub_connectivity" "Check_Google_Storage_connectivity" "Check_release_channels_connectivity" "Check_CARTO_images_registry_connectivity" "Check_BigQuery_connectivity" "Check_TomTom_connectivity" "Check_TravelTime_connectivity" )
       "PubSubValidator" (list "Check_publish_and_listen_to_topic" "Check_publish_and_listen_to_topic_via_REST_API")
   }}
-  
   {{/* Add optional analyzers to the preflightsDict */}}
-
   {{- $preflightOptionalList := list
       "Check_TravelTime_connectivity"
       "Check_TomTom_connectivity"
   }}
-
   {{/*
   We push conditionally new analyzers for the feature flags if the customer defined overridden feature flags
   */}}
@@ -333,8 +330,9 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
   {{- end }}
   {{/* First, check if each validator was skipped due to failed dependencies */}}
   {{- range $preflight, $preflightChecks := $preflightsDict }}
+  {{- range $preflightCheckName := $preflightChecks }}
   - jsonCompare:
-      checkName: {{ $preflight | replace "Validator" "" }} (skipped)
+      checkName: {{ $preflightCheckName | replace "_" " " }} (skipped)
       fileName: tenant-requirements-check/tenant-requirements-check.log
       path: "{{ $preflight }}.{{ $preflight }}.status"
       value: |
@@ -346,6 +344,7 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
         - pass:
             when: "false"
             message: "Validator was not skipped"
+  {{- end }}
   {{- end }}
   {{/* Then check individual preflight checks */}}
   {{- range $preflight, $preflightChecks  := $preflightsDict }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -897,7 +897,7 @@ Return the proper Carto tenant-requirements-checker image name
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "carto.imagePullSecrets" -}}
-{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.accountsWww.image .Values.importApi.image .Values.importWorker.image .Values.ldsApi.image .Values.mapsApi.image .Values.router.image .Values.httpCache.image .Values.cdnInvalidatorSub.image  .Values.workspaceApi.image .Values.workspaceSubscriber.image .Values.workspaceWww.image .Values.workspaceMigrations.image .Values.internalRedis.image .Values.aiApi.image .Values.aiProxy.image .Values.tenantRequirementsChecker.image) "context" $) -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.accountsWww.image .Values.aiApi.image .Values.aiProxy.image .Values.cdnInvalidatorSub.image .Values.httpCache.image .Values.importApi.image .Values.importWorker.image .Values.internalRedis.image .Values.ldsApi.image .Values.mapsApi.image .Values.router.image .Values.tenantRequirementsChecker.image .Values.workspaceApi.image .Values.workspaceMigrations.image .Values.workspaceSubscriber.image .Values.workspaceWww.image) "context" $) -}}
 {{- end -}}
 
 {{/*

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -897,7 +897,7 @@ Return the proper Carto tenant-requirements-checker image name
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "carto.imagePullSecrets" -}}
-{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.accountsWww.image .Values.importApi.image .Values.importWorker.image .Values.ldsApi.image .Values.mapsApi.image .Values.router.image .Values.httpCache.image .Values.cdnInvalidatorSub.image  .Values.workspaceApi.image .Values.workspaceSubscriber.image .Values.workspaceWww.image .Values.workspaceMigrations.image .Values.internalRedis.image .Values.aiApi.image .Values.aiProxy.image) "context" $) -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.accountsWww.image .Values.importApi.image .Values.importWorker.image .Values.ldsApi.image .Values.mapsApi.image .Values.router.image .Values.httpCache.image .Values.cdnInvalidatorSub.image  .Values.workspaceApi.image .Values.workspaceSubscriber.image .Values.workspaceWww.image .Values.workspaceMigrations.image .Values.internalRedis.image .Values.aiApi.image .Values.aiProxy.image .Values.tenantRequirementsChecker.image) "context" $) -}}
 {{- end -}}
 
 {{/*

--- a/chart/templates/preflight.yaml
+++ b/chart/templates/preflight.yaml
@@ -18,5 +18,5 @@ stringData:
             namespaces:
                 - {{ .Release.Namespace }}
     {{- include "carto.replicated.commonChecks.collectors" . | indent 6 }}
-      analyzers:
+      analyzers: 
     {{- include "carto.replicated.commonChecks.analyzers" . | indent 6 }}

--- a/chart/templates/preflight.yaml
+++ b/chart/templates/preflight.yaml
@@ -15,7 +15,8 @@ stringData:
     spec:
       collectors:
         - clusterResources:
-            exclude: true
+            namespaces:
+                - {{ .Release.Namespace }}
     {{- include "carto.replicated.commonChecks.collectors" . | indent 6 }}
       analyzers:
     {{- include "carto.replicated.commonChecks.analyzers" . | indent 6 }}

--- a/chart/templates/preflight.yaml
+++ b/chart/templates/preflight.yaml
@@ -7,13 +7,15 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 stringData:
   preflight.yaml: |
-    apiVersion: troubleshoot.sh/v1beta2
+    apiVersion: troubleshoot.sh/v1beta3
     kind: Preflight
     metadata:
       name: {{ .Release.Name }}-preflight
       namespace: {{ .Release.Namespace | quote }}
     spec:
       collectors:
+        - clusterResources:
+            exclude: true
     {{- include "carto.replicated.commonChecks.collectors" . | indent 6 }}
       analyzers:
     {{- include "carto.replicated.commonChecks.analyzers" . | indent 6 }}


### PR DESCRIPTION
## Summary

Adds new egress connectivity checks, fixes several analyzer issues, and improves preflight UX with docStrings and better resource collection.

**Related PR:** https://github.com/CartoDB/cloud-native/pull/21807

## Changes

### New Egress Checks
- Added `Check_BigQuery_connectivity` to EgressRequirementsValidator analyzers
- Added `Check_LaunchDarkly_connectivity` (conditional - only when SDK key is configured)
- Added `Check_publish_and_listen_to_topic_via_REST_API` (conditional - only when REST API is enabled)

### Bug Fixes
- **Fixed duplicate `Check_Google_Storage_connectivity`** - was listed twice in EgressRequirementsValidator analyzers (copy-paste error from original implementation)
- **Fixed duplicate images in registryImages collector** - all images were listed twice

### Missing Items Added
- Added missing images to registryImages: `aiApi`, `aiProxy`, `redis`, `routerMetrics`, `upgradeCheck`
- Added conditional logic for AI images (only when `aiFeaturesEnabled`)
- Added conditional logic for custom registry (only check all images when using custom registry)
- Added `imagePullSecrets` include for tenant-requirements-checker pod

### Preflight UX Improvements
- Added DocStrings to cluster-level analyzers (clusterVersion, containerRuntime, distribution, nodeResources, Gateway API) - supported in preflight API v1beta3
- Updated memory requirement from 16Gi to 32Gi to match actual requirements

## Type of change
- [x] Fix
- [x] Feature

## Notes

The initial implementation included a skipped status check for validators with failed dependencies. This was reverted per code review feedback as the dependency approach in cloud-native was fragile. A future improvement ticket was created: [sc-531901](https://app.shortcut.com/cartoteam/story/531901)

## Checklist
- [x] Good PR name
- [x] Related PR linked
- [x] Shortcut link