### PR TITLE
chore(import): wire Redis/Valkey into import-api and import-worker [sc-552800]

### DIFF
--- a/chart/templates/import-api/configmap.yaml
+++ b/chart/templates/import-api/configmap.yaml
@@ -94,6 +94,13 @@ data:
   {{- if eq .Values.appConfigValues.storageProvider "azure-blob" }}
   IMPORT_STORAGE_ACCOUNT: {{ .Values.appConfigValues.azureStorageAccount | quote }}
   {{- end }}
+  REDIS_CACHE_PREFIX: "onprem"
+  REDIS_HOST: {{ include "carto.redis.host" . | quote }}
+  REDIS_PORT: {{ include "carto.redis.port" . | quote }}
+  REDIS_TLS_ENABLED: {{ .Values.externalRedis.tlsEnabled | quote }}
+  {{- if and .Values.externalRedis.tlsEnabled .Values.externalRedis.tlsCA }}
+  REDIS_TLS_CA: {{ include "carto.redis.configMapMountAbsolutePath" . }}
+  {{- end }}
   {{- if .Values.externalProxy.enabled }}
   HTTP_PROXY: {{ include "carto.proxy.computedConnectionString" . | quote }}
   http_proxy: {{ include "carto.proxy.computedConnectionString" . | quote }}

--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -94,6 +94,13 @@ data:
   {{- if eq .Values.appConfigValues.storageProvider "azure-blob" }}
   IMPORT_STORAGE_ACCOUNT: {{ .Values.appConfigValues.azureStorageAccount | quote }}
   {{- end }}
+  REDIS_CACHE_PREFIX: "onprem"
+  REDIS_HOST: {{ include "carto.redis.host" . | quote }}
+  REDIS_PORT: {{ include "carto.redis.port" . | quote }}
+  REDIS_TLS_ENABLED: {{ .Values.externalRedis.tlsEnabled | quote }}
+  {{- if and .Values.externalRedis.tlsEnabled .Values.externalRedis.tlsCA }}
+  REDIS_TLS_CA: {{ include "carto.redis.configMapMountAbsolutePath" . }}
+  {{- end }}
   {{- if .Values.externalProxy.enabled }}
   HTTP_PROXY: {{ include "carto.proxy.computedConnectionString" . | quote }}
   http_proxy: {{ include "carto.proxy.computedConnectionString" . | quote }}

--- a/chart/templates/import-worker/deployment.yaml
+++ b/chart/templates/import-worker/deployment.yaml
@@ -31,6 +31,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/import-worker/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/import-worker/secret.yaml") . | sha256sum }}
+        checksum/redis-password: {{ include "carto.redis.passwordChecksum" . }}
         checksum/postgresql-password: {{ include "carto.postgresql.passwordChecksum" . }}
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         {{- if .Values.importWorker.podAnnotations }}
@@ -108,6 +109,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "carto.postgresql.secretName" . }}
                   key: {{ include "carto.postgresql.secret.key" . }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "carto.redis.secretName" . }}
+                  key: {{ include "carto.redis.existingsecret.key" . | quote }}
             {{- include "carto._utils.generateSecretDefs" (dict "vars" (list
               "BIGQUERY_OAUTH2_CLIENT_SECRET"
               "CARTO_SELFHOSTED_INSTANCE_ID"
@@ -201,6 +207,11 @@ spec:
               mountPath: {{ include "carto.postgresql.configMapMountDir" . }}
               readOnly: true
             {{- end }}
+            {{- if and .Values.externalRedis.tlsEnabled .Values.externalRedis.tlsCA }}
+            - name: redis-tls-ca
+              mountPath: {{ include "carto.redis.configMapMountDir" . }}
+              readOnly: true
+            {{- end }}
             {{- if and .Values.externalProxy.enabled (or .Values.externalProxy.sslCA .Values.externalProxy.sslCAConfigmap.name) }}
             - name: proxy-ssl-ca
               mountPath: {{ include "carto.proxy.configMapMountDir" . }}
@@ -239,6 +250,11 @@ spec:
         - name: postgresql-ssl-ca
           configMap:
             name: {{ include "carto.postgresql.configMapName" . }}
+        {{- end }}
+        {{- if and .Values.externalRedis.tlsEnabled .Values.externalRedis.tlsCA }}
+        - name: redis-tls-ca
+          configMap:
+            name: {{ include "carto.redis.configMapName" . }}
         {{- end }}
         {{- if and .Values.externalProxy.enabled (or .Values.externalProxy.sslCA .Values.externalProxy.sslCAConfigmap.name) }}
         - name: proxy-ssl-ca


### PR DESCRIPTION
## What

Wires the shared `REDIS_*` env-var contract into `import-api` and `import-worker` on Selfhosted k8s, mirroring the existing maps-api / lds-api / ai-api pattern. Companion to app-side PR CartoDB/cloud-native#24832.

Shortcut: [sc-552800](https://app.shortcut.com/cartoteam/story/552800) — epic 529993 (quota controls / usage-lock middleware).

## Changes

- **import-api/configmap.yaml** — adds the `REDIS_CACHE_PREFIX/HOST/PORT/TLS_ENABLED/TLS_CA` block. (Its deployment already had `REDIS_PASSWORD`, the `redis-tls-ca` volume+mount and the checksum — this was the only gap.)
- **import-worker/configmap.yaml** — same `REDIS_*` block.
- **import-worker/deployment.yaml** — adds `REDIS_PASSWORD` env, `redis-tls-ca` volumeMount + volume (gated on `externalRedis.tlsEnabled && tlsCA`), and `checksum/redis-password` pod annotation → full parity with import-api.

`REDIS_TLS_CA` uses the mount path (`/usr/src/certs/redis-tls-ca/ca.crt` via `carto.redis.configMapMountAbsolutePath`), matching maps-api/lds-api and the ticket.

## Decisions

- `REDIS_TIMEOUT` omitted — no API in this chart sets it; relies on app default.
- `REDIS_CACHE_PREFIX: "onprem"` — shared keyspace so the cross-API usage-lock coordinates.
- No new `values.yaml` keys (reuses `externalRedis.*` + `carto.redis.*` helpers) → `README.md` unchanged.
- No manual `Chart.yaml` version bump (CI/semver automated).
- **Ticket req #3 (NetworkPolicy) is N/A**: this chart ships no NetworkPolicy templates, so import pods already reach Valkey unrestricted. If egress rules exist anywhere they live in a separate dedicated-k8s repo.

## Test

Relying on CI helm lint/template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)