### PR TITLE
fix(chart): raise tenant-requirements-check preflight timeout to 300s [sc-562648]

### DIFF
--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -6,7 +6,12 @@ Return common collectors for preflights and support-bundle
       collectorName: tenant-requirements-check
       name: tenant-requirements-check
       namespace: {{ .Release.Namespace | quote }}
-      timeout: 180s
+      {{/*
+      The pod runs every validator sequentially and only emits results once the whole pass
+      finishes, so this budget must cover image pull plus the slowest full run. Keep headroom:
+      too tight and transient image-pull/egress latency trips a false timeout that blocks install.
+      */}}
+      timeout: 300s
       podSpec:
         {{- if include "carto.podIdentity.enabled" . }}
         serviceAccountName: {{ template "carto.commonSA.serviceAccountName" . }}


### PR DESCRIPTION
**Description of the change**

Raises the `tenant-requirements-check` runPod collector timeout from `180s` to `300s` in `chart/templates/_commonChecks.tpl`.

The preflight pod runs every validator sequentially and only emits its results once the whole pass finishes, so this budget has to cover image pull plus the slowest full run. On a cold image pull or slow egress the pass occasionally exceeds 180s; the pod is then killed with no output (`completed with no analysis results`) and the preflight blocks the install as a false negative, even though the environment is fine.

**Benefits**

Headroom absorbs transient image-pull / egress latency so a healthy environment isn't blocked by a timing flake. Real problems still surface — each individual check keeps its own internal cap, so a genuinely stuck dependency is still reported (just within the wider budget).

**Possible drawbacks**

A genuinely unreachable dependency now takes longer to report failure (up to the higher budget).

**Applicable issues**

- sc-562648

**Additional information**

Confirmed a timing flake, not a regression: re-running the same chart version with no code change passes. Companion CI-side change (retry the preflight step in the QA deploy action) ships separately.
