### PR TITLE
chore(security): expand .gitignore with credential file patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,71 @@ analyzer-bundle-*.tar.gz
 
 # Gitleaks report artifacts (produced by local runs and CI)
 gitleaks-report.json
+
+# Credential / secret file patterns — defense in depth.
+# Belt-and-suspenders against accidental commits; secret-scanning + push
+# protection are the primary line of defense.
+
+# Google Cloud — Workload Identity Federation credential files written by
+# google-github-actions/auth (the file pattern that caused the 2026-04-30 leak).
+gha-creds-*.json
+application_default_credentials.json
+*.gcp-key.json
+*-sa.json
+service-account*.json
+
+# AWS
+.aws/credentials
+.aws/config
+aws-credentials*
+*.pem
+**/credentials.csv
+
+# SSH / GPG / TLS private keys
+*_rsa
+*_ed25519
+*_ecdsa
+*_dsa
+id_rsa*
+id_ed25519*
+*.ppk
+*.pkcs12
+*.p12
+*.pfx
+*.key
+*.gpg
+secring.*
+
+# Kubernetes
+kubeconfig
+*.kubeconfig
+*-kubeconfig
+
+# Terraform
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+.terraform/
+terraform.rc
+
+# Generic env / secret files
+.env
+.env.*
+!.env.example
+!.env.template
+.envrc
+secrets.yaml
+secrets.yml
+*.secret
+*.secrets
+
+# npm / yarn auth
+.npmrc
+!**/template.npmrc
+.yarnrc.yml.local
+
+# Helm values overrides commonly used to hold secrets locally
+values.local.yaml
+values-secrets.yaml
+values-*-secrets.yaml


### PR DESCRIPTION
## Summary

Defense-in-depth against accidental credential commits. Adds a curated list of credential file patterns to `.gitignore`, including the specific pattern (`gha-creds-*.json`) written by `google-github-actions/auth` that triggered the 2026-04-30 leak in PR #855.

This complements — does not replace — the primary controls (secret scanning + push protection at the repo level, and the `create_credentials_file: false` upstream fix in CartoDB/cloud-native#24436). The intent is that *if* any of those primary controls are misconfigured or bypassed in the future, a `git add .` won't blindly stage a credential file that matches a well-known pattern.

## What's added

Grouped, with comments:
- **GCP** — `gha-creds-*.json`, `application_default_credentials.json`, `*-sa.json`, `service-account*.json`, `*.gcp-key.json`
- **AWS** — `.aws/credentials`, `aws-credentials*`, `*.pem`, `**/credentials.csv`
- **SSH / GPG / TLS keys** — `*_rsa`, `*_ed25519`, `id_rsa*`, `*.p12`, `*.pfx`, `*.key`, `*.gpg`, `secring.*`
- **Kubernetes** — `kubeconfig`, `*.kubeconfig`
- **Terraform** — `*.tfstate*`, `*.tfvars` (with `!*.tfvars.example` carve-out), `.terraform/`, `terraform.rc`
- **Generic env / secret files** — `.env`, `.env.*` (with `!.env.example` carve-out), `secrets.yaml`, `*.secret`
- **npm/yarn** — `.npmrc`, `.yarnrc.yml.local`
- **Helm values** — `values.local.yaml`, `values-*-secrets.yaml`

## What's NOT changed

- No tracked file currently matches these patterns (verified via `git ls-files | git check-ignore --stdin`). No risk of suddenly ignoring something that was being committed before.
- `chart/values.yaml` does not match any new pattern (only `values.local.yaml` and `values-*-secrets.yaml` are caught).
- Existing patterns (`**/*key.json`, `**/k8s-google-serviceaccount-secret.yaml`, etc.) are unchanged.

## Why some entries

- `gha-creds-*.json` — the exact pattern that leaked. The pre-existing `**/*key.json` did NOT match it (the leaked filename ends in a hex hash, not `key.json`).
- `*.pem`, `*.key` — broad on purpose; private keys in a Helm chart repo are virtually never legitimate.
- `!*.tfvars.example`, `!.env.example`, `!.env.template` — explicit carve-outs so example/template files used for documentation can still be committed.

## Test plan

- [x] `git ls-files | git check-ignore --stdin --verbose` returns empty on this branch (no currently-tracked file is now ignored)
- [x] gitleaks workflow continues to pass on this PR
- [ ] CI green


---

Tracked under [sc-549806](https://app.shortcut.com/cartoteam/story/549806).
