### PR TITLE
fix(router-metrics): mount proxy CA so PubSub TLS verifies through external proxy

### DIFF
--- a/chart/templates/router/deployment.yaml
+++ b/chart/templates/router/deployment.yaml
@@ -231,6 +231,11 @@ spec:
             - name: gcp-default-service-account-key
               mountPath: {{ include "carto.google.secretMountDir" . }}
               readOnly: true
+            {{- if and .Values.externalProxy.enabled (or .Values.externalProxy.sslCA .Values.externalProxy.sslCAConfigmap.name) }}
+            - name: proxy-ssl-ca
+              mountPath: {{ include "carto.proxy.configMapMountDir" . }}
+              readOnly: true
+            {{- end }}
           {{- if .Values.routerMetrics.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.routerMetrics.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -255,6 +260,11 @@ spec:
             items:
               - key: {{ include "carto.google.secretKey" . }}
                 path: {{ include "carto.google.secretMountFilename" . }}
+        {{- if and .Values.externalProxy.enabled (or .Values.externalProxy.sslCA .Values.externalProxy.sslCAConfigmap.name) }}
+        - name: proxy-ssl-ca
+          configMap:
+            name: {{ include "carto.proxy.configMapName" . }}
+        {{- end }}
         {{- if .Values.router.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.router.extraVolumes "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
## Summary
- `router/configmap.yaml` sets `NODE_EXTRA_CA_CERTS=/usr/src/certs/proxy-ssl-ca/ca.crt` whenever `externalProxy.sslCA` (or `sslCAConfigmap.name`) is set, and this configmap is consumed by **both** `router-http` and `router-metrics` via `envFrom`.
- `router-http` is nginx and ignores the env var, but `router-metrics` is a Node.js process that tries to load the file. Since the `proxy-ssl-ca` volume was never mounted into `router-metrics`, Node logged `Ignoring extra certs from /usr/src/certs/proxy-ssl-ca/ca.crt, load failed: ... No such file or directory`, then failed TLS verification when reaching `https://www.googleapis.com/oauth2/v4/token` through `carto-proxy` — breaking PubSub metric delivery (`UNABLE_TO_VERIFY_LEAF_SIGNATURE`).
- Mount the `proxy-ssl-ca` configmap volume into the `router-metrics` container, gated on the same condition every other Node deployment in the chart already uses (`externalProxy.enabled && (sslCA || sslCAConfigmap.name)`).

## Observed error (before fix)
```
Warning: Ignoring extra certs from `/usr/src/certs/proxy-ssl-ca/ca.crt`, load failed:
  error:80000002:system library::No such file or directory
...
FetchError: request to https://www.googleapis.com/oauth2/v4/token failed,
  reason: unable to verify the first certificate
  code: UNABLE_TO_VERIFY_LEAF_SIGNATURE
  proxy: { host: 'carto-proxy', port: 3129, secureProxy: true }
msg: "Error sending metric to PubSub"
```

## Test plan
- [x] Patched manifest applied to QA (`qa-onprem-sso` in `qa-team-sso`) — the warning disappears from `router-metrics` logs and PubSub calls succeed.
- [ ] `helm template` with `externalProxy.enabled=true` + `externalProxy.sslCA=...` renders the new `volumeMount` and `volume` in the router Deployment.
- [ ] `helm template` with `externalProxy.enabled=false` (default) is unchanged.
- [ ] `helm template` with `externalProxy.enabled=true` but no CA configured (`sslCA` and `sslCAConfigmap.name` both empty) does not add the mount/volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)