### PR TITLE
feat(chart): expose Workflows HTTP Request IP filtering config [sc-479237]

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -59,6 +59,9 @@ To install, upgrade or uninstall this chart, please refer to [the root README.md
 | `appConfigValues.ldsIsolineProvider`                               | The default LDS provider for isolines                                                                                  | `""`                   |
 | `appConfigValues.logLevel`                                         | The log level used in CARTO application                                                                                | `info`                 |
 | `appConfigValues.deploymentType`                                   | The deployment type used in CARTO application                                                                          | `helm`                 |
+| `appConfigValues.workflowsHttpRequestRestrictIps`                  | Block the Workflows HTTP Request component from reaching private and reserved IP ranges. Enabled by default.           | `true`                 |
+| `appConfigValues.workflowsHttpRequestAllowedIpRanges`              | CIDR ranges the HTTP Request component may reach even when otherwise blocked. Checked before the blocklist.            | `[]`                   |
+| `appConfigValues.workflowsHttpRequestRestrictedIpRanges`           | Override the default IP blocklist for the HTTP Request component. When set, it replaces CARTO's defaults.              | `[]`                   |
 
 ### CARTO Replicated parameters
 

--- a/chart/templates/workspace-api/configmap.yaml
+++ b/chart/templates/workspace-api/configmap.yaml
@@ -64,6 +64,14 @@ data:
   USING_EXTERNAL_REDIS: "true"
   {{- end }}
   WORKSPACE_ERROR_RESPONSE_STACK_TRACE: {{ .Values.cartoConfigValues.enableErrorResponseStackTrace | quote }}
+  {{- /* Always render the switch as a real boolean: an empty value makes workspace-api throw at boot. */}}
+  WORKSPACE_HTTP_REQUEST_RESTRICT_IPS: {{ .Values.appConfigValues.workflowsHttpRequestRestrictIps | quote }}
+  {{- if gt (len .Values.appConfigValues.workflowsHttpRequestAllowedIpRanges) 0 }}
+  WORKSPACE_HTTP_REQUEST_ALLOWED_IP_RANGES: {{ join "," .Values.appConfigValues.workflowsHttpRequestAllowedIpRanges | quote }}
+  {{- end }}
+  {{- if gt (len .Values.appConfigValues.workflowsHttpRequestRestrictedIpRanges) 0 }}
+  WORKSPACE_HTTP_REQUEST_RESTRICTED_IP_RANGES: {{ join "," .Values.appConfigValues.workflowsHttpRequestRestrictedIpRanges | quote }}
+  {{- end }}
   {{- if .Values.appConfigValues.aiFeaturesEnabled }}
   WORKSPACE_LITELLM_BASE_URL: "http://{{ include "carto.aiProxy.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
   {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -90,6 +90,12 @@ appConfigValues:
   logLevel: "info"
   ## @param appConfigValues.deploymentType The deployment type used in CARTO application
   deploymentType: "helm"
+  ## @param appConfigValues.workflowsHttpRequestRestrictIps Block the Workflows HTTP Request component from reaching private and reserved IP ranges. Enabled by default.
+  workflowsHttpRequestRestrictIps: true
+  ## @param appConfigValues.workflowsHttpRequestAllowedIpRanges CIDR ranges the HTTP Request component may reach even when otherwise blocked. Checked before the blocklist.
+  workflowsHttpRequestAllowedIpRanges: []
+  ## @param appConfigValues.workflowsHttpRequestRestrictedIpRanges Override the default IP blocklist for the HTTP Request component. When set, it replaces CARTO's defaults.
+  workflowsHttpRequestRestrictedIpRanges: []
 
 ## @section CARTO Replicated parameters
 ## Global configuration for installations using Replicated. If you change something from this section probably your self-hosted is going to stop working.


### PR DESCRIPTION
## Summary
Exposes the Workflows HTTP Request component's IP filtering as chart config. The component filters outbound requests by IP range (private and reserved ranges are blocked by default), and until now Helm operators could only change that through the generic `extraEnvVars` escape hatch. This adds three first-class `appConfigValues` so it can be configured, and documented, like any other knob.

Story: [sc-479237](https://app.shortcut.com/cartoteam/story/479237)
Platform side (workspace-api): CartoDB/cloud-native#26880

## What changed
Three new `appConfigValues`, wired into the workspace-api ConfigMap:

| Value | Default | Env var | Effect |
|-------|---------|---------|--------|
| `workflowsHttpRequestRestrictIps` | `true` | `WORKSPACE_HTTP_REQUEST_RESTRICT_IPS` | Master switch for the filter |
| `workflowsHttpRequestAllowedIpRanges` | `[]` | `WORKSPACE_HTTP_REQUEST_ALLOWED_IP_RANGES` | Allowlist ranges to reach internal endpoints; checked ahead of the blocklist |
| `workflowsHttpRequestRestrictedIpRanges` | `[]` | `WORKSPACE_HTTP_REQUEST_RESTRICTED_IP_RANGES` | Override the default blocklist entirely |

Defaults preserve current behaviour: the filter is already on by default in the app, so an install that sets none of these renders `RESTRICT_IPS: "true"` and no range lists, exactly as today.

## Design notes
- The switch always renders as a real boolean, so it can never be emitted blank; the app rejects an empty value at boot. That is why it is not wrapped in an `{{- if }}`.
- The two range lists render only when non-empty (`join ","`), so an unset list falls back to the app's own defaults rather than freezing a list into the chart.

## Validation
- `helm template` under four value combinations (default / allowlist set / filter off / blocklist override): each renders the expected env vars and `RESTRICT_IPS` is never blank.
- `helm lint`: clean.
- README values table regenerated with the helm-readme-generator (matches the CI parity check).

## Follow-up (not in this PR)
- KOTS Admin Console fields for these values, for Replicated installs (mirrors how the S3-compatible config was split across #887 → #888).
