### PR TITLE
chore(ai-api): add AI_WORKSPACE_VITE_URL_TEMPLATE env var [sc-550806]

### DIFF
--- a/chart/templates/ai-api/configmap.yaml
+++ b/chart/templates/ai-api/configmap.yaml
@@ -23,6 +23,7 @@ data:
   AI_API_PUBLIC_URL_ALLOWED_HOSTS: {{ .Values.appConfigValues.selfHostedDomain | quote }}
   AI_API_PUBLIC_URL_HOST: {{ .Values.appConfigValues.selfHostedDomain | quote }}
   AI_API_PUBLIC_URL_TEMPLATE: 'https://${host}/api${path}'
+  AI_WORKSPACE_VITE_URL_TEMPLATE: "https://{{ .Values.appConfigValues.selfHostedDomain }}"
   {{- if .Values.aiApi.customHeaders }}
   AI_CUSTOM_HEADERS: {{ .Values.aiApi.customHeaders | toJson | quote }}
   {{- end }}


### PR DESCRIPTION
## Summary

- Adds `AI_WORKSPACE_VITE_URL_TEMPLATE` to the ai-api ConfigMap, set to `https://<selfHostedDomain>`.
- Required by ai-api after [CartoDB/cloud-native#24400](https://github.com/CartoDB/cloud-native/pull/24400) — the rewritten `view_map` MCP tool reads this on boot via `getStringSetting('AI_WORKSPACE_VITE_URL_TEMPLATE')` and ai-api will refuse to start without it.
- Used to build the "Open in Builder" deep-link in the `load_builder_map` MCP iframe header. workspace-www is served at the root path on selfhosted (cf. `REACT_APP_API_BASE_URL: https://<host>/api`), so no path suffix is needed. The `{tenant_id}` placeholder is omitted (single-tenant) — ai-api strips trailing slashes and substitutes `{tenant_id}` defensively.

## Shortcut

[sc-550806](https://app.shortcut.com/cartoteam/story/550806) — Add AI_WORKSPACE_VITE_URL_TEMPLATE env var to selfhosted ai-api deployment

## Test plan

- [x] `helm template chart --set appConfigValues.aiFeaturesEnabled=true --set appConfigValues.selfHostedDomain=carto.example.com --show-only templates/ai-api/configmap.yaml` renders `AI_WORKSPACE_VITE_URL_TEMPLATE: "https://carto.example.com"`.
- [x] ai-api deployment already loads this ConfigMap via `envFrom: configMapRef` (deployment.yaml:119-121), so the var lands in the container.
- [ ] Verify ai-api boots cleanly on a selfhosted instance once #24400 ships.
- [ ] Smoke-test the "Open in Builder" link from the `load_builder_map` MCP tool resolves to the selfhosted workspace origin.

## Related

- PR https://github.com/CartoDB/cloud-native/pull/24400
- Review thread https://github.com/CartoDB/cloud-native/pull/24400#discussion_r3201199881