### PR TITLE
fix(chart): honor featureFlagsOverrides in ai-api, lds-api and public-events-api [sc-565003]

### DIFF
--- a/chart/templates/ai-api/configmap.yaml
+++ b/chart/templates/ai-api/configmap.yaml
@@ -34,6 +34,9 @@ data:
   CARTO_TRACING_MODE: "local"
   {{- end }}
   CARTO_SELFHOSTED_VERSION: {{ .Chart.AppVersion | quote }}
+  {{- if (include "carto.featureFlags.enabled" .) }}
+  CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
+  {{- end }}
   EVENT_BUS_PROJECT_ID: {{ .Values.cartoConfigValues.cartoAccGcpProjectId | quote }}
   EVENT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.cartoAccGcpProjectId }}/topics/{{ .Values.cartoConfigValues.cartoAccGcpProjectRegion }}-event-bus"
   {{- if .Values.externalProxy.enabled }}

--- a/chart/templates/ai-api/deployment.yaml
+++ b/chart/templates/ai-api/deployment.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/ai-api/configmap.yaml") . | sha256sum }}
+        checksum/feature-flags-config: {{ include (print $.Template.BasePath "/custom-feature-flags-configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/ai-api/secret.yaml") . | sha256sum }}
         checksum/postgresql-password: {{ include "carto.postgresql.passwordChecksum" . }}
         checksum/redis-password: {{ include "carto.redis.passwordChecksum" . }}
@@ -193,6 +194,12 @@ spec:
               mountPath: {{ include "carto.trustedCACerts.configMapMountDir" . }}
               readOnly: true
             {{- end }}
+            {{- if (include "carto.featureFlags.enabled" .) }}
+            - name: feature-flags
+              mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
+              subPath: custom-feature-flags.yaml
+              readOnly: true
+            {{- end }}
             {{- if .Values.aiApi.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.aiApi.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
@@ -220,6 +227,14 @@ spec:
         - name: trusted-ca-certs
           configMap:
             name: {{ include "carto.trustedCACerts.configMapName" . }}
+        {{- end }}
+        {{- if (include "carto.featureFlags.enabled" .) }}
+        - name: feature-flags
+          configMap:
+            name: {{ template "carto.featureFlags.configMapName" . }}
+            items:
+              - key: custom-feature-flags.yaml
+                path: custom-feature-flags.yaml
         {{- end }}
         {{- if .Values.aiApi.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.aiApi.extraVolumes "context" $) | nindent 8 }}

--- a/chart/templates/import-api/deployment.yaml
+++ b/chart/templates/import-api/deployment.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/import-api/configmap.yaml") . | sha256sum }}
+        checksum/feature-flags-config: {{ include (print $.Template.BasePath "/custom-feature-flags-configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/import-api/secret.yaml") . | sha256sum }}
         checksum/redis-password: {{ include "carto.redis.passwordChecksum" . }}
         checksum/postgresql-password: {{ include "carto.postgresql.passwordChecksum" . }}

--- a/chart/templates/import-worker/deployment.yaml
+++ b/chart/templates/import-worker/deployment.yaml
@@ -30,6 +30,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/import-worker/configmap.yaml") . | sha256sum }}
+        checksum/feature-flags-config: {{ include (print $.Template.BasePath "/custom-feature-flags-configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/import-worker/secret.yaml") . | sha256sum }}
         checksum/redis-password: {{ include "carto.redis.passwordChecksum" . }}
         checksum/postgresql-password: {{ include "carto.postgresql.passwordChecksum" . }}

--- a/chart/templates/lds-api/configmap.yaml
+++ b/chart/templates/lds-api/configmap.yaml
@@ -15,6 +15,9 @@ data:
   AUTH0_AUDIENCE: "carto-cloud-native-api"
   AUTH0_DOMAIN: {{ .Values.cartoConfigValues.cartoAuth0CustomDomain | quote }}
   AUTH0_NAMESPACE: "http://app.carto.com"
+  {{- if (include "carto.featureFlags.enabled" .) }}
+  CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
+  {{- end }}
   CARTO_SELFHOSTED_VERSION: {{ .Chart.AppVersion | quote }}
   {{- if eq .Values.appConfigValues.logLevel "debug" }}
   CARTO_TRACING_MODE: "local"

--- a/chart/templates/lds-api/deployment.yaml
+++ b/chart/templates/lds-api/deployment.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/lds-api/configmap.yaml") . | sha256sum }}
+        checksum/feature-flags-config: {{ include (print $.Template.BasePath "/custom-feature-flags-configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/lds-api/secret.yaml") . | sha256sum }}
         checksum/redis-password: {{ include "carto.redis.passwordChecksum" . }}
         checksum/postgresql-password: {{ include "carto.postgresql.passwordChecksum" . }}
@@ -199,6 +200,12 @@ spec:
               mountPath: {{ include "carto.trustedCACerts.configMapMountDir" . }}
               readOnly: true
             {{- end }}
+            {{- if (include "carto.featureFlags.enabled" .) }}
+            - name: feature-flags
+              mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
+              subPath: custom-feature-flags.yaml
+              readOnly: true
+            {{- end }}
           {{- if .Values.ldsApi.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.ldsApi.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -226,6 +233,14 @@ spec:
         - name: trusted-ca-certs
           configMap:
             name: {{ include "carto.trustedCACerts.configMapName" . }}
+        {{- end }}
+        {{- if (include "carto.featureFlags.enabled" .) }}
+        - name: feature-flags
+          configMap:
+            name: {{ template "carto.featureFlags.configMapName" . }}
+            items:
+              - key: custom-feature-flags.yaml
+                path: custom-feature-flags.yaml
         {{- end }}
         {{- if .Values.ldsApi.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.ldsApi.extraVolumes "context" $) | nindent 8 }}

--- a/chart/templates/public-events-api/configmap.yaml
+++ b/chart/templates/public-events-api/configmap.yaml
@@ -12,6 +12,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
+  {{- if (include "carto.featureFlags.enabled" .) }}
+  CARTO_FEATURE_FLAGS_FILE_PATH: {{ include "carto.featureFlags.configMapMountDir" . | quote }}
+  {{- end }}
   {{- if not .Values.commonBackendServiceAccount.enableGCPWorkloadIdentity }}
   GOOGLE_APPLICATION_CREDENTIALS: {{ include "carto.google.secretMountAbsolutePath" . }}
   {{- end }}

--- a/chart/templates/public-events-api/deployment.yaml
+++ b/chart/templates/public-events-api/deployment.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/public-events-api/configmap.yaml") . | sha256sum }}
+        checksum/feature-flags-config: {{ include (print $.Template.BasePath "/custom-feature-flags-configmap.yaml") . | sha256sum }}
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         {{- if .Values.publicEventsApi.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.publicEventsApi.podAnnotations "context" $) | nindent 8 }}
@@ -152,6 +153,12 @@ spec:
               mountPath: {{ include "carto.trustedCACerts.configMapMountDir" . }}
               readOnly: true
             {{- end }}
+            {{- if (include "carto.featureFlags.enabled" .) }}
+            - name: feature-flags
+              mountPath: {{ include "carto.featureFlags.configMapMountDir" . }}
+              subPath: custom-feature-flags.yaml
+              readOnly: true
+            {{- end }}
           {{- if .Values.publicEventsApi.extraVolumeMounts }}
           {{- include "common.tplvalues.render" (dict "value" .Values.publicEventsApi.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
@@ -169,6 +176,14 @@ spec:
         - name: trusted-ca-certs
           configMap:
             name: {{ include "carto.trustedCACerts.configMapName" . }}
+        {{- end }}
+        {{- if (include "carto.featureFlags.enabled" .) }}
+        - name: feature-flags
+          configMap:
+            name: {{ template "carto.featureFlags.configMapName" . }}
+            items:
+              - key: custom-feature-flags.yaml
+                path: custom-feature-flags.yaml
         {{- end }}
         {{- if .Values.publicEventsApi.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.publicEventsApi.extraVolumes "context" $) | nindent 8 }}


### PR DESCRIPTION
## Problem

`cartoConfigValues.featureFlagsOverrides` is written to the `carto-custom-feature-flags` ConfigMap and injected into services via `CARTO_FEATURE_FLAGS_FILE_PATH` — but only into 7 of the 10 CARTO backends.

`ai-api`, `lds-api` and `public-events-api` never got the env var or the mount, so they fell back to their baked-in flag defaults and **silently ignored every override**. On a deployment with no LaunchDarkly key there was no supported way to flip a flag for those services; the only workaround was setting the service's own `FF_*` env var through `extraEnvVars`.

## Change

Wire all four pieces into the three missing components, gated on the existing `carto.featureFlags.enabled` helper — same pattern as `maps-api`:

| | env var | pod checksum | volume | volumeMount |
|---|---|---|---|---|
| `ai-api` | ✅ | ✅ | ✅ | ✅ |
| `lds-api` | ✅ | ✅ | ✅ | ✅ |
| `public-events-api` | ✅ | ✅ | ✅ | ✅ |

Also adds the missing `checksum/feature-flags-config` annotation to `import-api` and `import-worker` — both already mounted the ConfigMap but lacked the annotation, so changing an override never restarted their pods.

No new helpers, no `values.yaml` change (so no `chart/README.md` regeneration), and no KOTS change — the override already reaches chart values via `platformAdvancedTuningValues` recursive-merge.

## Not wired, deliberately

- `router`, `http-cache`, `gateway` — nginx / varnish / Gateway API, not CARTO app services
- `aiproxy` — LiteLLM, does not read CARTO feature flags
- `accounts-www`, `notifier`, `cdn-invalidator-sub` — CARTO images, but no evidence they consume the flag file; wiring them would add a restart trigger for nothing

If any of those three do call `FeatureFlagsClient`, say so and I'll add them.

## Verification

`helm lint` clean. Rendered four ways; all 10 components uniform (env + volume + mount + checksum):

- overrides set, plain Helm
- overrides set, `--set replicated.enabled=true`
- `s3Endpoint` set with no explicit overrides — auto-injected `2024-private-buckets` reaches all 10
- no overrides — no ConfigMap, no volume, no mount; only the checksum annotation over empty content, matching the pre-existing behavior of the 7 already-wired components

🤖 Generated with [Claude Code](https://claude.com/claude-code)
