### PR TITLE
docs(chart): replace Redis with Valkey in README descriptions

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -200,8 +200,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `cartoSecrets.instanceId.value`                                | Value of the secret used to define the instance ID for the active installation. One of `cartoSecrets.instanceId.value` or `cartoSecrets.instanceId.existingSecret` could be defined.                                                                                  | `""`             |
 | `cartoSecrets.instanceId.existingSecret.name`                  | Name of the pre-existent secret containing the `cartoSecrets.instanceId.existingSecret.key`. If `cartoSecrets.instanceId.value` is defined, this value is going to be ignored and not used.                                                                           | `""`             |
 | `cartoSecrets.instanceId.existingSecret.key`                   | Key to find in `cartoSecrets.instanceId.existingSecret.name` where the value of `cartoSecrets.instanceId` is found. If `cartoSecrets.instanceId.value` is defined, this value is going to be ignored and not used.                                                    | `""`             |
-| `cartoSecrets.redisPassword`                                   | The password for the Valkey instance.                                                                                                                                                                                                                                  |                  |
-| `cartoSecrets.redisPassword.value`                             | Value of the secret used to define the password for the Valkey instance. One of `cartoSecrets.redisPassword.value` or `cartoSecrets.redisPassword.existingSecret` could be defined.                                                                                    | `""`             |
+| `cartoSecrets.redisPassword`                                   | The password for the Valkey instance.                                                                                                                                                                                                                                 |                  |
+| `cartoSecrets.redisPassword.value`                             | Value of the secret used to define the password for the Valkey instance. One of `cartoSecrets.redisPassword.value` or `cartoSecrets.redisPassword.existingSecret` could be defined.                                                                                   | `""`             |
 | `cartoSecrets.redisPassword.existingSecret.name`               | Name of the pre-existent secret containing the `cartoSecrets.redisPassword.existingSecret.key`. If `cartoSecrets.redisPassword.value` is defined, this value is going to be ignored and not used.                                                                     | `""`             |
 | `cartoSecrets.redisPassword.existingSecret.key`                | Key to find in `cartoSecrets.redisPassword.existingSecret.name` where the value of `cartoSecrets.redisPassword` is found. If `cartoSecrets.redisPassword.value` is defined, this value is going to be ignored and not used.                                           | `redis-password` |
 | `cartoSecrets.litellmMasterKey`                                | The master key for the Litellm instance.                                                                                                                                                                                                                              |                  |
@@ -1639,29 +1639,29 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 | Name                                                              | Description                                                                                            | Value                           |
 | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------- |
-| `internalRedis.enabled`                                           | Switch value between internal-valkey deployment and external-valkey deployment                   | `true`                          |
+| `internalRedis.enabled`                                           | Switch value between internal-valkey deployment and external-valkey deployment                         | `true`                          |
 | `internalRedis.image.registry`                                    | internal-valkey image registry                                                                         | `gcr.io/carto-onprem-artifacts` |
 | `internalRedis.image.repository`                                  | internal-valkey image repository                                                                       | `valkey`                        |
 | `internalRedis.image.tag`                                         | internal-valkey image tag (immutable tags are recommended)                                             | `""`                            |
 | `internalRedis.image.pullPolicy`                                  | internal-valkey image pull policy                                                                      | `IfNotPresent`                  |
 | `internalRedis.image.pullSecrets`                                 | internal-valkey image pull secrets                                                                     | `[]`                            |
 | `internalRedis.image.pullSecrets`                                 | Image-pull secrets for private registries                                                              | `[]`                            |
-| `internalRedis.auth.enabled`                                      | Enable password authentication on internal-valkey                                                       | `true`                          |
-| `internalRedis.auth.password`                                     | Password for Valkey authentication                                                                      | `""`                            |
-| `internalRedis.containerPorts.redis`                              | internal-valkey container port                                                                          | `6379`                          |
-| `internalRedis.livenessProbe.enabled`                             | Enable livenessProbe on internal-valkey containers                                                      | `true`                          |
+| `internalRedis.auth.enabled`                                      | Enable password authentication on internal-valkey                                                      | `true`                          |
+| `internalRedis.auth.password`                                     | Password for Valkey authentication                                                                     | `""`                            |
+| `internalRedis.containerPorts.redis`                              | internal-valkey container port                                                                         | `6379`                          |
+| `internalRedis.livenessProbe.enabled`                             | Enable livenessProbe on internal-valkey containers                                                     | `true`                          |
 | `internalRedis.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                                | `10`                            |
 | `internalRedis.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                       | `30`                            |
 | `internalRedis.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                      | `5`                             |
 | `internalRedis.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                    | `5`                             |
 | `internalRedis.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                    | `1`                             |
-| `internalRedis.readinessProbe.enabled`                            | Enable readinessProbe on internal-valkey containers                                                     | `true`                          |
+| `internalRedis.readinessProbe.enabled`                            | Enable readinessProbe on internal-valkey containers                                                    | `true`                          |
 | `internalRedis.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                               | `10`                            |
 | `internalRedis.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                      | `30`                            |
 | `internalRedis.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                     | `5`                             |
 | `internalRedis.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                   | `5`                             |
 | `internalRedis.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                   | `1`                             |
-| `internalRedis.startupProbe.enabled`                              | Enable startupProbe on internal-valkey containers                                                       | `false`                         |
+| `internalRedis.startupProbe.enabled`                              | Enable startupProbe on internal-valkey containers                                                      | `false`                         |
 | `internalRedis.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                                 | `10`                            |
 | `internalRedis.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                        | `30`                            |
 | `internalRedis.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                       | `5`                             |
@@ -1674,46 +1674,46 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `internalRedis.resources.limits.cpu`                              | Container cpu limits in milliCPU cores                                                                 | `200m`                          |
 | `internalRedis.resources.requests.memory`                         | Container memory requests in MiB                                                                       | `512Mi`                         |
 | `internalRedis.resources.requests.cpu`                            | Container cpu requests in milliCPU cores                                                               | `200m`                          |
-| `internalRedis.podSecurityContext.enabled`                        | Enabled internal-valkey pods' Security Context                                                          | `true`                          |
-| `internalRedis.podSecurityContext.fsGroup`                        | Set internal-valkey pod's Security Context fsGroup                                                      | `1000`                          |
-| `internalRedis.podSecurityContext.supplementalGroups[0]`          | Set internal-valkey pod's Security Context supplementalGroups                                           | `2345`                          |
-| `internalRedis.containerSecurityContext.enabled`                  | Enabled internal-valkey containers' Security Context                                                    | `true`                          |
-| `internalRedis.containerSecurityContext.runAsUser`                | Set internal-valkey containers' Security Context runAsUser                                              | `1000`                          |
-| `internalRedis.containerSecurityContext.runAsGroup`               | Set internal-valkey containers' Security Context runAsGroup                                             | `1000`                          |
-| `internalRedis.containerSecurityContext.runAsNonRoot`             | Set internal-valkey containers' Security Context runAsNonRoot                                           | `true`                          |
-| `internalRedis.containerSecurityContext.allowPrivilegeEscalation` | Set internal-valkey containers' Security Context allowPrivilegeEscalation                               | `false`                         |
-| `internalRedis.containerSecurityContext.readOnlyRootFilesystem`   | Set internal-valkey containers' Security Context readOnlyRootFilesystem                                 | `true`                          |
-| `internalRedis.containerSecurityContext.capabilities.drop`        | Removes internal-valkey containers' Security Context capabilities                                       | `["all"]`                       |
+| `internalRedis.podSecurityContext.enabled`                        | Enabled internal-valkey pods' Security Context                                                         | `true`                          |
+| `internalRedis.podSecurityContext.fsGroup`                        | Set internal-valkey pod's Security Context fsGroup                                                     | `1000`                          |
+| `internalRedis.podSecurityContext.supplementalGroups[0]`          | Set internal-valkey pod's Security Context supplementalGroups                                          | `2345`                          |
+| `internalRedis.containerSecurityContext.enabled`                  | Enabled internal-valkey containers' Security Context                                                   | `true`                          |
+| `internalRedis.containerSecurityContext.runAsUser`                | Set internal-valkey containers' Security Context runAsUser                                             | `1000`                          |
+| `internalRedis.containerSecurityContext.runAsGroup`               | Set internal-valkey containers' Security Context runAsGroup                                            | `1000`                          |
+| `internalRedis.containerSecurityContext.runAsNonRoot`             | Set internal-valkey containers' Security Context runAsNonRoot                                          | `true`                          |
+| `internalRedis.containerSecurityContext.allowPrivilegeEscalation` | Set internal-valkey containers' Security Context allowPrivilegeEscalation                              | `false`                         |
+| `internalRedis.containerSecurityContext.readOnlyRootFilesystem`   | Set internal-valkey containers' Security Context readOnlyRootFilesystem                                | `true`                          |
+| `internalRedis.containerSecurityContext.capabilities.drop`        | Removes internal-valkey containers' Security Context capabilities                                      | `["all"]`                       |
 | `internalRedis.terminationGracePeriodSeconds`                     | Time to wait before force killing the container                                                        | `10`                            |
-| `internalRedis.existingSecret`                                    | The name of an existing Secret with your custom password for internal-valkey                            | `""`                            |
+| `internalRedis.existingSecret`                                    | The name of an existing Secret with your custom password for internal-valkey                           | `""`                            |
 | `internalRedis.command`                                           | Override default container command (useful when using custom images)                                   | `[]`                            |
 | `internalRedis.args`                                              | Override default container args (useful when using custom images)                                      | `[]`                            |
-| `internalRedis.hostAliases`                                       | internal-valkey pods host aliases                                                                       | `[]`                            |
-| `internalRedis.podLabels`                                         | Extra labels for internal-valkey pods                                                                   | `{}`                            |
-| `internalRedis.podAnnotations`                                    | Annotations for internal-valkey pods                                                                    | `{}`                            |
+| `internalRedis.hostAliases`                                       | internal-valkey pods host aliases                                                                      | `[]`                            |
+| `internalRedis.podLabels`                                         | Extra labels for internal-valkey pods                                                                  | `{}`                            |
+| `internalRedis.podAnnotations`                                    | Annotations for internal-valkey pods                                                                   | `{}`                            |
 | `internalRedis.podAffinityPreset`                                 | Pod affinity preset. Ignored if `internalRedis.affinity` is set. Allowed values: `soft` or `hard`      | `""`                            |
 | `internalRedis.podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `internalRedis.affinity` is set. Allowed values: `soft` or `hard` | `soft`                          |
 | `internalRedis.nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `internalRedis.affinity` is set                                  | `""`                            |
 | `internalRedis.nodeAffinityPreset.key`                            | Node label key to match. Ignored if `internalRedis.affinity` is set                                    | `""`                            |
 | `internalRedis.nodeAffinityPreset.values`                         | Node label values to match. Ignored if `internalRedis.affinity` is set                                 | `[]`                            |
-| `internalRedis.affinity`                                          | Affinity for internal-valkey pods assignment                                                            | `{}`                            |
-| `internalRedis.nodeSelector`                                      | Node labels for internal-valkey pods assignment                                                         | `{}`                            |
-| `internalRedis.tolerations`                                       | Tolerations for internal-valkey pods assignment                                                         | `[]`                            |
-| `internalRedis.priorityClassName`                                 | internal-valkey pods' priorityClassName                                                                 | `""`                            |
-| `internalRedis.schedulerName`                                     | Name of the k8s scheduler (other than default) for internal-valkey pods                                 | `""`                            |
-| `internalRedis.lifecycleHooks`                                    | Lifecycle hooks for internal-valkey container(s)                                                        | `{}`                            |
-| `internalRedis.extraEnvVars`                                      | Extra environment variables for internal-valkey pods                                                    | `[]`                            |
+| `internalRedis.affinity`                                          | Affinity for internal-valkey pods assignment                                                           | `{}`                            |
+| `internalRedis.nodeSelector`                                      | Node labels for internal-valkey pods assignment                                                        | `{}`                            |
+| `internalRedis.tolerations`                                       | Tolerations for internal-valkey pods assignment                                                        | `[]`                            |
+| `internalRedis.priorityClassName`                                 | internal-valkey pods' priorityClassName                                                                | `""`                            |
+| `internalRedis.schedulerName`                                     | Name of the k8s scheduler (other than default) for internal-valkey pods                                | `""`                            |
+| `internalRedis.lifecycleHooks`                                    | Lifecycle hooks for internal-valkey container(s)                                                       | `{}`                            |
+| `internalRedis.extraEnvVars`                                      | Extra environment variables for internal-valkey pods                                                   | `[]`                            |
 | `internalRedis.extraEnvVarsCM`                                    | Name of existing ConfigMap with extra env vars                                                         | `""`                            |
 | `internalRedis.extraEnvVarsSecret`                                | Name of existing Secret with extra env vars                                                            | `""`                            |
-| `internalRedis.extraVolumes`                                      | Optionally specify extra volumes for internal-valkey pod(s)                                             | `[]`                            |
-| `internalRedis.extraVolumeMounts`                                 | Optionally specify extra volumeMounts for internal-valkey container(s)                                  | `[]`                            |
-| `internalRedis.sidecars`                                          | Add additional sidecar containers to internal-valkey pod(s)                                             | `{}`                            |
-| `internalRedis.initContainers`                                    | Add additional init containers to internal-valkey pod(s)                                                | `{}`                            |
+| `internalRedis.extraVolumes`                                      | Optionally specify extra volumes for internal-valkey pod(s)                                            | `[]`                            |
+| `internalRedis.extraVolumeMounts`                                 | Optionally specify extra volumeMounts for internal-valkey container(s)                                 | `[]`                            |
+| `internalRedis.sidecars`                                          | Add additional sidecar containers to internal-valkey pod(s)                                            | `{}`                            |
+| `internalRedis.initContainers`                                    | Add additional init containers to internal-valkey pod(s)                                               | `{}`                            |
 
 ### internalRedis Service Parameters
 
-| Name                                             | Description                                         | Value       |
-| ------------------------------------------------ | --------------------------------------------------- | ----------- |
+| Name                                             | Description                                          | Value       |
+| ------------------------------------------------ | ---------------------------------------------------- | ----------- |
 | `internalRedis.service.type`                     | internal-valkey service type                         | `ClusterIP` |
 | `internalRedis.service.ports.http`               | internal-valkey service HTTP port                    | `6379`      |
 | `internalRedis.service.nodePorts.redis`          | Node port for internal-valkey service                | `""`        |
@@ -1727,15 +1727,15 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 ### External Valkey parameters
 
-| Name                                      | Description                                                                                 | Value       |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------- | ----------- |
+| Name                                      | Description                                                                                  | Value       |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------- | ----------- |
 | `externalRedis.host`                      | Valkey host                                                                                  | `localhost` |
 | `externalRedis.port`                      | Valkey port number                                                                           | `6379`      |
 | `externalRedis.password`                  | Valkey password                                                                              | `""`        |
 | `externalRedis.tlsEnabled`                | Whether or not connect to Valkey via TLS                                                     | `false`     |
 | `externalRedis.tlsCA`                     | CA certificate in case Valkey TLS cert it's selfsigned                                       | `""`        |
 | `externalRedis.existingSecret`            | Name of an existing secret resource containing the Valkey password in a 'redis-password' key | `""`        |
-| `externalRedis.existingSecretPasswordKey` | Key of the existing secret                                                                  | `""`        |
+| `externalRedis.existingSecretPasswordKey` | Key of the existing secret                                                                   | `""`        |
 
 ### Internal PostgreSQL subchart parameters
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -200,8 +200,8 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `cartoSecrets.instanceId.value`                                | Value of the secret used to define the instance ID for the active installation. One of `cartoSecrets.instanceId.value` or `cartoSecrets.instanceId.existingSecret` could be defined.                                                                                  | `""`             |
 | `cartoSecrets.instanceId.existingSecret.name`                  | Name of the pre-existent secret containing the `cartoSecrets.instanceId.existingSecret.key`. If `cartoSecrets.instanceId.value` is defined, this value is going to be ignored and not used.                                                                           | `""`             |
 | `cartoSecrets.instanceId.existingSecret.key`                   | Key to find in `cartoSecrets.instanceId.existingSecret.name` where the value of `cartoSecrets.instanceId` is found. If `cartoSecrets.instanceId.value` is defined, this value is going to be ignored and not used.                                                    | `""`             |
-| `cartoSecrets.redisPassword`                                   | The password for the Redis instance.                                                                                                                                                                                                                                  |                  |
-| `cartoSecrets.redisPassword.value`                             | Value of the secret used to define the password for the Redis instance. One of `cartoSecrets.redisPassword.value` or `cartoSecrets.redisPassword.existingSecret` could be defined.                                                                                    | `""`             |
+| `cartoSecrets.redisPassword`                                   | The password for the Valkey instance.                                                                                                                                                                                                                                  |                  |
+| `cartoSecrets.redisPassword.value`                             | Value of the secret used to define the password for the Valkey instance. One of `cartoSecrets.redisPassword.value` or `cartoSecrets.redisPassword.existingSecret` could be defined.                                                                                    | `""`             |
 | `cartoSecrets.redisPassword.existingSecret.name`               | Name of the pre-existent secret containing the `cartoSecrets.redisPassword.existingSecret.key`. If `cartoSecrets.redisPassword.value` is defined, this value is going to be ignored and not used.                                                                     | `""`             |
 | `cartoSecrets.redisPassword.existingSecret.key`                | Key to find in `cartoSecrets.redisPassword.existingSecret.name` where the value of `cartoSecrets.redisPassword` is found. If `cartoSecrets.redisPassword.value` is defined, this value is going to be ignored and not used.                                           | `redis-password` |
 | `cartoSecrets.litellmMasterKey`                                | The master key for the Litellm instance.                                                                                                                                                                                                                              |                  |
@@ -1639,29 +1639,29 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 
 | Name                                                              | Description                                                                                            | Value                           |
 | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------- |
-| `internalRedis.enabled`                                           | Switch value between internal-valkey deployment and external-redis/valkey deployment                   | `true`                          |
+| `internalRedis.enabled`                                           | Switch value between internal-valkey deployment and external-valkey deployment                   | `true`                          |
 | `internalRedis.image.registry`                                    | internal-valkey image registry                                                                         | `gcr.io/carto-onprem-artifacts` |
 | `internalRedis.image.repository`                                  | internal-valkey image repository                                                                       | `valkey`                        |
 | `internalRedis.image.tag`                                         | internal-valkey image tag (immutable tags are recommended)                                             | `""`                            |
 | `internalRedis.image.pullPolicy`                                  | internal-valkey image pull policy                                                                      | `IfNotPresent`                  |
 | `internalRedis.image.pullSecrets`                                 | internal-valkey image pull secrets                                                                     | `[]`                            |
 | `internalRedis.image.pullSecrets`                                 | Image-pull secrets for private registries                                                              | `[]`                            |
-| `internalRedis.auth.enabled`                                      | Enable password authentication on internal-redis                                                       | `true`                          |
-| `internalRedis.auth.password`                                     | Password for Redis authentication                                                                      | `""`                            |
-| `internalRedis.containerPorts.redis`                              | internal-redis container port                                                                          | `6379`                          |
-| `internalRedis.livenessProbe.enabled`                             | Enable livenessProbe on internal-redis containers                                                      | `true`                          |
+| `internalRedis.auth.enabled`                                      | Enable password authentication on internal-valkey                                                       | `true`                          |
+| `internalRedis.auth.password`                                     | Password for Valkey authentication                                                                      | `""`                            |
+| `internalRedis.containerPorts.redis`                              | internal-valkey container port                                                                          | `6379`                          |
+| `internalRedis.livenessProbe.enabled`                             | Enable livenessProbe on internal-valkey containers                                                      | `true`                          |
 | `internalRedis.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                                | `10`                            |
 | `internalRedis.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                       | `30`                            |
 | `internalRedis.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                      | `5`                             |
 | `internalRedis.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                    | `5`                             |
 | `internalRedis.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                    | `1`                             |
-| `internalRedis.readinessProbe.enabled`                            | Enable readinessProbe on internal-redis containers                                                     | `true`                          |
+| `internalRedis.readinessProbe.enabled`                            | Enable readinessProbe on internal-valkey containers                                                     | `true`                          |
 | `internalRedis.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                               | `10`                            |
 | `internalRedis.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                      | `30`                            |
 | `internalRedis.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                     | `5`                             |
 | `internalRedis.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                   | `5`                             |
 | `internalRedis.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                   | `1`                             |
-| `internalRedis.startupProbe.enabled`                              | Enable startupProbe on internal-redis containers                                                       | `false`                         |
+| `internalRedis.startupProbe.enabled`                              | Enable startupProbe on internal-valkey containers                                                       | `false`                         |
 | `internalRedis.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                                 | `10`                            |
 | `internalRedis.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                        | `30`                            |
 | `internalRedis.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                       | `5`                             |
@@ -1674,67 +1674,67 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `internalRedis.resources.limits.cpu`                              | Container cpu limits in milliCPU cores                                                                 | `200m`                          |
 | `internalRedis.resources.requests.memory`                         | Container memory requests in MiB                                                                       | `512Mi`                         |
 | `internalRedis.resources.requests.cpu`                            | Container cpu requests in milliCPU cores                                                               | `200m`                          |
-| `internalRedis.podSecurityContext.enabled`                        | Enabled internal-redis pods' Security Context                                                          | `true`                          |
-| `internalRedis.podSecurityContext.fsGroup`                        | Set internal-redis pod's Security Context fsGroup                                                      | `1000`                          |
-| `internalRedis.podSecurityContext.supplementalGroups[0]`          | Set internal-redis pod's Security Context supplementalGroups                                           | `2345`                          |
-| `internalRedis.containerSecurityContext.enabled`                  | Enabled internal-redis containers' Security Context                                                    | `true`                          |
-| `internalRedis.containerSecurityContext.runAsUser`                | Set internal-redis containers' Security Context runAsUser                                              | `1000`                          |
-| `internalRedis.containerSecurityContext.runAsGroup`               | Set internal-redis containers' Security Context runAsGroup                                             | `1000`                          |
-| `internalRedis.containerSecurityContext.runAsNonRoot`             | Set internal-redis containers' Security Context runAsNonRoot                                           | `true`                          |
-| `internalRedis.containerSecurityContext.allowPrivilegeEscalation` | Set internal-redis containers' Security Context allowPrivilegeEscalation                               | `false`                         |
-| `internalRedis.containerSecurityContext.readOnlyRootFilesystem`   | Set internal-redis containers' Security Context readOnlyRootFilesystem                                 | `true`                          |
-| `internalRedis.containerSecurityContext.capabilities.drop`        | Removes internal-redis containers' Security Context capabilities                                       | `["all"]`                       |
+| `internalRedis.podSecurityContext.enabled`                        | Enabled internal-valkey pods' Security Context                                                          | `true`                          |
+| `internalRedis.podSecurityContext.fsGroup`                        | Set internal-valkey pod's Security Context fsGroup                                                      | `1000`                          |
+| `internalRedis.podSecurityContext.supplementalGroups[0]`          | Set internal-valkey pod's Security Context supplementalGroups                                           | `2345`                          |
+| `internalRedis.containerSecurityContext.enabled`                  | Enabled internal-valkey containers' Security Context                                                    | `true`                          |
+| `internalRedis.containerSecurityContext.runAsUser`                | Set internal-valkey containers' Security Context runAsUser                                              | `1000`                          |
+| `internalRedis.containerSecurityContext.runAsGroup`               | Set internal-valkey containers' Security Context runAsGroup                                             | `1000`                          |
+| `internalRedis.containerSecurityContext.runAsNonRoot`             | Set internal-valkey containers' Security Context runAsNonRoot                                           | `true`                          |
+| `internalRedis.containerSecurityContext.allowPrivilegeEscalation` | Set internal-valkey containers' Security Context allowPrivilegeEscalation                               | `false`                         |
+| `internalRedis.containerSecurityContext.readOnlyRootFilesystem`   | Set internal-valkey containers' Security Context readOnlyRootFilesystem                                 | `true`                          |
+| `internalRedis.containerSecurityContext.capabilities.drop`        | Removes internal-valkey containers' Security Context capabilities                                       | `["all"]`                       |
 | `internalRedis.terminationGracePeriodSeconds`                     | Time to wait before force killing the container                                                        | `10`                            |
-| `internalRedis.existingSecret`                                    | The name of an existing Secret with your custom password for internal-redis                            | `""`                            |
+| `internalRedis.existingSecret`                                    | The name of an existing Secret with your custom password for internal-valkey                            | `""`                            |
 | `internalRedis.command`                                           | Override default container command (useful when using custom images)                                   | `[]`                            |
 | `internalRedis.args`                                              | Override default container args (useful when using custom images)                                      | `[]`                            |
-| `internalRedis.hostAliases`                                       | internal-redis pods host aliases                                                                       | `[]`                            |
-| `internalRedis.podLabels`                                         | Extra labels for internal-redis pods                                                                   | `{}`                            |
-| `internalRedis.podAnnotations`                                    | Annotations for internal-redis pods                                                                    | `{}`                            |
+| `internalRedis.hostAliases`                                       | internal-valkey pods host aliases                                                                       | `[]`                            |
+| `internalRedis.podLabels`                                         | Extra labels for internal-valkey pods                                                                   | `{}`                            |
+| `internalRedis.podAnnotations`                                    | Annotations for internal-valkey pods                                                                    | `{}`                            |
 | `internalRedis.podAffinityPreset`                                 | Pod affinity preset. Ignored if `internalRedis.affinity` is set. Allowed values: `soft` or `hard`      | `""`                            |
 | `internalRedis.podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `internalRedis.affinity` is set. Allowed values: `soft` or `hard` | `soft`                          |
 | `internalRedis.nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `internalRedis.affinity` is set                                  | `""`                            |
 | `internalRedis.nodeAffinityPreset.key`                            | Node label key to match. Ignored if `internalRedis.affinity` is set                                    | `""`                            |
 | `internalRedis.nodeAffinityPreset.values`                         | Node label values to match. Ignored if `internalRedis.affinity` is set                                 | `[]`                            |
-| `internalRedis.affinity`                                          | Affinity for internal-redis pods assignment                                                            | `{}`                            |
-| `internalRedis.nodeSelector`                                      | Node labels for internal-redis pods assignment                                                         | `{}`                            |
-| `internalRedis.tolerations`                                       | Tolerations for internal-redis pods assignment                                                         | `[]`                            |
-| `internalRedis.priorityClassName`                                 | internal-redis pods' priorityClassName                                                                 | `""`                            |
-| `internalRedis.schedulerName`                                     | Name of the k8s scheduler (other than default) for internal-redis pods                                 | `""`                            |
-| `internalRedis.lifecycleHooks`                                    | Lifecycle hooks for internal-redis container(s)                                                        | `{}`                            |
-| `internalRedis.extraEnvVars`                                      | Extra environment variables for internal-redis pods                                                    | `[]`                            |
+| `internalRedis.affinity`                                          | Affinity for internal-valkey pods assignment                                                            | `{}`                            |
+| `internalRedis.nodeSelector`                                      | Node labels for internal-valkey pods assignment                                                         | `{}`                            |
+| `internalRedis.tolerations`                                       | Tolerations for internal-valkey pods assignment                                                         | `[]`                            |
+| `internalRedis.priorityClassName`                                 | internal-valkey pods' priorityClassName                                                                 | `""`                            |
+| `internalRedis.schedulerName`                                     | Name of the k8s scheduler (other than default) for internal-valkey pods                                 | `""`                            |
+| `internalRedis.lifecycleHooks`                                    | Lifecycle hooks for internal-valkey container(s)                                                        | `{}`                            |
+| `internalRedis.extraEnvVars`                                      | Extra environment variables for internal-valkey pods                                                    | `[]`                            |
 | `internalRedis.extraEnvVarsCM`                                    | Name of existing ConfigMap with extra env vars                                                         | `""`                            |
 | `internalRedis.extraEnvVarsSecret`                                | Name of existing Secret with extra env vars                                                            | `""`                            |
-| `internalRedis.extraVolumes`                                      | Optionally specify extra volumes for internal-redis pod(s)                                             | `[]`                            |
-| `internalRedis.extraVolumeMounts`                                 | Optionally specify extra volumeMounts for internal-redis container(s)                                  | `[]`                            |
-| `internalRedis.sidecars`                                          | Add additional sidecar containers to internal-redis pod(s)                                             | `{}`                            |
-| `internalRedis.initContainers`                                    | Add additional init containers to internal-redis pod(s)                                                | `{}`                            |
+| `internalRedis.extraVolumes`                                      | Optionally specify extra volumes for internal-valkey pod(s)                                             | `[]`                            |
+| `internalRedis.extraVolumeMounts`                                 | Optionally specify extra volumeMounts for internal-valkey container(s)                                  | `[]`                            |
+| `internalRedis.sidecars`                                          | Add additional sidecar containers to internal-valkey pod(s)                                             | `{}`                            |
+| `internalRedis.initContainers`                                    | Add additional init containers to internal-valkey pod(s)                                                | `{}`                            |
 
 ### internalRedis Service Parameters
 
 | Name                                             | Description                                         | Value       |
 | ------------------------------------------------ | --------------------------------------------------- | ----------- |
-| `internalRedis.service.type`                     | internal-redis service type                         | `ClusterIP` |
-| `internalRedis.service.ports.http`               | internal-redis service HTTP port                    | `6379`      |
-| `internalRedis.service.nodePorts.redis`          | Node port for internal-redis service                | `""`        |
-| `internalRedis.service.clusterIP`                | internal-redis service ClusterIP                    | `""`        |
-| `internalRedis.service.loadBalancerIP`           | internal-redis service LoadBalancer IP              | `""`        |
-| `internalRedis.service.labelSelectorsOverride`   | Label selectors override for internal-redis service | `{}`        |
-| `internalRedis.service.loadBalancerSourceRanges` | internal-redis service LoadBalancer source ranges   | `[]`        |
-| `internalRedis.service.externalTrafficPolicy`    | internal-redis service external traffic policy      | `Cluster`   |
-| `internalRedis.service.annotations`              | Additional annotations for internal-redis service   | `{}`        |
-| `internalRedis.service.extraPorts`               | Extra ports for internal-redis service              | `[]`        |
+| `internalRedis.service.type`                     | internal-valkey service type                         | `ClusterIP` |
+| `internalRedis.service.ports.http`               | internal-valkey service HTTP port                    | `6379`      |
+| `internalRedis.service.nodePorts.redis`          | Node port for internal-valkey service                | `""`        |
+| `internalRedis.service.clusterIP`                | internal-valkey service ClusterIP                    | `""`        |
+| `internalRedis.service.loadBalancerIP`           | internal-valkey service LoadBalancer IP              | `""`        |
+| `internalRedis.service.labelSelectorsOverride`   | Label selectors override for internal-valkey service | `{}`        |
+| `internalRedis.service.loadBalancerSourceRanges` | internal-valkey service LoadBalancer source ranges   | `[]`        |
+| `internalRedis.service.externalTrafficPolicy`    | internal-valkey service external traffic policy      | `Cluster`   |
+| `internalRedis.service.annotations`              | Additional annotations for internal-valkey service   | `{}`        |
+| `internalRedis.service.extraPorts`               | Extra ports for internal-valkey service              | `[]`        |
 
-### External Redis parameters
+### External Valkey parameters
 
 | Name                                      | Description                                                                                 | Value       |
 | ----------------------------------------- | ------------------------------------------------------------------------------------------- | ----------- |
-| `externalRedis.host`                      | Redis host                                                                                  | `localhost` |
-| `externalRedis.port`                      | Redis port number                                                                           | `6379`      |
-| `externalRedis.password`                  | Redis password                                                                              | `""`        |
-| `externalRedis.tlsEnabled`                | Whether or not connect to Redis via TLS                                                     | `false`     |
-| `externalRedis.tlsCA`                     | CA certificate in case Redis TLS cert it's selfsigned                                       | `""`        |
-| `externalRedis.existingSecret`            | Name of an existing secret resource containing the Redis password in a 'redis-password' key | `""`        |
+| `externalRedis.host`                      | Valkey host                                                                                  | `localhost` |
+| `externalRedis.port`                      | Valkey port number                                                                           | `6379`      |
+| `externalRedis.password`                  | Valkey password                                                                              | `""`        |
+| `externalRedis.tlsEnabled`                | Whether or not connect to Valkey via TLS                                                     | `false`     |
+| `externalRedis.tlsCA`                     | CA certificate in case Valkey TLS cert it's selfsigned                                       | `""`        |
+| `externalRedis.existingSecret`            | Name of an existing secret resource containing the Valkey password in a 'redis-password' key | `""`        |
 | `externalRedis.existingSecretPasswordKey` | Key of the existing secret                                                                  | `""`        |
 
 ### Internal PostgreSQL subchart parameters

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -398,9 +398,9 @@ cartoSecrets:
     existingSecret:
       name: ""
       key: ""
-  ## @extra cartoSecrets.redisPassword The password for the Redis instance.
+  ## @extra cartoSecrets.redisPassword The password for the Valkey instance.
   redisPassword:
-    ## @param cartoSecrets.redisPassword.value Value of the secret used to define the password for the Redis instance. One of `cartoSecrets.redisPassword.value` or `cartoSecrets.redisPassword.existingSecret` could be defined.
+    ## @param cartoSecrets.redisPassword.value Value of the secret used to define the password for the Valkey instance. One of `cartoSecrets.redisPassword.value` or `cartoSecrets.redisPassword.existingSecret` could be defined.
     value: ""
     ## @param cartoSecrets.redisPassword.existingSecret.name Name of the pre-existent secret containing the `cartoSecrets.redisPassword.existingSecret.key`. If `cartoSecrets.redisPassword.value` is defined, this value is going to be ignored and not used.
     ## @param cartoSecrets.redisPassword.existingSecret.key Key to find in `cartoSecrets.redisPassword.existingSecret.name` where the value of `cartoSecrets.redisPassword` is found. If `cartoSecrets.redisPassword.value` is defined, this value is going to be ignored and not used.
@@ -5206,7 +5206,7 @@ tenantRequirementsChecker:
 ##
 internalRedis:
   ## internal-valkey image (formerly Redis; key name kept for backward compatibility)
-  ## @param internalRedis.enabled Switch value between internal-valkey deployment and external-redis/valkey deployment
+  ## @param internalRedis.enabled Switch value between internal-valkey deployment and external-valkey deployment
   ## @param internalRedis.image.registry internal-valkey image registry
   ## @param internalRedis.image.repository internal-valkey image repository
   ## @param internalRedis.image.tag internal-valkey image tag (immutable tags are recommended)
@@ -5229,21 +5229,21 @@ internalRedis:
     ## @param internalRedis.image.pullSecrets Image-pull secrets for private registries
     pullSecrets: []
 
-  ## @param internalRedis.auth.enabled Enable password authentication on internal-redis
-  ## @param internalRedis.auth.password Password for Redis authentication
+  ## @param internalRedis.auth.enabled Enable password authentication on internal-valkey
+  ## @param internalRedis.auth.password Password for Valkey authentication
   ##
   auth:
     enabled: true
     password: ""
 
-  ## @param internalRedis.containerPorts.redis internal-redis container port
+  ## @param internalRedis.containerPorts.redis internal-valkey container port
   ##
   containerPorts:
     redis: 6379
 
-  ## Configure extra options for internal-redis containers' liveness and readiness probes
+  ## Configure extra options for internal-valkey containers' liveness and readiness probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param internalRedis.livenessProbe.enabled Enable livenessProbe on internal-redis containers
+  ## @param internalRedis.livenessProbe.enabled Enable livenessProbe on internal-valkey containers
   ## @param internalRedis.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
   ## @param internalRedis.livenessProbe.periodSeconds Period seconds for livenessProbe
   ## @param internalRedis.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
@@ -5258,7 +5258,7 @@ internalRedis:
     successThreshold: 1
     failureThreshold: 5
 
-  ## @param internalRedis.readinessProbe.enabled Enable readinessProbe on internal-redis containers
+  ## @param internalRedis.readinessProbe.enabled Enable readinessProbe on internal-valkey containers
   ## @param internalRedis.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
   ## @param internalRedis.readinessProbe.periodSeconds Period seconds for readinessProbe
   ## @param internalRedis.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
@@ -5273,7 +5273,7 @@ internalRedis:
     successThreshold: 1
     failureThreshold: 5
 
-  ## @param internalRedis.startupProbe.enabled Enable startupProbe on internal-redis containers
+  ## @param internalRedis.startupProbe.enabled Enable startupProbe on internal-valkey containers
   ## @param internalRedis.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
   ## @param internalRedis.startupProbe.periodSeconds Period seconds for startupProbe
   ## @param internalRedis.startupProbe.timeoutSeconds Timeout seconds for startupProbe
@@ -5300,7 +5300,7 @@ internalRedis:
   ##
   customStartupProbe: {}
 
-  ## internal-redis resource requests and limits
+  ## internal-valkey resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ## @param internalRedis.resources.limits.memory Container memory limits in MiB
   ## @param internalRedis.resources.limits.cpu Container cpu limits in milliCPU cores
@@ -5317,9 +5317,9 @@ internalRedis:
 
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  ## @param internalRedis.podSecurityContext.enabled Enabled internal-redis pods' Security Context
-  ## @param internalRedis.podSecurityContext.fsGroup Set internal-redis pod's Security Context fsGroup
-  ## @param internalRedis.podSecurityContext.supplementalGroups[0] Set internal-redis pod's Security Context supplementalGroups
+  ## @param internalRedis.podSecurityContext.enabled Enabled internal-valkey pods' Security Context
+  ## @param internalRedis.podSecurityContext.fsGroup Set internal-valkey pod's Security Context fsGroup
+  ## @param internalRedis.podSecurityContext.supplementalGroups[0] Set internal-valkey pod's Security Context supplementalGroups
   ##
   podSecurityContext:
     enabled: true
@@ -5328,13 +5328,13 @@ internalRedis:
 
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-  ## @param internalRedis.containerSecurityContext.enabled Enabled internal-redis containers' Security Context
-  ## @param internalRedis.containerSecurityContext.runAsUser Set internal-redis containers' Security Context runAsUser
-  ## @param internalRedis.containerSecurityContext.runAsGroup Set internal-redis containers' Security Context runAsGroup
-  ## @param internalRedis.containerSecurityContext.runAsNonRoot Set internal-redis containers' Security Context runAsNonRoot
-  ## @param internalRedis.containerSecurityContext.allowPrivilegeEscalation Set internal-redis containers' Security Context allowPrivilegeEscalation
-  ## @param internalRedis.containerSecurityContext.readOnlyRootFilesystem Set internal-redis containers' Security Context readOnlyRootFilesystem
-  ## @param internalRedis.containerSecurityContext.capabilities.drop Removes internal-redis containers' Security Context capabilities
+  ## @param internalRedis.containerSecurityContext.enabled Enabled internal-valkey containers' Security Context
+  ## @param internalRedis.containerSecurityContext.runAsUser Set internal-valkey containers' Security Context runAsUser
+  ## @param internalRedis.containerSecurityContext.runAsGroup Set internal-valkey containers' Security Context runAsGroup
+  ## @param internalRedis.containerSecurityContext.runAsNonRoot Set internal-valkey containers' Security Context runAsNonRoot
+  ## @param internalRedis.containerSecurityContext.allowPrivilegeEscalation Set internal-valkey containers' Security Context allowPrivilegeEscalation
+  ## @param internalRedis.containerSecurityContext.readOnlyRootFilesystem Set internal-valkey containers' Security Context readOnlyRootFilesystem
+  ## @param internalRedis.containerSecurityContext.capabilities.drop Removes internal-valkey containers' Security Context capabilities
   ##
   containerSecurityContext:
     enabled: true
@@ -5351,7 +5351,7 @@ internalRedis:
   ##
   terminationGracePeriodSeconds: 10
 
-  ## @param internalRedis.existingSecret The name of an existing Secret with your custom password for internal-redis
+  ## @param internalRedis.existingSecret The name of an existing Secret with your custom password for internal-valkey
   ##
   existingSecret: ""
 
@@ -5363,15 +5363,15 @@ internalRedis:
   ##
   args: []
 
-  ## @param internalRedis.hostAliases internal-redis pods host aliases
+  ## @param internalRedis.hostAliases internal-valkey pods host aliases
   ##
   hostAliases: []
 
-  ## @param internalRedis.podLabels Extra labels for internal-redis pods
+  ## @param internalRedis.podLabels Extra labels for internal-valkey pods
   ##
   podLabels: {}
 
-  ## @param internalRedis.podAnnotations Annotations for internal-redis pods
+  ## @param internalRedis.podAnnotations Annotations for internal-valkey pods
   ##
   podAnnotations: {}
 
@@ -5383,7 +5383,7 @@ internalRedis:
   ##
   podAntiAffinityPreset: soft
 
-  ## internal-redis affinity preset
+  ## internal-valkey affinity preset
   ##
   nodeAffinityPreset:
     ## @param internalRedis.nodeAffinityPreset.type Node affinity preset type. Ignored if `internalRedis.affinity` is set
@@ -5396,31 +5396,31 @@ internalRedis:
     ##
     values: []
 
-  ## @param internalRedis.affinity Affinity for internal-redis pods assignment
+  ## @param internalRedis.affinity Affinity for internal-valkey pods assignment
   ##
   affinity: {}
 
-  ## @param internalRedis.nodeSelector Node labels for internal-redis pods assignment
+  ## @param internalRedis.nodeSelector Node labels for internal-valkey pods assignment
   ##
   nodeSelector: {}
 
-  ## @param internalRedis.tolerations Tolerations for internal-redis pods assignment
+  ## @param internalRedis.tolerations Tolerations for internal-valkey pods assignment
   ##
   tolerations: []
 
-  ## @param internalRedis.priorityClassName internal-redis pods' priorityClassName
+  ## @param internalRedis.priorityClassName internal-valkey pods' priorityClassName
   ##
   priorityClassName: ""
 
-  ## @param internalRedis.schedulerName Name of the k8s scheduler (other than default) for internal-redis pods
+  ## @param internalRedis.schedulerName Name of the k8s scheduler (other than default) for internal-valkey pods
   ##
   schedulerName: ""
 
-  ## @param internalRedis.lifecycleHooks Lifecycle hooks for internal-redis container(s)
+  ## @param internalRedis.lifecycleHooks Lifecycle hooks for internal-valkey container(s)
   ##
   lifecycleHooks: {}
 
-  ## @param internalRedis.extraEnvVars Extra environment variables for internal-redis pods
+  ## @param internalRedis.extraEnvVars Extra environment variables for internal-valkey pods
   ##
   extraEnvVars: []
 
@@ -5432,67 +5432,67 @@ internalRedis:
   ##
   extraEnvVarsSecret: ""
 
-  ## @param internalRedis.extraVolumes Optionally specify extra volumes for internal-redis pod(s)
+  ## @param internalRedis.extraVolumes Optionally specify extra volumes for internal-valkey pod(s)
   ##
   extraVolumes: []
 
-  ## @param internalRedis.extraVolumeMounts Optionally specify extra volumeMounts for internal-redis container(s)
+  ## @param internalRedis.extraVolumeMounts Optionally specify extra volumeMounts for internal-valkey container(s)
   ##
   extraVolumeMounts: []
 
-  ## @param internalRedis.sidecars Add additional sidecar containers to internal-redis pod(s)
+  ## @param internalRedis.sidecars Add additional sidecar containers to internal-valkey pod(s)
   ##
   sidecars: {}
 
-  ## @param internalRedis.initContainers Add additional init containers to internal-redis pod(s)
+  ## @param internalRedis.initContainers Add additional init containers to internal-valkey pod(s)
   ##
   initContainers: {}
 
   ## @section internalRedis Service Parameters
   ##
   service:
-    ## @param internalRedis.service.type internal-redis service type
+    ## @param internalRedis.service.type internal-valkey service type
     ##
     type: ClusterIP
-    ## @param internalRedis.service.ports.http internal-redis service HTTP port
+    ## @param internalRedis.service.ports.http internal-valkey service HTTP port
     ##
     ports:
       http: 6379
-    ## @param internalRedis.service.nodePorts.redis Node port for internal-redis service
+    ## @param internalRedis.service.nodePorts.redis Node port for internal-valkey service
     ##
     nodePorts:
       redis: ""
-    ## @param internalRedis.service.clusterIP internal-redis service ClusterIP
+    ## @param internalRedis.service.clusterIP internal-valkey service ClusterIP
     ##
     clusterIP: ""
-    ## @param internalRedis.service.loadBalancerIP internal-redis service LoadBalancer IP
+    ## @param internalRedis.service.loadBalancerIP internal-valkey service LoadBalancer IP
     ##
     loadBalancerIP: ""
-    ## @param internalRedis.service.labelSelectorsOverride Label selectors override for internal-redis service
+    ## @param internalRedis.service.labelSelectorsOverride Label selectors override for internal-valkey service
     ##
     labelSelectorsOverride: {}
-    ## @param internalRedis.service.loadBalancerSourceRanges internal-redis service LoadBalancer source ranges
+    ## @param internalRedis.service.loadBalancerSourceRanges internal-valkey service LoadBalancer source ranges
     ##
     loadBalancerSourceRanges: []
-    ## @param internalRedis.service.externalTrafficPolicy internal-redis service external traffic policy
+    ## @param internalRedis.service.externalTrafficPolicy internal-valkey service external traffic policy
     ##
     externalTrafficPolicy: Cluster
-    ## @param internalRedis.service.annotations Additional annotations for internal-redis service
+    ## @param internalRedis.service.annotations Additional annotations for internal-valkey service
     ##
     annotations: {}
-    ## @param internalRedis.service.extraPorts Extra ports for internal-redis service
+    ## @param internalRedis.service.extraPorts Extra ports for internal-valkey service
     ##
     extraPorts: []
 
-## @section External Redis parameters
-## External Redis configuration
+## @section External Valkey parameters
+## External Valkey configuration
 ## All of these values are only used when redis.enabled is set to false
-## @param externalRedis.host Redis host
-## @param externalRedis.port Redis port number
-## @param externalRedis.password Redis password
-## @param externalRedis.tlsEnabled Whether or not connect to Redis via TLS
-## @param externalRedis.tlsCA CA certificate in case Redis TLS cert it's selfsigned
-## @param externalRedis.existingSecret Name of an existing secret resource containing the Redis password in a 'redis-password' key
+## @param externalRedis.host Valkey host
+## @param externalRedis.port Valkey port number
+## @param externalRedis.password Valkey password
+## @param externalRedis.tlsEnabled Whether or not connect to Valkey via TLS
+## @param externalRedis.tlsCA CA certificate in case Valkey TLS cert it's selfsigned
+## @param externalRedis.existingSecret Name of an existing secret resource containing the Valkey password in a 'redis-password' key
 ## @param externalRedis.existingSecretPasswordKey Key of the existing secret
 ##
 externalRedis:


### PR DESCRIPTION
## Summary

Updates `chart/README.md` description text to reflect the Redis→Valkey migration that landed in chart `1.251.6` (commit `47c5087`, CARTO Self-Hosted **2026.04**). README-only, no `values.yaml` changes — fully non-breaking.

Shortcut: [sc-545928](https://app.shortcut.com/cartoteam/story/545928)

## What changed

In `chart/README.md`, replaced `Redis` → `Valkey` (and `internal-redis`/`external-redis` → `internal-valkey`/`external-valkey`) **in description-column text only**. 52 line changes; all changes are inside the right-hand description column of parameter tables, plus one section heading.

## What was deliberately NOT changed

- **`chart/values.yaml`** — untouched. No key, value, default, or `## @param` comment was modified. The README will go out-of-sync with `values.yaml` `## @param` description comments; that sync is a follow-up that can be handled by regenerating the README via `readme-generator-for-helm` after the source comments are updated. Doing it as a docs-only README edit was the explicit ask to keep the PR scope tight and non-breaking.
- **Chart keys** — `internalRedis.*`, `externalRedis.*`, `cartoSecrets.redisPassword.*`, `internalRedis.containerPorts.redis`, `internalRedis.service.nodePorts.redis` all kept verbatim. Renaming them would be a breaking change.
- **Example secret-key value `redis-password`** — kept (it's a literal example identifier; renaming would force users to migrate Kubernetes Secrets).
- **Section heading `internalRedis Deployment Parameters` / `internalRedis Service Parameters`** — kept (names the camelCase chart key family verbatim). The other heading `### External Redis parameters` was descriptive (spaced "External Redis"), so it became `### External Valkey parameters`.

## Companion PR

`gitbook-documentation` non-legacy Self-Hosted public docs are updated in [PR #179](https://github.com/CartoDB/gitbook-documentation/pull/179).

## Test plan

- [ ] `helm lint chart/` still passes (no logic touched, but worth confirming).
- [ ] Confirm chart `README.md` renders correctly on GitHub.
- [ ] Follow-up: when `values.yaml` `## @param` comments get the matching update and the README is regenerated, this PR's diff should remain a no-op (verify the regenerator produces the same Valkey descriptions).