### PR TITLE
fix: update trivy-action from 0.28.0 to 0.35.0

### DIFF
--- a/.github/workflows/trivy-security-scanning.yaml
+++ b/.github/workflows/trivy-security-scanning.yaml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.13' 
 
       - name: Run Trivy vulnerability scanner in IaC mode
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'config'
           hide-progress: false


### PR DESCRIPTION
## Summary

- `aquasecurity/trivy-action@0.28.0` does not exist upstream, causing the scheduled Trivy security scanning workflow to fail immediately at job setup
- Updated to `0.35.0` (latest release as of 2026-03-20)

## Reference

- Failed run: https://github.com/CartoDB/carto-selfhosted-helm/actions/runs/23519645646/job/68460004111
- Shortcut: https://app.shortcut.com/cartoteam/story/543755