### PR TITLE
feat: register external bucket preflight checks in KOTS analyzer as warn [sc-555238]

### DIFF
--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -292,6 +292,17 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
   }}
 
   {{/*
+  When an S3-compatible split-horizon external URL is configured, the checker also emits the
+  browser-facing (external) bucket checks. They are non-authoritative (CORS is enforced by the
+  browser, not by the checker), so they are registered as warn outcomes rather than fail.
+  */}}
+  {{- if and (eq .Values.appConfigValues.storageProvider "s3") .Values.appConfigValues.s3ExternalUrl }}
+  {{- $_ := set $preflightsDict "BucketsValidator" (list "Check_assets_bucket" "Check_temp_bucket" "Check_assets_bucket_external" "Check_temp_bucket_external") -}}
+  {{- $preflightOptionalList = append $preflightOptionalList "Check_assets_bucket_external" -}}
+  {{- $preflightOptionalList = append $preflightOptionalList "Check_temp_bucket_external" -}}
+  {{- end }}
+
+  {{/*
   We push conditionally new analyzers for the feature flags if the customer defined overridden feature flags
   */}}
   {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
@@ -528,6 +539,12 @@ Return customer values to use in preflights and support-bundle
     value: {{ .Values.appConfigValues.s3Endpoint | quote }}
   - name: WORKSPACE_IMPORTS_ENDPOINT
     value: {{ .Values.appConfigValues.s3Endpoint | quote }}
+  {{- end }}
+  {{- if .Values.appConfigValues.s3ExternalUrl }}
+  - name: WORKSPACE_THUMBNAILS_EXTERNAL_URL
+    value: {{ .Values.appConfigValues.s3ExternalUrl | quote }}
+  - name: WORKSPACE_IMPORTS_EXTERNAL_URL
+    value: {{ .Values.appConfigValues.s3ExternalUrl | quote }}
   {{- end }}
   {{- if .Values.appConfigValues.s3ForcePathStyle }}
   - name: WORKSPACE_THUMBNAILS_FORCE_PATH_STYLE


### PR DESCRIPTION
**Description of the change**

Wires the new browser-facing (external) bucket preflight checks into the KOTS analyzer, and passes the split-horizon external URL to the `tenant-requirements-checker` collector.

Two changes to `chart/templates/_commonChecks.tpl`:

- The checker collector now receives `WORKSPACE_THUMBNAILS_EXTERNAL_URL` / `WORKSPACE_IMPORTS_EXTERNAL_URL` from `appConfigValues.s3ExternalUrl` (mirrors how workspace-api and import-worker are already wired). Without this the checker can't run the external audience.
- The analyzer registers `Check_assets_bucket_external` and `Check_temp_bucket_external` under `BucketsValidator` as **warn** outcomes (not fail), gated on `storageProvider=s3` + a configured `s3ExternalUrl`.

**Benefits**

On S3-compatible split-horizon setups, a bucket reachable from the backend but not from the browser surfaces as a non-blocking warning in preflights/support-bundle instead of failing. The external round-trip is non-authoritative on purpose — CORS is enforced by the browser, not by the checker — so warn is the correct severity.

**Possible drawbacks**

Depends on the checker emitting the new check names (CartoDB/cloud-native#26280). Until a checker image with that change ships, the external checks won't be produced; the analyzer gate and the checker's own gate stay aligned, so nothing renders when `s3ExternalUrl` is unset.

**Applicable issues**

  - sc-555238

**Additional information**

Verified with `helm template` (storageProvider=s3, s3ExternalUrl set): both external checks render with a `warn` outcome and the `*_EXTERNAL_URL` env reaches the checker; with `s3ExternalUrl` unset, zero external checks render.
