### PR TITLE
chore(gitignore): add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 **/*carto-values.yaml*
 **/customer.env
 **/*customization.yaml*
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION
## Summary
Add `.worktrees/` to `.gitignore` to support in-repo git worktree directories, following the pattern established in cloud-native (PR #23519).

## What Changed
**Added:**
- `.worktrees/` entry in `.gitignore` to prevent tracking local worktree checkouts

**Modified:**
- N/A

**Removed:**
- N/A

## Architectural Context
EAD: N/A - small change

**Architectural Decisions Made:**
- N/A - small change

## Review Focus Areas
**Critical areas** (require thorough review):
1. `.gitignore` - verify the entry correctly ignores the `.worktrees/` directory

**Safe to skip**: N/A - single-line change

## Deployment Impact
- [x] Not applicable (docs, tests only)

## Migration & Breaking Changes
- [x] No migrations or breaking changes

## Security Considerations
- [x] No security impact

## Performance Impact
- [x] No performance impact

## Tests
- [x] No tests needed (gitignore-only change)

## Dependencies
- Related: CartoDB/cloud-native#23519 (same pattern)

## How to Validate
1. Verify `.worktrees/` appears in `.gitignore`
2. Create a test directory `.worktrees/test` and confirm `git status` does not show it

## AI-Generated Code Notice
- [x] This PR contains AI-generated code
- [x] Areas requiring extra verification: N/A - trivial gitignore entry
- [ ] Not applicable

## Coding Standards Compliance
- [x] Changes follow team coding standards
- [x] No violations of deprecated patterns

## Checklist
- [x] PR title follows convention
- [ ] Shortcut story linked
- [x] One issue per PR
- [ ] Appropriate labels applied
- [ ] Reviewers assigned (or auto-assigned)
- [x] AI review findings addressed (if applicable)