### PR TITLE
feat(chart): auto-enable 2024-private-buckets flag for S3-compatible storage [sc-555757]

### DIFF
--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -168,7 +168,7 @@ Return common collectors for preflights and support-bundle
               - name: CARTO_SELFHOSTED_AWS_EKS_POD_IDENTITY_S3_ENABLED
                 value: "true"
               {{- end }}
-              {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+              {{- if (include "carto.featureFlags.enabled" .) }}
               - name: OVERRIDDEN_FEATURE_FLAGS
                 value: {{ include "carto.featureFlags.overriddenFeatureFlags" . | quote }}
               {{- end }}
@@ -294,7 +294,7 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
   {{/*
   We push conditionally new analyzers for the feature flags if the customer defined overridden feature flags
   */}}
-  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+  {{- if (include "carto.featureFlags.enabled" .) }}
   {{- $_ := set $preflightsDict "FeatureFlagsValidator" (list "Check_valid_feature_flags") -}}
   {{- end }}
   {{/*

--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -168,7 +168,7 @@ Return common collectors for preflights and support-bundle
               - name: CARTO_SELFHOSTED_AWS_EKS_POD_IDENTITY_S3_ENABLED
                 value: "true"
               {{- end }}
-              {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+              {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
               - name: OVERRIDDEN_FEATURE_FLAGS
                 value: {{ include "carto.featureFlags.overriddenFeatureFlags" . | quote }}
               {{- end }}
@@ -294,7 +294,7 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
   {{/*
   We push conditionally new analyzers for the feature flags if the customer defined overridden feature flags
   */}}
-  {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
   {{- $_ := set $preflightsDict "FeatureFlagsValidator" (list "Check_valid_feature_flags") -}}
   {{- end }}
   {{/*

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1381,16 +1381,49 @@ Return the directory where the custom feature flags config file will be mounted
 {{- end -}}
 
 {{/*
+Auto-enable 2024-private-buckets when an S3-compatible endpoint is set: private
+main buckets need it for markers/branding to resolve (compat-analysis D-ACL).
+Safe because an S3-compatible deployment is a fresh install with no legacy
+public-URL maps to migrate. An explicit operator override for the flag wins.
+*/}}
+{{- define "carto.featureFlags.effectiveOverrides" -}}
+{{- $overrides := .Values.cartoConfigValues.featureFlagsOverrides | default list -}}
+{{- $result := $overrides -}}
+{{- if .Values.appConfigValues.s3Endpoint -}}
+{{- $names := list -}}
+{{- range $overrides -}}{{- $names = append $names .name -}}{{- end -}}
+{{- if not (has "2024-private-buckets" $names) -}}
+{{- $result = append $result (dict "name" "2024-private-buckets" "value" true) -}}
+{{- end -}}
+{{- end -}}
+{{- $result | toYaml -}}
+{{- end -}}
+
+{{/*
+Whether any feature-flag override is in effect (operator-provided or the
+S3-compatible auto-injected one). Emits "true" or nothing; use with `eq`.
+*/}}
+{{- define "carto.featureFlags.enabled" -}}
+{{- if or .Values.cartoConfigValues.featureFlagsOverrides .Values.appConfigValues.s3Endpoint -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the list of overridden feature flags as a comma-separated string
 */}}
 {{- define "carto.featureFlags.overriddenFeatureFlags" -}}
-{{- $featureFlags := .Values.cartoConfigValues.featureFlagsOverrides -}}
+{{- $overrides := .Values.cartoConfigValues.featureFlagsOverrides | default list -}}
 {{- $ffNames := list -}}
-{{- range $featureFlags -}}
+{{- range $overrides -}}
 {{- $ffNames = append $ffNames .name -}}
 {{- end -}}
-{{- $nameList := join "," $ffNames -}}
-{{- $nameList -}}
+{{- if .Values.appConfigValues.s3Endpoint -}}
+{{- if not (has "2024-private-buckets" $ffNames) -}}
+{{- $ffNames = append $ffNames "2024-private-buckets" -}}
+{{- end -}}
+{{- end -}}
+{{- join "," $ffNames -}}
 {{- end -}}
 
 {{/*

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1381,10 +1381,14 @@ Return the directory where the custom feature flags config file will be mounted
 {{- end -}}
 
 {{/*
-Auto-enable 2024-private-buckets when an S3-compatible endpoint is set: private
-main buckets need it for markers/branding to resolve (compat-analysis D-ACL).
-Safe because an S3-compatible deployment is a fresh install with no legacy
-public-URL maps to migrate. An explicit operator override for the flag wins.
+Effective feature-flag overrides = the operator-provided list plus any flags the
+chart auto-enables from deployment config. An auto-enabled flag never clobbers an
+explicit operator override of the same flag.
+
+Today the only auto-enabled flag is 2024-private-buckets, switched on when an
+S3-compatible endpoint is set: private main buckets need it for markers/branding
+to resolve (compat-analysis D-ACL), and it's safe because such a deployment is a
+fresh install with no legacy public-URL maps to migrate.
 */}}
 {{- define "carto.featureFlags.effectiveOverrides" -}}
 {{- $overrides := .Values.cartoConfigValues.featureFlagsOverrides | default list -}}

--- a/chart/templates/custom-feature-flags-configmap.yaml
+++ b/chart/templates/custom-feature-flags-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+{{- if eq (include "carto.featureFlags.enabled" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,5 +14,5 @@ metadata:
 data:
   custom-feature-flags.yaml: |-
     featureFlagsOverrides:
-{{ .Values.cartoConfigValues.featureFlagsOverrides | toYaml | indent 6 }}
+{{ include "carto.featureFlags.effectiveOverrides" . | indent 6 }}
 {{- end }}

--- a/chart/templates/custom-feature-flags-configmap.yaml
+++ b/chart/templates/custom-feature-flags-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+{{- if (include "carto.featureFlags.enabled" .) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/chart/templates/import-api/configmap.yaml
+++ b/chart/templates/import-api/configmap.yaml
@@ -15,7 +15,7 @@ data:
   AUTH0_AUDIENCE: "carto-cloud-native-api"
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
-  {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
   {{- end }}
   {{- if .Values.replicated.enabled }}

--- a/chart/templates/import-api/configmap.yaml
+++ b/chart/templates/import-api/configmap.yaml
@@ -15,7 +15,7 @@ data:
   AUTH0_AUDIENCE: "carto-cloud-native-api"
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
-  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+  {{- if (include "carto.featureFlags.enabled" .) }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
   {{- end }}
   {{- if .Values.replicated.enabled }}

--- a/chart/templates/import-api/deployment.yaml
+++ b/chart/templates/import-api/deployment.yaml
@@ -206,7 +206,7 @@ spec:
               mountPath: {{ include "carto.proxy.configMapMountDir" . }}
               readOnly: true
             {{- end }}
-            {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+            {{- if (include "carto.featureFlags.enabled" .) }}
             - name: feature-flags
               mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
               subPath: custom-feature-flags.yaml
@@ -248,7 +248,7 @@ spec:
           configMap:
             name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
-        {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+        {{- if (include "carto.featureFlags.enabled" .) }}
         - name: feature-flags
           configMap:
             name: {{ template "carto.featureFlags.configMapName" . }}

--- a/chart/templates/import-api/deployment.yaml
+++ b/chart/templates/import-api/deployment.yaml
@@ -206,7 +206,7 @@ spec:
               mountPath: {{ include "carto.proxy.configMapMountDir" . }}
               readOnly: true
             {{- end }}
-            {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+            {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
             - name: feature-flags
               mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
               subPath: custom-feature-flags.yaml
@@ -248,7 +248,7 @@ spec:
           configMap:
             name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
-        {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+        {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
         - name: feature-flags
           configMap:
             name: {{ template "carto.featureFlags.configMapName" . }}

--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -16,7 +16,7 @@ data:
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
   BIGQUERY_OAUTH2_CLIENT_ID: {{ .Values.appConfigValues.bigqueryOauth2ClientId | quote }}
-  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+  {{- if (include "carto.featureFlags.enabled" .) }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
   {{- end }}
   {{- if .Values.replicated.enabled }}

--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -16,7 +16,7 @@ data:
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
   BIGQUERY_OAUTH2_CLIENT_ID: {{ .Values.appConfigValues.bigqueryOauth2ClientId | quote }}
-  {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
   {{- end }}
   {{- if .Values.replicated.enabled }}

--- a/chart/templates/import-worker/deployment.yaml
+++ b/chart/templates/import-worker/deployment.yaml
@@ -217,7 +217,7 @@ spec:
               mountPath: {{ include "carto.proxy.configMapMountDir" . }}
               readOnly: true
             {{- end }}
-            {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+            {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
             - name: feature-flags
               mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
               subPath: custom-feature-flags.yaml
@@ -261,7 +261,7 @@ spec:
           configMap:
             name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
-        {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+        {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
         - name: feature-flags
           configMap:
             name: {{ template "carto.featureFlags.configMapName" . }}

--- a/chart/templates/import-worker/deployment.yaml
+++ b/chart/templates/import-worker/deployment.yaml
@@ -217,7 +217,7 @@ spec:
               mountPath: {{ include "carto.proxy.configMapMountDir" . }}
               readOnly: true
             {{- end }}
-            {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+            {{- if (include "carto.featureFlags.enabled" .) }}
             - name: feature-flags
               mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
               subPath: custom-feature-flags.yaml
@@ -261,7 +261,7 @@ spec:
           configMap:
             name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
-        {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+        {{- if (include "carto.featureFlags.enabled" .) }}
         - name: feature-flags
           configMap:
             name: {{ template "carto.featureFlags.configMapName" . }}

--- a/chart/templates/maps-api/configmap.yaml
+++ b/chart/templates/maps-api/configmap.yaml
@@ -16,7 +16,7 @@ data:
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
   BIGQUERY_OAUTH2_CLIENT_ID: {{ .Values.appConfigValues.bigqueryOauth2ClientId | quote }}
-  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+  {{- if (include "carto.featureFlags.enabled" .) }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
   {{- end }}
   {{- if .Values.replicated.enabled }}

--- a/chart/templates/maps-api/configmap.yaml
+++ b/chart/templates/maps-api/configmap.yaml
@@ -16,7 +16,7 @@ data:
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
   BIGQUERY_OAUTH2_CLIENT_ID: {{ .Values.appConfigValues.bigqueryOauth2ClientId | quote }}
-  {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
   {{- end }}
   {{- if .Values.replicated.enabled }}

--- a/chart/templates/maps-api/deployment.yaml
+++ b/chart/templates/maps-api/deployment.yaml
@@ -203,7 +203,7 @@ spec:
               mountPath: {{ include "carto.proxy.configMapMountDir" . }}
               readOnly: true
             {{- end }}
-            {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+            {{- if (include "carto.featureFlags.enabled" .) }}
             - name: feature-flags
               mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
               subPath: custom-feature-flags.yaml
@@ -245,7 +245,7 @@ spec:
           configMap:
             name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
-        {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+        {{- if (include "carto.featureFlags.enabled" .) }}
         - name: feature-flags
           configMap:
             name: {{ template "carto.featureFlags.configMapName" . }}

--- a/chart/templates/maps-api/deployment.yaml
+++ b/chart/templates/maps-api/deployment.yaml
@@ -203,7 +203,7 @@ spec:
               mountPath: {{ include "carto.proxy.configMapMountDir" . }}
               readOnly: true
             {{- end }}
-            {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+            {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
             - name: feature-flags
               mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
               subPath: custom-feature-flags.yaml
@@ -245,7 +245,7 @@ spec:
           configMap:
             name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
-        {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+        {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
         - name: feature-flags
           configMap:
             name: {{ template "carto.featureFlags.configMapName" . }}

--- a/chart/templates/sql-worker/configmap.yaml
+++ b/chart/templates/sql-worker/configmap.yaml
@@ -15,7 +15,7 @@ data:
   AUTH0_AUDIENCE: "carto-cloud-native-api"
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
-  {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
   {{- end }}
   {{- if .Values.replicated.enabled }}

--- a/chart/templates/sql-worker/configmap.yaml
+++ b/chart/templates/sql-worker/configmap.yaml
@@ -15,7 +15,7 @@ data:
   AUTH0_AUDIENCE: "carto-cloud-native-api"
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
-  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+  {{- if (include "carto.featureFlags.enabled" .) }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
   {{- end }}
   {{- if .Values.replicated.enabled }}

--- a/chart/templates/sql-worker/deployment.yaml
+++ b/chart/templates/sql-worker/deployment.yaml
@@ -193,7 +193,7 @@ spec:
               mountPath: {{ include "carto.proxy.configMapMountDir" . }}
               readOnly: true
             {{- end }}
-            {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+            {{- if (include "carto.featureFlags.enabled" .) }}
             - name: feature-flags
               mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
               subPath: custom-feature-flags.yaml
@@ -230,7 +230,7 @@ spec:
           configMap:
             name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
-        {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+        {{- if (include "carto.featureFlags.enabled" .) }}
         - name: feature-flags
           configMap:
             name: {{ template "carto.featureFlags.configMapName" . }}

--- a/chart/templates/sql-worker/deployment.yaml
+++ b/chart/templates/sql-worker/deployment.yaml
@@ -193,7 +193,7 @@ spec:
               mountPath: {{ include "carto.proxy.configMapMountDir" . }}
               readOnly: true
             {{- end }}
-            {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+            {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
             - name: feature-flags
               mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
               subPath: custom-feature-flags.yaml
@@ -230,7 +230,7 @@ spec:
           configMap:
             name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
-        {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+        {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
         - name: feature-flags
           configMap:
             name: {{ template "carto.featureFlags.configMapName" . }}

--- a/chart/templates/workspace-api/configmap.yaml
+++ b/chart/templates/workspace-api/configmap.yaml
@@ -16,7 +16,7 @@ data:
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
   BIGQUERY_OAUTH2_CLIENT_ID: {{ .Values.appConfigValues.bigqueryOauth2ClientId | quote }}
-  {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
   {{- end }}
   CARTO_SELFHOSTED_AUTH0_CLIENT_ID: {{ .Values.cartoConfigValues.cartoAuth0ClientId | quote }}

--- a/chart/templates/workspace-api/configmap.yaml
+++ b/chart/templates/workspace-api/configmap.yaml
@@ -16,7 +16,7 @@ data:
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
   BIGQUERY_OAUTH2_CLIENT_ID: {{ .Values.appConfigValues.bigqueryOauth2ClientId | quote }}
-  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+  {{- if (include "carto.featureFlags.enabled" .) }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
   {{- end }}
   CARTO_SELFHOSTED_AUTH0_CLIENT_ID: {{ .Values.cartoConfigValues.cartoAuth0ClientId | quote }}

--- a/chart/templates/workspace-api/deployment.yaml
+++ b/chart/templates/workspace-api/deployment.yaml
@@ -295,7 +295,7 @@ spec:
               mountPath: {{ include "carto.proxy.configMapMountDir" . }}
               readOnly: true
             {{- end }}
-            {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+            {{- if (include "carto.featureFlags.enabled" .) }}
             - name: feature-flags
               mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
               subPath: custom-feature-flags.yaml
@@ -339,7 +339,7 @@ spec:
           configMap:
             name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
-        {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+        {{- if (include "carto.featureFlags.enabled" .) }}
         - name: feature-flags
           configMap:
             name: {{ template "carto.featureFlags.configMapName" . }}

--- a/chart/templates/workspace-api/deployment.yaml
+++ b/chart/templates/workspace-api/deployment.yaml
@@ -295,7 +295,7 @@ spec:
               mountPath: {{ include "carto.proxy.configMapMountDir" . }}
               readOnly: true
             {{- end }}
-            {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+            {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
             - name: feature-flags
               mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
               subPath: custom-feature-flags.yaml
@@ -339,7 +339,7 @@ spec:
           configMap:
             name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
-        {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+        {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
         - name: feature-flags
           configMap:
             name: {{ template "carto.featureFlags.configMapName" . }}

--- a/chart/templates/workspace-subscriber/configmap.yaml
+++ b/chart/templates/workspace-subscriber/configmap.yaml
@@ -16,7 +16,7 @@ data:
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
   BIGQUERY_OAUTH2_CLIENT_ID: {{ .Values.appConfigValues.bigqueryOauth2ClientId | quote }}
-  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+  {{- if (include "carto.featureFlags.enabled" .) }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
   {{- end }}
   CARTO_SELFHOSTED_DOMAIN: {{ .Values.appConfigValues.selfHostedDomain | quote }}

--- a/chart/templates/workspace-subscriber/configmap.yaml
+++ b/chart/templates/workspace-subscriber/configmap.yaml
@@ -16,7 +16,7 @@ data:
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
   BIGQUERY_OAUTH2_CLIENT_ID: {{ .Values.appConfigValues.bigqueryOauth2ClientId | quote }}
-  {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
   {{- end }}
   CARTO_SELFHOSTED_DOMAIN: {{ .Values.appConfigValues.selfHostedDomain | quote }}

--- a/chart/templates/workspace-subscriber/deployment.yaml
+++ b/chart/templates/workspace-subscriber/deployment.yaml
@@ -196,7 +196,7 @@ spec:
               mountPath: {{ include "carto.proxy.configMapMountDir" . }}
               readOnly: true
             {{- end }}
-            {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+            {{- if (include "carto.featureFlags.enabled" .) }}
             - name: feature-flags
               mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
               subPath: custom-feature-flags.yaml
@@ -230,7 +230,7 @@ spec:
           configMap:
             name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
-        {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+        {{- if (include "carto.featureFlags.enabled" .) }}
         - name: feature-flags
           configMap:
             name: {{ template "carto.featureFlags.configMapName" . }}

--- a/chart/templates/workspace-subscriber/deployment.yaml
+++ b/chart/templates/workspace-subscriber/deployment.yaml
@@ -196,7 +196,7 @@ spec:
               mountPath: {{ include "carto.proxy.configMapMountDir" . }}
               readOnly: true
             {{- end }}
-            {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+            {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
             - name: feature-flags
               mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
               subPath: custom-feature-flags.yaml
@@ -230,7 +230,7 @@ spec:
           configMap:
             name: {{ include "carto.proxy.configMapName" . }}
         {{- end }}
-        {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+        {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
         - name: feature-flags
           configMap:
             name: {{ template "carto.featureFlags.configMapName" . }}

--- a/chart/templates/workspace-www/configmap.yaml
+++ b/chart/templates/workspace-www/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
 data:
   CARTO_DATA_WAREHOUSE_ENABLED: {{ .Values.cartoConfigValues.cartoDataWarehouseEnabled | quote }}
-  {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
   {{- end }}
   {{- if $.Values.appConfigValues.bigqueryOauth2ClientId }}

--- a/chart/templates/workspace-www/configmap.yaml
+++ b/chart/templates/workspace-www/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
 data:
   CARTO_DATA_WAREHOUSE_ENABLED: {{ .Values.cartoConfigValues.cartoDataWarehouseEnabled | quote }}
-  {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+  {{- if (include "carto.featureFlags.enabled" .) }}
   CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
   {{- end }}
   {{- if $.Values.appConfigValues.bigqueryOauth2ClientId }}

--- a/chart/templates/workspace-www/deployment.yaml
+++ b/chart/templates/workspace-www/deployment.yaml
@@ -167,7 +167,7 @@ spec:
               mountPath: /tmp
             - name: nginx-shared-snippets
               mountPath: /etc/nginx/conf.d/shared-snippets
-            {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+            {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
             - name: feature-flags
               mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
               subPath: custom-feature-flags.yaml
@@ -188,7 +188,7 @@ spec:
             medium: Memory
         - name: tmp
           emptyDir: {}
-        {{- if .Values.cartoConfigValues.featureFlagsOverrides }}
+        {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
         - name: feature-flags
           configMap:
             name: {{ template "carto.featureFlags.configMapName" . }}

--- a/chart/templates/workspace-www/deployment.yaml
+++ b/chart/templates/workspace-www/deployment.yaml
@@ -167,7 +167,7 @@ spec:
               mountPath: /tmp
             - name: nginx-shared-snippets
               mountPath: /etc/nginx/conf.d/shared-snippets
-            {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+            {{- if (include "carto.featureFlags.enabled" .) }}
             - name: feature-flags
               mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
               subPath: custom-feature-flags.yaml
@@ -188,7 +188,7 @@ spec:
             medium: Memory
         - name: tmp
           emptyDir: {}
-        {{- if eq (include "carto.featureFlags.enabled" .) "true" }}
+        {{- if (include "carto.featureFlags.enabled" .) }}
         - name: feature-flags
           configMap:
             name: {{ template "carto.featureFlags.configMapName" . }}


### PR DESCRIPTION
## Summary

On S3-compatible self-hosted deployments the main buckets run **private** (the portable path from the compat-analysis, D-ACL — public-read ACLs aren't honoured across MinIO/OCI/OVH, nor by AWS S3 since 2023). With private buckets, markers & branding must resolve through the private `AssetsService` instead of a baked-in public object URL, which is gated by the `2024-private-buckets` feature flag. That flag is absent from the self-hosted defaults, so markers/branding would 403.

This wires the chart to **auto-enable `2024-private-buckets` when `appConfigValues.s3Endpoint` is set**. No app-code change, no global default flip — the auto-injection is scoped to S3-compatible installs, which are new by definition (no legacy public-URL maps to migrate). An explicit operator override for the flag still wins.

Story: [sc-555757](https://app.shortcut.com/cartoteam/story/555757) — epic [sc-544278](https://app.shortcut.com/cartoteam/epic/544278)

## Why not promote it globally

Flipping the flag ON for every self-hosted install would break markers on **existing** orgs: their maps store legacy public marker URLs in the mapconfig and are never migrated to the new ID-based scheme. Confirmed with the original "Unify buckets" owners (@atena, @mcalzado) in [#carto3-sh-s3-compatible-buckets](https://cartoteam.slack.com/archives/C0B5YSDCFC6/p1783928302028029). Gating on the S3-compatible endpoint keeps it to fresh installs only. The general migration of existing customers stays a separate, unresourced follow-up.

## What changed

- New helpers in `_helpers.tpl`:
  - `carto.featureFlags.effectiveOverrides` — operator overrides plus the auto-injected `2024-private-buckets: true` when `s3Endpoint` is set and the operator hasn't already declared it.
  - `carto.featureFlags.enabled` — boolean gate (operator overrides **or** `s3Endpoint`).
- `custom-feature-flags-configmap.yaml` renders the effective list; its render gate uses the new helper.
- The 7 service deployments/configmaps + `_commonChecks.tpl` (preflight `OVERRIDDEN_FEATURE_FLAGS` / `FeatureFlagsValidator`) switch their gate to `carto.featureFlags.enabled`.
- `overriddenFeatureFlags` also reflects the auto-injected flag so the preflight validates it.

`WORKSPACE_ASSETS_BUCKETS` is intentionally **not** added: the assets bucket falls back to the thumbnails bucket (`workspace-api/src/lib/assets-settings.ts`), which already carries the S3-compatible `endpoint`/`externalUrl`/`forcePathStyle` from sc-555243. A distinct assets bucket remains an optional follow-up.

## Deployment impact

Self-hosted (Helm/KOTS), k8s deployment methods. **Default-off / additive**: with no `s3Endpoint` the configmap doesn't render and behaviour is byte-for-byte unchanged. Not to be merged until the SH release window per the epic's release constraint.

## Validation

`helm lint` clean. `helm template --show-only` of the configmap across the matrix:

| Scenario | Result |
|---|---|
| default (no endpoint, no overrides) | configmap not rendered ✅ |
| `s3Endpoint` set | `2024-private-buckets: true` auto-injected ✅ |
| `s3Endpoint` + operator sets flag `false` | respects `false`, no duplicate ✅ |
| `s3Endpoint` + operator sets a different flag | both present ✅ |
| no endpoint + operator override (legacy) | unchanged ✅ |
