### PR TITLE
chore(gh): adopt cloud-native pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -92,9 +92,8 @@ EAD: <!-- Google Docs link to EAD, or "N/A - small change" -->
 
 ## Coding Standards Compliance
 - [ ] Changes follow team coding standards
-- [ ] No violations of deprecated patterns (e.g., no new Redux Sagas)
-- [ ] Backend: layer separation respected (middlewares → services → data layer)
-- [ ] Backend: new/modified tests are black-box (test behavior, not implementation)
+- [ ] Chart documentation updated (via helm-readme-generator)
+- [ ] Chart templates linted and validated
 
 ## Checklist
 - [ ] PR title follows convention

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,31 +1,105 @@
-<!--
- Before you open the request please review the following guidelines and tips to help it be more easily integrated:
+## Summary
+<!-- 1-2 sentences: WHAT changed and WHY -->
+Story: [sc-XXXXX]
 
- - Describe the scope of your change - i.e. what the change does.
- - Describe any known limitations with your change.
- - Please run any tests or examples that can exercise your modified code.
+## What Changed
+**Added:**
+-
 
- Thank you for contributing!
- -->
+**Modified:**
+-
 
-**Description of the change**
+**Removed:**
+-
 
-<!-- Describe the scope of your change - i.e. what the change does. -->
+## Architectural Context
+<!-- For large/initiative-level changes: link the EAD (Engineering Architecture Document) -->
+<!-- EADs live in Google Docs - paste the full URL here -->
+EAD: <!-- Google Docs link to EAD, or "N/A - small change" -->
 
-**Benefits**
+<!-- For small changes without an EAD: explain the architectural approach and
+    reasoning behind your implementation decisions (why this approach over alternatives, where was it agreed, product approved the change in X forum…) -->
 
-<!-- What benefits will be realized by the code change? -->
+**Architectural Decisions Made:**
+<!-- Answer these if your change involves architecture decisions: -->
+- Sync vs Async: <!-- e.g., "Sync endpoint - simple CRUD, responds <1s" or "Async subscriber - bulk import, emits event" -->
+- Communication pattern: <!-- e.g., "REST endpoint", "PubSub subscriber", "Event-driven" -->
+- Data access: <!-- e.g., "Query with tenant filter", "New repository method" -->
+- Why this approach: <!-- Explain trade-offs, alternatives considered -->
 
-**Possible drawbacks**
+## Review Focus Areas
+<!-- Help reviewers prioritize their time -->
+**Critical areas** (require thorough review):
+1. [File/Component] - [What to look for]
+2.
 
-<!-- Describe any known limitations with your change -->
+**Safe to skip**: [List files with trivial changes - formatting, config, auto-generated]
 
-**Applicable issues**
+## Deployment Impact
+- [ ] SaaS only
+- [ ] Selfhosted only
+- [ ] Both SaaS and Selfhosted
+- [ ] Not applicable (docs, tests only)
 
-<!-- Enter any applicable Issues here (You can reference an issue using #) -->
-  - fixes #
+## Migration & Breaking Changes
+- [ ] No migrations or breaking changes
+- [ ] Database migration (backward compatible?)
+- [ ] API contract change (versioned?)
+- [ ] Configuration change (env-specific handling?)
 
-**Additional information**
+## Security Considerations
+- [ ] No security impact
+- [ ] Auth/authorization changes
+- [ ] New API endpoints exposed
+- [ ] Data exposure or multi-tenant isolation changes
 
-<!-- If there's anything else that's important and relevant to your pull
-request, mention that information here.-->
+## Performance Impact
+<!-- If applicable: database queries, API calls, algorithm complexity, bundle size -->
+- [ ] No performance impact
+- [ ] Performance implications (describe below)
+
+<!-- If performance impact: explain changes to queries, API calls, rendering, etc. -->
+
+## Tests
+- [ ] Unit tests added/updated (coverage: XX%)
+- [ ] Integration tests added/updated
+- [ ] E2E tests added/updated
+- [ ] Selfhosted validation done
+- [ ] Edge cases verified: [list specific scenarios]
+- [ ] No tests needed (explain why)
+
+## Dependencies
+<!-- Link related PRs -->
+- Depends on: #XXX
+- Blocks: #XXX
+- Related: #XXX
+- None
+
+## How to Validate
+<!-- Step-by-step instructions for reviewers to verify this change -->
+1. ...
+2. ...
+
+## Screenshots/Demos
+<!-- If UI changes: attach before/after screenshots or video demo -->
+<!-- If backend/API: provide curl examples or API response samples -->
+
+## AI-Generated Code Notice
+<!-- If this PR contains AI-generated code (Claude Code, Copilot, etc.): -->
+- [ ] This PR contains AI-generated code
+- [ ] Areas requiring extra verification: [list specific concerns]
+- [ ] Not applicable
+
+## Coding Standards Compliance
+- [ ] Changes follow team coding standards
+- [ ] No violations of deprecated patterns (e.g., no new Redux Sagas)
+- [ ] Backend: layer separation respected (middlewares → services → data layer)
+- [ ] Backend: new/modified tests are black-box (test behavior, not implementation)
+
+## Checklist
+- [ ] PR title follows convention
+- [ ] Shortcut story linked
+- [ ] One issue per PR
+- [ ] Appropriate labels applied
+- [ ] Reviewers assigned (or auto-assigned)
+- [ ] AI review findings addressed (if applicable)


### PR DESCRIPTION
## Summary

Adopt `CartoDB/cloud-native`'s `pull_request_template.md` in this repo, replacing the current minimal template (Description / Benefits / Drawbacks / Issues), for consistency across CARTO repos — with the checkbox content adapted to a Helm chart.

## What Changed

**Added:**
- The cloud-native template's full section structure: Summary, What Changed, Architectural Context, Review Focus Areas, Deployment Impact, Migration & Breaking Changes, Security Considerations, Performance Impact, Tests, Dependencies, How to Validate, Screenshots/Demos, AI-Generated Code Notice, Coding Standards Compliance, Checklist.

**Modified (adapted to this repo):**
- **Coding Standards** — dropped Redux Sagas and backend layer separation; now covers chart-doc regeneration, template linting, wiring customer-set values across `values.yaml` + `kots-config.yaml` + `kots-helm.yaml`, `## @param` comments, leaving version fields to the release bot, and the public-repo disclosure rule.
- **Architectural Decisions** — dropped sync-vs-async / REST-vs-PubSub / repository-method prompts; now asks where the value lives, whether it is customer-facing, and what an existing install gets on upgrade.
- **Deployment Impact** — "SaaS only / Selfhosted only" is meaningless here (everything ships to Self-Hosted); now picks the *install path*: pure Helm, Replicated/KOTS, or both.
- **Migration & Breaking Changes** — dropped DB migrations and API versioning; now covers upgrade behaviour changes, renamed/removed chart values, required customer config changes, and `minKotsVersion` bumps.
- **Security Considerations** — dropped "new API endpoints exposed"; now covers secret handling, RBAC/ServiceAccount/securityContext, network exposure, and what preflight/support-bundle artifacts capture.
- **Tests** — dropped unit-coverage percentages and E2E; now covers rendering both install paths, validating on a real new install *and* an upgrade from the released chart, and chart tests / preflight specs.
- **Screenshots/Demos** — reframed for KOTS Admin Console config screens and rendered template diffs.

**Removed:**
- The previous minimal template.

## Architectural Context
EAD: N/A - small change

**Architectural Decisions Made:**
- Where the value lives: N/A — repo tooling, no chart value.
- Customer-facing or not: N/A.
- Default and upgrade behaviour: N/A.
- Why this approach: **keep cloud-native's section structure, adapt only the checkbox content.** Cross-repo consistency is the point of adopting the template, so the headings are left alone — a reviewer moving between repos sees the same shape. But a checkbox that can only ever be marked N/A is worse than no checkbox: it trains contributors to skim the whole list. So each item was rewritten to something a chart change can actually answer, drawn from the gates this repo really has (`CLAUDE.md`, `CONTRIBUTING.md`, the CI jobs).

## Review Focus Areas
**Critical areas** (require thorough review):
1. `Coding Standards Compliance` and `Tests` — these encode the repo's actual gates. If anything is missing or wrong, it will be wrong on every future PR.

**Safe to skip**: the sections carried over verbatim (Summary, What Changed, Review Focus Areas, Performance Impact, Dependencies, How to Validate, Checklist).

## Deployment Impact
- [ ] Pure Helm installs
- [ ] Replicated / KOTS installs (Admin Console, embedded cluster)
- [ ] Both install paths
- [x] Not applicable (docs, CI only)

## Migration & Breaking Changes
- [x] No migrations or breaking changes

## Security Considerations
- [x] No security impact

## Performance Impact
- [x] No performance impact

## Tests
- [ ] Renders on both install paths — N/A, no chart change
- [ ] Validated on a real install — new install — N/A
- [ ] Validated on a real install — upgrade from the released chart — N/A
- [ ] Chart tests / preflight specs added or updated — N/A
- [x] Edge cases verified: template renders as valid Markdown; every checkbox is answerable for at least one realistic change in this repo
- [x] No tests needed — a PR template has no runtime behaviour. This PR's own body is written against the new template, so it doubles as the smoke test.

## Dependencies
- Split out from the CLAUDE.md PR (#852) to keep that one focused.

## How to Validate
1. Read the rendered body of this PR — it is written against the new template.
2. Open a scratch PR in this repo and confirm the template pre-populates.
3. Check that no checkbox requires an "N/A" for a typical chart-value change.

## Screenshots/Demos
N/A — the template's own rendering is visible in this PR body.

## AI-Generated Code Notice
- [x] This PR contains AI-generated code
- [x] Areas requiring extra verification: whether the Coding Standards and Tests items match the gates the team actually wants enforced
- [ ] Not applicable

## Coding Standards Compliance
- [x] Changes follow the repo conventions
- [ ] Chart documentation updated (via helm-readme-generator) — N/A
- [ ] Chart templates linted and validated — N/A
- [ ] Customer-set values wired end to end — N/A
- [ ] New values carry a `## @param` comment — N/A
- [x] Version fields left to the release bot
- [x] No secrets, internal hostnames/project IDs, or customer data added (public repo)

## Checklist
- [x] PR title follows convention
- [ ] Shortcut story linked — no story; repo tooling chore
- [x] One issue per PR
- [x] Appropriate labels applied
- [x] Reviewers assigned (or auto-assigned)
- [x] AI review findings addressed (if applicable) — the Gemini suggestion on the Coding Standards section was applied in 4be1aca and extended here
