### PR TITLE
fix(import-worker,workspace-subscriber): expose missing Auth0 env vars

### DIFF
--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -12,6 +12,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
+  AUTH0_AUDIENCE: "carto-cloud-native-api"
+  AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
+  AUTH0_NAMESPACE: "http://app.carto.com"
   BIGQUERY_OAUTH2_CLIENT_ID: {{ .Values.appConfigValues.bigqueryOauth2ClientId | quote }}
   {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}

--- a/chart/templates/workspace-subscriber/configmap.yaml
+++ b/chart/templates/workspace-subscriber/configmap.yaml
@@ -14,6 +14,7 @@ metadata:
 data:
   AUTH0_AUDIENCE: "carto-cloud-native-api"
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
+  AUTH0_NAMESPACE: "http://app.carto.com"
   BIGQUERY_OAUTH2_CLIENT_ID: {{ .Values.appConfigValues.bigqueryOauth2ClientId | quote }}
   {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}


### PR DESCRIPTION
## Summary

- `import-worker` was missing all three Auth0 env vars (`AUTH0_AUDIENCE`, `AUTH0_DOMAIN`, `AUTH0_NAMESPACE`) that every other backend service in the chart exposes (`import-api`, `sql-worker`, `workspace-api`, `lds-api`, `maps-api`, `ai-api`, `aiproxy`).
- `workspace-subscriber` had `AUTH0_AUDIENCE`/`AUTH0_DOMAIN` but was missing `AUTH0_NAMESPACE`.
- Values mirror the convention used by `import-api` — the closest sibling to `import-worker`.

Frontend bundles (`accounts-www`, `workspace-www`) intentionally remain unchanged: they only consume `REACT_APP_AUTH0_DOMAIN`; the JWT-claim namespace is a backend concern.

[sc-553211](https://app.shortcut.com/cartoteam/story/553211)

## Test plan

- [x] \`helm template chart/\` renders both ConfigMaps with the new keys present
- [ ] Deploy to a test environment and verify import-worker can validate Auth0 JWTs against the expected namespace/audience

🤖 Generated with [Claude Code](https://claude.com/claude-code)