### PR TITLE
fix: redirect outdated package notification to public upgrade docs [sc-509441]

### DIFF
--- a/chart/templates/pre-upgrade-check-versions-cm.yaml
+++ b/chart/templates/pre-upgrade-check-versions-cm.yaml
@@ -23,7 +23,7 @@ data :
       printf 'Release version is OK\n'
       exit 0
     else
-      printf 'Release version is outdated. Please follow the upgrade guide to update your CARTO Self-Hosted installation: https://docs.carto.com/carto-self-hosted/maintenance/upgrading\n'
+      printf 'Release version is outdated. Please follow the upgrade guide to update your CARTO Self-Hosted installation: https://docs.carto.com/carto-self-hosted/maintenance/maintenance-helm/updates\n'
       exit 1
     fi
 

--- a/chart/templates/pre-upgrade-check-versions-cm.yaml
+++ b/chart/templates/pre-upgrade-check-versions-cm.yaml
@@ -23,7 +23,7 @@ data :
       printf 'Release version is OK\n'
       exit 0
     else
-      printf 'Release version is outdated, please contact support team at support-team@carto.com.\n'
+      printf 'Release version is outdated. Please follow the upgrade guide to update your CARTO Self-Hosted installation: https://docs.carto.com/carto-self-hosted/maintenance/upgrading\n'
       exit 1
     fi
 


### PR DESCRIPTION
## Summary

Story: [sc-509441](https://app.shortcut.com/cartoteam/story/509441)

The pre-upgrade check script told customers to email `support-team@carto.com` when their `customerPackageVersion` was outdated. Changed the message to link to the public upgrade guide so customers can self-serve.

## What Changed

**Modified:**
- `chart/templates/pre-upgrade-check-versions-cm.yaml` — updated the outdated-version error message in `check-version.sh`

## Review Focus Areas

**Critical areas** (require thorough review):
1. `chart/templates/pre-upgrade-check-versions-cm.yaml` — confirm the new docs URL is correct

**Safe to skip**: everything else

## Deployment Impact

- [x] Selfhosted only

## Migration & Breaking Changes

- [x] No migrations or breaking changes

## Security Considerations

- [x] No security impact

## Performance Impact

- [x] No performance impact

## Tests

- [x] No tests needed (explain why)

Single-line message change in a shell script inside a ConfigMap template.

## Dependencies

- Related: CartoDB/cloud-native#24002

## How to Validate

1. Trigger a helm install or upgrade with a `customerPackageVersion` older than `minVersion` in `Chart.yaml`.
2. Check the pre-upgrade job logs — the message should now read: `Release version is outdated. Please follow the upgrade guide...` with the docs URL.

## AI-Generated Code Notice

- [x] This PR contains AI-generated code
- [x] Areas requiring extra verification: docs URL (`https://docs.carto.com/carto-self-hosted/maintenance/upgrading`) — confirm it resolves to the correct page

## Coding Standards Compliance

- [x] Changes follow team coding standards

## Checklist

- [x] PR title follows convention
- [x] Shortcut story linked
- [x] One issue per PR