### PR TITLE
fix(chart): omit Deployment replicas when autoscaling is enabled [sc-560007]

### DIFF
--- a/chart/templates/accounts-www/deployment.yaml
+++ b/chart/templates/accounts-www/deployment.yaml
@@ -13,7 +13,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.accountsWww.autoscaling.enabled }}
   replicas: {{ .Values.accountsWww.replicaCount }}
+  {{- end }}
   {{- if .Values.accountsWww.updateStrategy }}
   strategy: {{- toYaml .Values.accountsWww.updateStrategy | nindent 4 }}
   {{- end }}

--- a/chart/templates/ai-api/deployment.yaml
+++ b/chart/templates/ai-api/deployment.yaml
@@ -13,7 +13,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.aiApi.autoscaling.enabled }}
   replicas: {{ .Values.aiApi.replicaCount }}
+  {{- end }}
   {{- if .Values.aiApi.updateStrategy }}
   strategy: {{- toYaml .Values.aiApi.updateStrategy | nindent 4 }}
   {{- end }}

--- a/chart/templates/aiproxy/deployment.yaml
+++ b/chart/templates/aiproxy/deployment.yaml
@@ -13,7 +13,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.aiProxy.autoscaling.enabled }}
   replicas: {{ .Values.aiProxy.replicaCount }}
+  {{- end }}
   {{- if .Values.aiProxy.updateStrategy }}
   strategy: {{- toYaml .Values.aiProxy.updateStrategy | nindent 4 }}
   {{- end }}

--- a/chart/templates/import-api/deployment.yaml
+++ b/chart/templates/import-api/deployment.yaml
@@ -13,7 +13,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.importApi.autoscaling.enabled }}
   replicas: {{ .Values.importApi.replicaCount }}
+  {{- end }}
   {{- if .Values.importApi.updateStrategy }}
   strategy: {{- toYaml .Values.importApi.updateStrategy | nindent 4 }}
   {{- end }}

--- a/chart/templates/lds-api/deployment.yaml
+++ b/chart/templates/lds-api/deployment.yaml
@@ -13,7 +13,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.ldsApi.autoscaling.enabled }}
   replicas: {{ .Values.ldsApi.replicaCount }}
+  {{- end }}
   {{- if .Values.ldsApi.updateStrategy }}
   strategy: {{- toYaml .Values.ldsApi.updateStrategy | nindent 4 }}
   {{- end }}

--- a/chart/templates/maps-api/deployment.yaml
+++ b/chart/templates/maps-api/deployment.yaml
@@ -13,7 +13,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.mapsApi.autoscaling.enabled }}
   replicas: {{ .Values.mapsApi.replicaCount }}
+  {{- end }}
   {{- if .Values.mapsApi.updateStrategy }}
   strategy: {{- toYaml .Values.mapsApi.updateStrategy | nindent 4 }}
   {{- end }}

--- a/chart/templates/public-events-api/deployment.yaml
+++ b/chart/templates/public-events-api/deployment.yaml
@@ -13,7 +13,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.publicEventsApi.autoscaling.enabled }}
   replicas: {{ .Values.publicEventsApi.replicaCount }}
+  {{- end }}
   {{- if .Values.publicEventsApi.updateStrategy }}
   strategy: {{- toYaml .Values.publicEventsApi.updateStrategy | nindent 4 }}
   {{- end }}

--- a/chart/templates/router/deployment.yaml
+++ b/chart/templates/router/deployment.yaml
@@ -13,7 +13,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.router.autoscaling.enabled }}
   replicas: {{ .Values.router.replicaCount }}
+  {{- end }}
   {{- if .Values.router.updateStrategy }}
   strategy: {{- toYaml .Values.router.updateStrategy | nindent 4 }}
   {{- end }}

--- a/chart/templates/workspace-api/deployment.yaml
+++ b/chart/templates/workspace-api/deployment.yaml
@@ -13,7 +13,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.workspaceApi.autoscaling.enabled }}
   replicas: {{ .Values.workspaceApi.replicaCount }}
+  {{- end }}
   {{- if .Values.workspaceApi.updateStrategy }}
   strategy: {{- toYaml .Values.workspaceApi.updateStrategy | nindent 4 }}
   {{- end }}

--- a/chart/templates/workspace-www/deployment.yaml
+++ b/chart/templates/workspace-www/deployment.yaml
@@ -13,7 +13,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.workspaceWww.autoscaling.enabled }}
   replicas: {{ .Values.workspaceWww.replicaCount }}
+  {{- end }}
   {{- if .Values.workspaceWww.updateStrategy }}
   strategy: {{- toYaml .Values.workspaceWww.updateStrategy | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/560007
- Autolink: [sc-560007]

When `autoscaling.enabled: true` the chart renders both the HPA **and** a hardcoded `spec.replicas` on the Deployment. Once the HPA scales the workload, `kube-controller-manager` becomes the field owner of `.spec.replicas` (via the `scale` subresource). Any installer deploying with server-side apply — KOTS ≥ 1.129.1 embeds Helm 4, where SSA is the default — then fails the upgrade with:

```
Apply failed with 1 conflict: conflict with "kube-controller-manager" with subresource "scale" using apps/v1: .spec.replicas
```

This is exactly what blocked a PSS customer on an EKS existing-cluster KOTS install after enabling autoscaling (see linked story). With client-side Helm 3 the same defect doesn't fail the upgrade, but it silently resets HPA-scaled replicas back to `replicaCount` on every upgrade. Customers installing with Helm 4 CLI would hit the same hard conflict, so this is not KOTS-specific.

The fix follows the [Kubernetes-documented pattern](https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling): omit `spec.replicas` from the Deployment manifest when the HPA manages it. Applied to the 10 components that ship an HPA template (`accounts-www`, `ai-api`, `aiproxy`, `import-api`, `lds-api`, `maps-api`, `public-events-api`, `router`, `workspace-api`, `workspace-www`). Components without an HPA are untouched.

References: [KOTS release notes on Helm 4 / SSA](https://docs.replicated.com/release-notes/rn-app-manager) · [K8s Server-Side Apply field ownership](https://kubernetes.io/docs/reference/using-api/server-side-apply/)

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Documentation
- [ ] Security
- [ ] Chore

## Acceptance

1. `helm template . --set accountsWww.autoscaling.enabled=true` → the `carto-accounts-www` Deployment has **no** `spec.replicas` and the HPA is rendered.
2. `helm template .` with defaults (`autoscaling.enabled: false`) → all Deployments keep `replicas: <replicaCount>` and no HPA is rendered.
3. On a KOTS existing-cluster install with autoscaling enabled and the HPA having already scaled a Deployment, redeploy/upgrade succeeds instead of failing with the `.spec.replicas` SSA conflict.

## Basic checklist

- [x] Good PR name
- [x] Shortcut link
- [x] Just one issue per PR
- [ ] GitHub labels
- [ ] Proper status & reviewers
- [x] Tests
- [ ] Documentation

https://claude.ai/code/session_012EmMYTPo4CPoi7uky9tS49
