### PR TITLE
fix(chart): render ai-api GOOGLE_APPLICATION_CREDENTIALS without external proxy [sc-561902]

### DIFF
--- a/chart/templates/ai-api/configmap.yaml
+++ b/chart/templates/ai-api/configmap.yaml
@@ -43,9 +43,6 @@ data:
   https_proxy: {{ include "carto.proxy.computedConnectionString" . | quote }}
   GRPC_PROXY: {{ include "carto.proxy.computedConnectionString" . | quote }}
   grpc_proxy: {{ include "carto.proxy.computedConnectionString" . | quote }}
-  {{- if not .Values.commonBackendServiceAccount.enableGCPWorkloadIdentity }}
-  GOOGLE_APPLICATION_CREDENTIALS: {{ include "carto.google.secretMountAbsolutePath" . }}
-  {{- end }}
   {{- if gt (len .Values.externalProxy.excludedDomains) 0 }}
   NO_PROXY: {{ join "," .Values.externalProxy.excludedDomains | quote }}
   no_proxy: {{ join "," .Values.externalProxy.excludedDomains | quote }}
@@ -54,6 +51,9 @@ data:
   NODE_EXTRA_CA_CERTS: {{ include "carto.proxy.configMapMountAbsolutePath" . | quote }}
   {{- end }}
   NODE_TLS_REJECT_UNAUTHORIZED: {{ ternary "1" "0" .Values.externalProxy.sslRejectUnauthorized | quote }}
+  {{- end }}
+  {{- if not .Values.commonBackendServiceAccount.enableGCPWorkloadIdentity }}
+  GOOGLE_APPLICATION_CREDENTIALS: {{ include "carto.google.secretMountAbsolutePath" . }}
   {{- end }}
   LOG_LEVEL: {{ .Values.appConfigValues.logLevel | quote }}
   NODE_OPTIONS: {{ template "carto.aiApi.nodeOptions" . }}


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/561902

In the ai-api configmap, the `GOOGLE_APPLICATION_CREDENTIALS` block was nested inside the `{{- if .Values.externalProxy.enabled }}` conditional. On deployments with no external proxy and no GCP Workload Identity, the variable was never rendered: the service account key is mounted in the pod, but nothing points ADC at it, so ai-api cannot authenticate against Google APIs and its event publishing fails silently (`EventBus.publishEvent` swallows publish errors).

Every other service template (workspace-api, import-api, maps-api, etc.) renders this variable at the top level, guarded only by the Workload Identity check. This PR moves the ai-api block out of the proxy conditional to match.

## Validation

`helm template` matrix on `templates/ai-api/configmap.yaml` (with `appConfigValues.aiFeaturesEnabled=true`):

| Scenario | Before | After |
|---|---|---|
| No proxy, no Workload Identity | var absent (bug) | var present |
| `externalProxy.enabled=true`, no Workload Identity | var present | var present (once, no duplicate) |
| `enableGCPWorkloadIdentity=true` | var absent | var absent (expected) |

`helm lint` passes.

## Workaround for existing installations

Until upgrading to a release with this fix:

```yaml
aiApi:
  extraEnvVars:
    - name: GOOGLE_APPLICATION_CREDENTIALS
      value: /usr/src/certs/gcp-default-service-account/key.json
```
