### PR TITLE
fix(chart): pass S3-compatible endpoint to BucketsValidator preflight [sc-559408]

### DIFF
--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -523,6 +523,18 @@ Return customer values to use in preflights and support-bundle
     value: {{ .Values.appConfigValues.awsS3Region | quote }}
   - name: WORKSPACE_IMPORTS_REGION
     value: {{ .Values.appConfigValues.awsS3Region | quote }}
+  {{- if .Values.appConfigValues.s3Endpoint }}
+  - name: WORKSPACE_THUMBNAILS_ENDPOINT
+    value: {{ .Values.appConfigValues.s3Endpoint | quote }}
+  - name: WORKSPACE_IMPORTS_ENDPOINT
+    value: {{ .Values.appConfigValues.s3Endpoint | quote }}
+  {{- end }}
+  {{- if .Values.appConfigValues.s3ForcePathStyle }}
+  - name: WORKSPACE_THUMBNAILS_FORCE_PATH_STYLE
+    value: {{ .Values.appConfigValues.s3ForcePathStyle | quote }}
+  - name: WORKSPACE_IMPORTS_FORCE_PATH_STYLE
+    value: {{ .Values.appConfigValues.s3ForcePathStyle | quote }}
+  {{- end }}
   {{- end }}
   {{- if eq .Values.appConfigValues.storageProvider "azure-blob" }}
   - name: WORKSPACE_THUMBNAILS_STORAGE_ACCOUNT
@@ -618,23 +630,7 @@ Return customer secrets to use in preflights and support-bundle
     value: {{ .Values.appSecrets.awsAccessKeySecret.value | quote }}
   {{- else -}}
   {{ include "carto._utils.generateSecretDef" (dict "var" "WORKSPACE_IMPORTS_SECRETACCESSKEY" "context" .) | nindent 2 }}
-  {{- end }}
-  - name: WORKSPACE_THUMBNAILS_REGION
-    value: {{ .Values.appConfigValues.awsS3Region | quote }}
-  - name: WORKSPACE_IMPORTS_REGION
-    value: {{ .Values.appConfigValues.awsS3Region | quote }}
-  {{- if .Values.appConfigValues.s3Endpoint }}
-  - name: WORKSPACE_THUMBNAILS_ENDPOINT
-    value: {{ .Values.appConfigValues.s3Endpoint | quote }}
-  - name: WORKSPACE_IMPORTS_ENDPOINT
-    value: {{ .Values.appConfigValues.s3Endpoint | quote }}
-  {{- end }}
-  {{- if .Values.appConfigValues.s3ForcePathStyle }}
-  - name: WORKSPACE_THUMBNAILS_FORCE_PATH_STYLE
-    value: {{ .Values.appConfigValues.s3ForcePathStyle | quote }}
-  - name: WORKSPACE_IMPORTS_FORCE_PATH_STYLE
-    value: {{ .Values.appConfigValues.s3ForcePathStyle | quote }}
-  {{- end }}
+  {{- end -}}
   {{- end -}}
   {{- if eq .Values.appConfigValues.storageProvider "azure-blob" }}
   {{- if eq .Values.appSecrets.azureStorageAccessKey.existingSecret.name "" }}

--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -618,7 +618,23 @@ Return customer secrets to use in preflights and support-bundle
     value: {{ .Values.appSecrets.awsAccessKeySecret.value | quote }}
   {{- else -}}
   {{ include "carto._utils.generateSecretDef" (dict "var" "WORKSPACE_IMPORTS_SECRETACCESSKEY" "context" .) | nindent 2 }}
-  {{- end -}}
+  {{- end }}
+  - name: WORKSPACE_THUMBNAILS_REGION
+    value: {{ .Values.appConfigValues.awsS3Region | quote }}
+  - name: WORKSPACE_IMPORTS_REGION
+    value: {{ .Values.appConfigValues.awsS3Region | quote }}
+  {{- if .Values.appConfigValues.s3Endpoint }}
+  - name: WORKSPACE_THUMBNAILS_ENDPOINT
+    value: {{ .Values.appConfigValues.s3Endpoint | quote }}
+  - name: WORKSPACE_IMPORTS_ENDPOINT
+    value: {{ .Values.appConfigValues.s3Endpoint | quote }}
+  {{- end }}
+  {{- if .Values.appConfigValues.s3ForcePathStyle }}
+  - name: WORKSPACE_THUMBNAILS_FORCE_PATH_STYLE
+    value: {{ .Values.appConfigValues.s3ForcePathStyle | quote }}
+  - name: WORKSPACE_IMPORTS_FORCE_PATH_STYLE
+    value: {{ .Values.appConfigValues.s3ForcePathStyle | quote }}
+  {{- end }}
   {{- end -}}
   {{- if eq .Values.appConfigValues.storageProvider "azure-blob" }}
   {{- if eq .Values.appSecrets.azureStorageAccessKey.existingSecret.name "" }}


### PR DESCRIPTION
**Description of the change**

Follow-up fix to sc-555243. The S3-compatible storage wiring (`endpoint` / `externalUrl` / `forcePathStyle`) was added to the API configmaps but **not** to the `BucketsValidator` preflight in `chart/templates/_commonChecks.tpl`.

On an S3-compatible deploy the preflight's S3 client therefore had `provider=s3` + creds + bucket name but **no custom endpoint**, so it talked to real AWS S3 and failed:

```
FAIL  Check assets bucket   Failed to upload a file to the bucket carto-thumbnails-storage
FAIL  Check temp bucket     Failed to upload a file to the bucket carto-import-storage
```

…aborting the whole install. Caught while validating sc-555250 on a dedicated-k8s env (cloud-native #25874) against the in-cluster SeaweedFS test-bed.

This adds, to the preflight's `storageProvider == "s3"` block:
- `WORKSPACE_{THUMBNAILS,IMPORTS}_REGION` (unconditional, like the configmaps)
- `WORKSPACE_{THUMBNAILS,IMPORTS}_ENDPOINT` and `_FORCE_PATH_STYLE` (gated on non-empty)

`EXTERNAL_URL` is intentionally omitted — the preflight only does a server-side upload, it doesn't generate browser-facing URLs.

**Benefits**

The bucket preflight can reach an S3-compatible endpoint, so installs against MinIO / Ceph / SeaweedFS / etc. pass instead of failing on the bucket checks. Unblocks the dedicated-k8s S3-compatible validation (sc-555250).

**Possible drawbacks**

None for existing deployments: the endpoint/force-path vars are gated on non-empty values (default-off), and `REGION` is the same `awsS3Region` already used by the runtime configmaps.

**Additional information**

Validated with `helm template` (default render unchanged; with `storageProvider=s3` + `s3Endpoint`/`s3ForcePathStyle` the new vars render in the preflight env, no YAML glue) and `helm lint` (no new errors). Part of the "Self-Hosted support for any S3-compatible storage bucket" initiative (`sc-559408`).