### PR TITLE
fix(kots): correct typo in BigQuery billing project field title

### DIFF
--- a/manifests/kots-config.yaml
+++ b/manifests/kots-config.yaml
@@ -874,7 +874,7 @@ spec:
           required: true
           type: text
         - name: bigqueryWorkloadIdentityConnectionBillingProject
-          title: Google billing broject
+          title: Google billing project
           when: *when_google_workload_identity_and_connections
           help_text: |-
             GCP project to be charged with the BigQuery costs when using Workload Identity


### PR DESCRIPTION
## Summary

Fixes a typo in `manifests/kots-config.yaml` line 877.

Field `bigqueryWorkloadIdentityConnectionBillingProject` had title:
```
Google billing broject
```
→ corrected to:
```
Google billing project
```

Found during a documentation audit cross-referencing the Admin Console field names against the docs.

Cosmetic only — no functional impact.