### PR TITLE
fix(chart): wire EXPORTS_GCS_BUCKET_NAME into import-api and import-worker

### DIFF
--- a/chart/templates/import-api/configmap.yaml
+++ b/chart/templates/import-api/configmap.yaml
@@ -82,6 +82,7 @@ data:
   CARTO_SELFHOSTED_AWS_RDS_METADATA_REGION: {{ .Values.externalPostgresql.awsRdsRegion | quote }}
   CARTO_SELFHOSTED_AWS_EKS_POD_IDENTITY_METADATA_DB_ENABLED: {{ .Values.externalPostgresql.awsEksPodIdentityEnabled | quote }}
   {{- end }}
+  EXPORTS_GCS_BUCKET_NAME: {{ .Values.appConfigValues.workspaceExportsBucket | quote }}
   IMPORT_AWS_CUSTOM_BUCKET_ROLE_ARN: {{ .Values.appConfigValues.importAwsRoleArn | quote }}
   IMPORT_DATA_IMPORTS_BUCKET: {{ .Values.appConfigValues.workspaceImportsBucket | quote }}
   IMPORT_PROVIDER: {{ .Values.appConfigValues.storageProvider | quote }}

--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -82,6 +82,7 @@ data:
   CARTO_SELFHOSTED_AWS_RDS_METADATA_REGION: {{ .Values.externalPostgresql.awsRdsRegion | quote }}
   CARTO_SELFHOSTED_AWS_EKS_POD_IDENTITY_METADATA_DB_ENABLED: {{ .Values.externalPostgresql.awsEksPodIdentityEnabled | quote }}
   {{- end }}
+  EXPORTS_GCS_BUCKET_NAME: {{ .Values.appConfigValues.workspaceExportsBucket | quote }}
   IMPORT_AWS_CUSTOM_BUCKET_ROLE_ARN: {{ .Values.appConfigValues.importAwsRoleArn | quote }}
   IMPORT_DATA_IMPORTS_BUCKET: {{ .Values.appConfigValues.workspaceImportsBucket | quote }}
   IMPORT_PROVIDER: {{ .Values.appConfigValues.storageProvider | quote }}


### PR DESCRIPTION
## Summary

`import-api` and `import-worker` were the only backend services whose configmaps did not render `EXPORTS_GCS_BUCKET_NAME` (`workspace-api`, `maps-api` and `sql-worker` already do). The DuckDB export engine that backs the interactive data-export flow (`import-api` `POST /v3/exports`, processed by `import-worker`) stages BigQuery `EXPORT DATA` output to the bucket named by `EXPORTS_GCS_BUCKET_NAME`, and falls back to the imports bucket when that variable is unset. On deployments that configure **separate** import and export buckets (i.e. "configure your own buckets"), the export was therefore staged in the imports bucket, which does not carry the export bucket's IAM — so BigQuery exports failed with a permission-denied writing to GCS.

This wiring existed briefly before and was removed as unused when the PDF-export path stopped reading it (#846); the DuckDB export engine reintroduced the read afterward, so it needs to be restored.

## Story

[sc-563200](https://app.shortcut.com/cartoteam/story/563200)

## What changed

Render `EXPORTS_GCS_BUCKET_NAME` from `appConfigValues.workspaceExportsBucket` in:

- `chart/templates/import-api/configmap.yaml`
- `chart/templates/import-worker/configmap.yaml`

Mirrors the existing wiring in `sql-worker`, `workspace-api` and `maps-api`. One line each; no default value change (when `workspaceExportsBucket` is unset it renders empty, preserving the current fallback behaviour).

## Deployment impact

Selfhosted only. On a deployment where import and export buckets are the same, behaviour is unchanged. On a deployment with separate buckets, the interactive export now stages in the configured export bucket instead of the imports bucket. No migration.

## Validation

`helm template` with `workspaceExportsBucket` set renders the variable in both configmaps:

```
# import-api & import-worker configmaps
EXPORTS_GCS_BUCKET_NAME: "…-private-export-bucket"
IMPORT_DATA_IMPORTS_BUCKET: "…-private-client-bucket"
```

## Review focus

Confirm `EXPORTS_GCS_BUCKET_NAME` should map to `workspaceExportsBucket` for the import services (same source the other three services use).
