### PR TITLE
fix(chart): wire EXPORTS_S3_BUCKET_NAME into import-api/import-worker [sc-564698]

### DIFF
--- a/chart/templates/import-api/configmap.yaml
+++ b/chart/templates/import-api/configmap.yaml
@@ -83,6 +83,7 @@ data:
   CARTO_SELFHOSTED_AWS_EKS_POD_IDENTITY_METADATA_DB_ENABLED: {{ .Values.externalPostgresql.awsEksPodIdentityEnabled | quote }}
   {{- end }}
   EXPORTS_GCS_BUCKET_NAME: {{ .Values.appConfigValues.workspaceExportsBucket | quote }}
+  EXPORTS_S3_BUCKET_NAME: {{ .Values.appConfigValues.awsExportBucket | quote }}
   IMPORT_AWS_CUSTOM_BUCKET_ROLE_ARN: {{ .Values.appConfigValues.importAwsRoleArn | quote }}
   IMPORT_DATA_IMPORTS_BUCKET: {{ .Values.appConfigValues.workspaceImportsBucket | quote }}
   IMPORT_PROVIDER: {{ .Values.appConfigValues.storageProvider | quote }}

--- a/chart/templates/import-worker/configmap.yaml
+++ b/chart/templates/import-worker/configmap.yaml
@@ -83,6 +83,7 @@ data:
   CARTO_SELFHOSTED_AWS_EKS_POD_IDENTITY_METADATA_DB_ENABLED: {{ .Values.externalPostgresql.awsEksPodIdentityEnabled | quote }}
   {{- end }}
   EXPORTS_GCS_BUCKET_NAME: {{ .Values.appConfigValues.workspaceExportsBucket | quote }}
+  EXPORTS_S3_BUCKET_NAME: {{ .Values.appConfigValues.awsExportBucket | quote }}
   IMPORT_AWS_CUSTOM_BUCKET_ROLE_ARN: {{ .Values.appConfigValues.importAwsRoleArn | quote }}
   IMPORT_DATA_IMPORTS_BUCKET: {{ .Values.appConfigValues.workspaceImportsBucket | quote }}
   IMPORT_PROVIDER: {{ .Values.appConfigValues.storageProvider | quote }}


### PR DESCRIPTION
## Summary

The import engine resolves its export bucket from `EXPORTS_S3_BUCKET_NAME` when the storage provider is `s3`, but the chart only set that env var on `sql-worker` and `maps-api`. `import-api` and `import-worker` (which share import-api's settings) got only `EXPORTS_GCS_BUCKET_NAME`, so on S3-compatible deployments the DuckDB / BigQuery export path fell back to the GCS-derived export bucket and wrote exports to the wrong place.

This wires `EXPORTS_S3_BUCKET_NAME` (from `appConfigValues.awsExportBucket`, same source sql-worker/maps-api already use) into the `import-api` and `import-worker` configmaps.

Chart-side counterpart of the import-api code fix in cloud-native PR #26900.

## Story

[sc-564698](https://app.shortcut.com/cartoteam/story/564604) (bug found during CloudFerro re-validation of 1.280.1)

## Scope note

Only the bucket **name** is added. Region, endpoint, credentials and role-ARN for the export target are inherited from the import storage config (`{ ...dataImportSettings.storage, container: EXPORTS_S3_BUCKET_NAME }` in `import-api/src/settings.ts`), which is already wired via the `IMPORT_*` vars. `EXPORTS_S3_BUCKET_REGION` / `EXPORTS_S3_BUCKET_ROLE_ARN` (used by sql-worker/maps-api) are **not** read by import-api, so they are intentionally not added here. `workspace-api` was likewise left untouched — it only reads `EXPORTS_GCS_BUCKET_NAME`.

## Deployment impact

Self-hosted chart change. No-op for non-S3 deployments (var renders empty, same as `EXPORTS_GCS_BUCKET_NAME` already does). Requires the import-api image that reads the var (cloud-native #26900) to take effect on the export path.

## Validation

`helm template` with `storageProvider=s3` and `awsExportBucket` set renders both configmaps with `EXPORTS_S3_BUCKET_NAME` populated from `awsExportBucket`.