### PR TITLE
fix(sql-worker): add GCS bucket SA volume mount and credentials env var [sc-540843]

### DIFF
--- a/chart/templates/sql-worker/configmap.yaml
+++ b/chart/templates/sql-worker/configmap.yaml
@@ -26,6 +26,9 @@ data:
   CARTO_TRACING_MODE: "local"
   {{- end }}
   EXPORTS_GCS_BUCKET_NAME: {{ .Values.appConfigValues.workspaceExportsBucket | quote }}
+  {{- if ( include "carto.googleCloudStorageServiceAccountKey.used" . ) }}
+  EXPORTS_GCS_CREDENTIALS_KEY_FILENAME: {{ include "carto.googleCloudStorageServiceAccountKey.secretMountAbsolutePath" . }}
+  {{- end }}
   EXPORTS_S3_BUCKET_NAME: {{ .Values.appConfigValues.awsExportBucket | quote }}
   EXPORTS_S3_BUCKET_REGION: {{ .Values.appConfigValues.awsExportBucketRegion | quote }}
   EXPORTS_S3_BUCKET_ROLE_ARN: {{ .Values.appConfigValues.exportAwsRoleArn | quote }}

--- a/chart/templates/sql-worker/deployment.yaml
+++ b/chart/templates/sql-worker/deployment.yaml
@@ -183,6 +183,11 @@ spec:
             - name: gcp-default-service-account-key
               mountPath: {{ include "carto.google.secretMountDir" . }}
               readOnly: true
+            {{- if ( include "carto.googleCloudStorageServiceAccountKey.used" . ) }}
+            - name: gcp-buckets-service-account-key
+              mountPath: {{ include "carto.googleCloudStorageServiceAccountKey.secretMountDir" . }}
+              readOnly: true
+            {{- end }}
             {{- if and .Values.externalPostgresql.sslEnabled .Values.externalPostgresql.sslCA }}
             - name: postgresql-ssl-ca
               mountPath: {{ include "carto.postgresql.configMapMountDir" . }}


### PR DESCRIPTION
## Summary
Add the missing `gcp-buckets-service-account` volume mount and `EXPORTS_GCS_CREDENTIALS_KEY_FILENAME` env var to the sql-worker deployment, matching the pattern already used by maps-api, import-api, import-worker, and workspace-api.

Story: [sc-540843](https://app.shortcut.com/cartoteam/story/540843)

## What Changed
**Added:**
- `deployment.yaml`: Volume mount for `gcp-buckets-service-account-key` (the volume was already defined but never mounted)
- `configmap.yaml`: `EXPORTS_GCS_CREDENTIALS_KEY_FILENAME` env var pointing to the mounted SA key file

**Modified:**
- None (purely additive)

**Removed:**
- None

## Root Cause
The `gcp-buckets-service-account` volume was defined in sql-worker's `volumes:` section (line 216) but was **never added to `volumeMounts:`**. Additionally, `EXPORTS_GCS_CREDENTIALS_KEY_FILENAME` was set on maps-api's configmap but missing from sql-worker's.

This meant that on selfhosted K8s environments, the sql-worker (which runs DuckDB export conversions) could not authenticate to GCS using the dedicated bucket SA. BQ exports that require DuckDB format conversion (GeoJSON, Shapefile, KML, Geopackage, Geoparquet) would hang silently because DuckDB couldn't read the intermediate Parquet files from `gs://`.

## Deployment Impact
- [ ] SaaS only
- [x] Selfhosted only
- [ ] Both SaaS and Selfhosted

## How to Validate
1. Deploy to a K8s dedicated environment with BQ exports enabled
2. Export a BQ dataset as GeoJSON (not CSV/Parquet — those are native and don't need DuckDB)
3. Verify the export completes instead of hanging

## Checklist
- [x] PR title follows convention
- [x] Shortcut story linked
- [x] One issue per PR

## AI-Generated Code Notice
- [x] This PR contains AI-generated code
- [ ] Areas requiring extra verification