### PR TITLE
fix(chart): correct HealthCheckPolicy spec for GKE gateway [sc-548219]

### DIFF
--- a/chart/templates/gateway/health-check-policy.yaml
+++ b/chart/templates/gateway/health-check-policy.yaml
@@ -14,9 +14,8 @@ spec:
       enabled: true
     config:
       type: HTTP
-      httpsHealthCheck:
+      httpHealthCheck:
         port: 8080
-        portName: http
         requestPath: /
   targetRef:
     group: ""


### PR DESCRIPTION
**Description of the change**

The `carto-gateway-healthcheck` `HealthCheckPolicy.networking.gke.io` template declared `type: HTTP` but nested its config block under `httpsHealthCheck:` (with an `s`). Recent GKE Gateway API CRD validation rejects this schema mismatch:

```
Error: UPGRADE FAILED: failed to create resource:
HealthCheckPolicy.networking.gke.io "carto-gateway-healthcheck" is invalid:
spec.default.config: Invalid value: httpHealthCheck must be specified for type HTTP
```

The fix:
1. Rename `httpsHealthCheck` → `httpHealthCheck` so the sub-block matches `type: HTTP`.
2. Drop `portName: http`. The `router` pod has two containers (router + routerMetrics) that both expose a port named `http`, so selecting the backend by name is ambiguous and also produces a `duplicate port name "http"` warning during render. `port: 8080` is sufficient and unambiguous.

**Benefits**

- Unblocks new self-hosted installs on GKE with the default Kubernetes access mode. This is currently blocking a live customer install (MasterWorks / STC, Thursday sync).
- Removes the `duplicate port name` warning from the Helm render output.
- Dedicated environments are unaffected either way, because they set `accessToCartoModeK8sCustom` in KOTS config, which disables `gateway.enabled`, so the template doesn't render there.

**Possible drawbacks**

- None expected. The fix brings the template into compliance with the `HealthCheckPolicy.networking.gke.io/v1` schema. Customers already on older GKE Gateway API CRD versions (that silently accepted the mismatched spec) will see the resource apply cleanly on the next reconcile.

**Applicable issues**

- Shortcut: [sc-548219](https://app.shortcut.com/cartoteam/story/548219)
- Origin: PR #542 (2024-06-03) — the template was merged with the typo; GKE has since tightened CRD validation.
- Affected chart versions: every tag from `1.110.1` through current (`1.141.1+`, including `2026.3.10`).

**Additional information**

Customer evidence (MasterWorks support bundle, `namespace-carto-selfhosted-logs/kotsadm-7747c6b5c6-hk6vv/kotsadm.log`):

> `Error: UPGRADE FAILED: failed to create resource: HealthCheckPolicy.networking.gke.io "carto-gateway-healthcheck" is invalid: spec.default.config: Invalid value: httpHealthCheck must be specified for type HTTP`

Same error repeated on three install attempts (10:52:05Z, 11:10:51Z, 11:13:04Z). All 15 `carto-*` app deployments reached Ready on the first attempt; the failure is localized to the gateway / HealthCheckPolicy apply.

**Test plan**
- [ ] Render the chart against a GKE-distribution KOTS config and confirm the HealthCheckPolicy applies cleanly.
- [ ] Verify existing dedicated environments remain unaffected (template should still not render there).
- [ ] Confirm the Helm `duplicate port name "http"` warning is gone.