### PR TITLE
feat: register bucket CORS preflight checks in KOTS analyzer as warn [sc-564170]

### DIFF
--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -313,9 +313,9 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
   checker probes this with a live OPTIONS preflight; these checks always run. Non-authoritative
   like the external checks (CORS is enforced by the browser), so registered as warn.
   */}}
-  {{- $_ := set $preflightsDict "BucketsValidator" (concat (index $preflightsDict "BucketsValidator") (list "Check_assets_bucket_CORS" "Check_temp_bucket_CORS")) -}}
-  {{- $preflightOptionalList = append $preflightOptionalList "Check_assets_bucket_CORS" -}}
-  {{- $preflightOptionalList = append $preflightOptionalList "Check_temp_bucket_CORS" -}}
+  {{- $_ := set $preflightsDict "BucketsValidator" (concat (index $preflightsDict "BucketsValidator") (list "Check_assets_bucket_CORS_sanity_check" "Check_temp_bucket_CORS_sanity_check")) -}}
+  {{- $preflightOptionalList = append $preflightOptionalList "Check_assets_bucket_CORS_sanity_check" -}}
+  {{- $preflightOptionalList = append $preflightOptionalList "Check_temp_bucket_CORS_sanity_check" -}}
 
   {{/*
   We push conditionally new analyzers for the feature flags if the customer defined overridden feature flags

--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -308,6 +308,21 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
   {{- end }}
 
   {{/*
+  When a custom S3-compatible endpoint is configured, browser direct uploads/downloads go
+  straight to the bucket host (a different origin than the app), so each bucket needs a CORS
+  policy allowing the app origin. The checker probes this with a live OPTIONS preflight. Gated
+  on the endpoint (not the external URL) on purpose: a single-host S3-compatible setup
+  (external URL unset) still needs the policy, and that is exactly where browser uploads
+  silently failed. Non-authoritative like the external checks (CORS is a browser concern), so
+  registered as warn.
+  */}}
+  {{- if and (eq .Values.appConfigValues.storageProvider "s3") .Values.appConfigValues.s3Endpoint }}
+  {{- $_ := set $preflightsDict "BucketsValidator" (concat (index $preflightsDict "BucketsValidator") (list "Check_assets_bucket_CORS" "Check_temp_bucket_CORS")) -}}
+  {{- $preflightOptionalList = append $preflightOptionalList "Check_assets_bucket_CORS" -}}
+  {{- $preflightOptionalList = append $preflightOptionalList "Check_temp_bucket_CORS" -}}
+  {{- end }}
+
+  {{/*
   We push conditionally new analyzers for the feature flags if the customer defined overridden feature flags
   */}}
   {{- if (include "carto.featureFlags.enabled" .) }}
@@ -465,6 +480,8 @@ Return customer values to use in preflights and support-bundle
 {{- define "carto.replicated.tenantRequirementsChecker.customerValues" }}
   - name: CARTO_SELFHOSTED_VERSION
     value: {{ .Chart.AppVersion | quote }}
+  - name: CARTO_SELFHOSTED_DOMAIN
+    value: {{ .Values.appConfigValues.selfHostedDomain | quote }}
   - name: REDIS_CACHE_PREFIX 
     value: "onprem"
   - name: REDIS_HOST

--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -308,19 +308,14 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
   {{- end }}
 
   {{/*
-  When a custom S3-compatible endpoint is configured, browser direct uploads/downloads go
-  straight to the bucket host (a different origin than the app), so each bucket needs a CORS
-  policy allowing the app origin. The checker probes this with a live OPTIONS preflight. Gated
-  on the endpoint (not the external URL) on purpose: a single-host S3-compatible setup
-  (external URL unset) still needs the policy, and that is exactly where browser uploads
-  silently failed. Non-authoritative like the external checks (CORS is a browser concern), so
-  registered as warn.
+  Browser direct uploads/downloads hit the bucket host (a different origin than the app) on
+  every storage provider, so the bucket needs a CORS policy allowing the app origin. The
+  checker probes this with a live OPTIONS preflight; these checks always run. Non-authoritative
+  like the external checks (CORS is enforced by the browser), so registered as warn.
   */}}
-  {{- if and (eq .Values.appConfigValues.storageProvider "s3") .Values.appConfigValues.s3Endpoint }}
   {{- $_ := set $preflightsDict "BucketsValidator" (concat (index $preflightsDict "BucketsValidator") (list "Check_assets_bucket_CORS" "Check_temp_bucket_CORS")) -}}
   {{- $preflightOptionalList = append $preflightOptionalList "Check_assets_bucket_CORS" -}}
   {{- $preflightOptionalList = append $preflightOptionalList "Check_temp_bucket_CORS" -}}
-  {{- end }}
 
   {{/*
   We push conditionally new analyzers for the feature flags if the customer defined overridden feature flags


### PR DESCRIPTION
## Summary

Companion chart change for the S3-compatible bucket CORS preflight. Wires `CARTO_SELFHOSTED_DOMAIN` into the `tenant-requirements-checker` pod (so it knows the app origin to validate) and registers the two new bucket CORS checks in the KOTS preflight analyzer.

Story: [sc-564170](https://app.shortcut.com/cartoteam/story/564170) · found during the CloudFerro validation ([sc-563327](https://app.shortcut.com/cartoteam/story/563327)).

## What it does (`chart/templates/_commonChecks.tpl`)

- Adds `CARTO_SELFHOSTED_DOMAIN` (from `appConfigValues.selfHostedDomain`) to the checker's shared customer values.
- Registers `Check assets bucket CORS` and `Check temp bucket CORS` in the analyzer as **warn** outcomes. CORS applies to browser direct uploads/downloads on every storage provider, so they run unconditionally (not gated on a custom endpoint). Non-authoritative like the external bucket checks — CORS is enforced by the browser — so they warn rather than block install.

## Deployment impact

Self-hosted only.

## Related PRs

Checker implementation that emits these results: CartoDB/cloud-native#26802

**Reviewers: please review both PRs together — the checker emits the results and this chart maps them to analyzer outcomes; neither works without the other.**

## Validation steps

`helm dependency build && helm template … --show-only templates/preflight.yaml`:

- Default `gcp` provider, `storageProvider=s3` (with and without `s3Endpoint`) → both CORS checks render with a `warn` outcome and `CARTO_SELFHOSTED_DOMAIN` is set on the checker pod.
- Emitted result path (`BucketsValidator.Check_temp_bucket_CORS.status`) matches the checker's logger output.
