### PR TITLE
feat(chart): add REACT_APP_HOSTED_APPS_URL to workspace-www configmap [sc-563910]

### DIFF
--- a/chart/templates/workspace-www/configmap.yaml
+++ b/chart/templates/workspace-www/configmap.yaml
@@ -37,6 +37,7 @@ data:
   REACT_APP_LAUNCH_DARKLY_CLIENT_SIDE_ID: {{ .Values.cartoConfigValues.launchDarklyClientSideId | quote }}
   REACT_APP_PUBLIC_MAP_URL: "https://{{ .Values.appConfigValues.selfHostedDomain }}/api/v3/maps/public"
   REACT_APP_WORKSPACE_API_URL: "https://{{ .Values.appConfigValues.selfHostedDomain }}/workspace-api"
+  REACT_APP_HOSTED_APPS_URL: "https://{{ .Values.appConfigValues.selfHostedDomain }}/app"
   REACT_APP_NOTIFIER_API_URL: "https://{{ .Values.appConfigValues.selfHostedDomain }}/notifier"
   REACT_APP_WORKSPACE_URL_TEMPLATE: "https://{tenantDomain}"
   THUMBNAILS_BUCKET_EXTERNAL_URL: {{ .Values.appConfigValues.thumbnailsBucketExternalURL | quote }}


### PR DESCRIPTION
## Summary
Hosted apps are served under `/app` on the same domain in Self-Hosted. The workspace-www launcher reads a new `REACT_APP_HOSTED_APPS_URL` (`https://<selfHostedDomain>/app`); this adds it to the workspace-www configmap, derived from `selfHostedDomain` just like `REACT_APP_WORKSPACE_API_URL`.

Paired with CartoDB/cloud-native#26749 (router `location ^/app/` + launcher wiring). `release-changes` is set so the branch chart publishes to a Replicated channel for the dedicated-k8s test env of that PR.

Story: sc-563910