### PR TITLE
fix: make bucket CORS preflight checks hard-fail instead of warn [sc-564170]

### DIFF
--- a/chart/templates/_commonChecks.tpl
+++ b/chart/templates/_commonChecks.tpl
@@ -309,12 +309,10 @@ NOTE: Remember that with the ingress testing mode the components are not deploye
   {{/*
   Browser direct uploads/downloads hit the bucket host (a different origin than the app) on
   every storage provider, so the bucket needs a CORS policy allowing the app origin. The
-  checker probes this with a live OPTIONS preflight; these checks always run. Non-authoritative
-  like the external checks (CORS is enforced by the browser), so registered as warn.
+  checker probes this with a live OPTIONS preflight; these checks always run and block install
+  (fail, not warn) because import and asset flows are broken without a correct CORS policy.
   */}}
   {{- $_ := set $preflightsDict "BucketsValidator" (concat (index $preflightsDict "BucketsValidator") (list "Check_assets_bucket_CORS_sanity_check" "Check_temp_bucket_CORS_sanity_check")) -}}
-  {{- $preflightOptionalList = append $preflightOptionalList "Check_assets_bucket_CORS_sanity_check" -}}
-  {{- $preflightOptionalList = append $preflightOptionalList "Check_temp_bucket_CORS_sanity_check" -}}
 
   {{/*
   We push conditionally new analyzers for the feature flags if the customer defined overridden feature flags


### PR DESCRIPTION
## Summary

Follow-up to the merged bucket CORS preflight ([sc-564170](https://app.shortcut.com/cartoteam/story/564170)). The team decided (thread in #selfhosted-internal) the two CORS checks should be **hard failures** rather than warnings: without a correct bucket CORS policy the browser upload and asset flows don't work, so the platform runs degraded — that warrants blocking install, not just warning.

## Change

`chart/templates/_commonChecks.tpl`: drop `Check_assets_bucket_CORS_sanity_check` / `Check_temp_bucket_CORS_sanity_check` from `$preflightOptionalList` so the analyzer renders them as `fail` (like every other required check). They still only render when the checker emits them. No change to the checker (cloud-native) or the check naming.

## Validation

`helm template … --show-only templates/preflight.yaml`:
- Both CORS checks now render a `fail` outcome (previously `warn`).
- The external bucket checks are untouched (still `warn`).

Seen live on the CloudFerro env (sh-ferro): the checks correctly flag the missing CORS policy — this just promotes that from a warning to a blocking error.
