### PR TITLE
feat(chart): add ai-api backend service URLs [sc-565022]

### DIFF
--- a/chart/templates/ai-api/configmap.yaml
+++ b/chart/templates/ai-api/configmap.yaml
@@ -17,8 +17,19 @@ data:
   # AI_OPENAI_ENDPOINT points to aiProxy proxy service, not directly to OpenAI
   # aiProxy acts as a unified gateway that can route to various AI providers
   AI_OPENAI_ENDPOINT: "http://{{ include "carto.aiProxy.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}/v1"
+  # AI_SQL_API_URL and AI_MAPS_API_URL both point to maps-api: it serves the SQL
+  # and the Maps API surfaces in self-hosted, unlike SaaS where they are split
   AI_SQL_API_URL: "http://{{ include "carto.mapsApi.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+  AI_MAPS_API_URL: "http://{{ include "carto.mapsApi.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
   AI_LDS_API_URL: "http://{{ include "carto.ldsApi.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+  AI_WORKSPACE_API_URL: "http://{{ include "carto.workspaceApi.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+  AI_IMPORT_API_URL: "http://{{ include "carto.importApi.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+  {{- if .Values.cartoConfigValues.cartoAccApiDomain }}
+  AI_ACCOUNTS_API_URL: "https://{{ .Values.cartoConfigValues.cartoAccApiDomain }}"
+  {{- end }}
+  {{- if .Values.cartoConfigValues.cartoDoApiDomain }}
+  AI_DO_CATALOG_API_URL: "https://{{ .Values.cartoConfigValues.cartoDoApiDomain }}"
+  {{- end }}
   AI_TENANT_ID: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
   AI_API_PUBLIC_URL_ALLOWED_HOSTS: {{ .Values.appConfigValues.selfHostedDomain | quote }}
   AI_API_PUBLIC_URL_HOST: {{ .Values.appConfigValues.selfHostedDomain | quote }}


### PR DESCRIPTION
## Problem

`ai-api` reaches each backing service through an `AI_<SERVICE>_API_URL` env var. The chart only set `AI_SQL_API_URL` and `AI_LDS_API_URL`, so the tool groups gated on the other five never registered on Self-Hosted.

## Change

One file, `chart/templates/ai-api/configmap.yaml`. Three of the five resolve to in-cluster services:

| Env var | Target | Tool groups it gates |
|---|---|---|
| `AI_WORKSPACE_API_URL` | `workspace-api` | connections, resources, maps, projects, named sources, workflows |
| `AI_MAPS_API_URL` | `maps-api` | maps write pipeline |
| `AI_IMPORT_API_URL` | `import-api` | imports, exports, transfers |

The other two are **not deployed by this chart** — `accounts-api` and `do-catalog-api` are CARTO-hosted. They use the existing `cartoConfigValues.cartoAccApiDomain` / `cartoDoApiDomain` over https, the same values `workspace-www` already consumes:

| Env var | Source |
|---|---|
| `AI_ACCOUNTS_API_URL` | `https://{{ cartoAccApiDomain }}` |
| `AI_DO_CATALOG_API_URL` | `https://{{ cartoDoApiDomain }}` |

### Two judgment calls worth reviewing

**Those two are gated on a non-empty domain.** Both default to `""` and no validator requires them, so a pure-Helm install can legitimately leave them unset. Emitting a bare `https://` would make `ai-api` register the credentials and Data Observatory tool groups against an unusable URL — worse than the story's intended "don't register until set". KOTS always populates both from `valuesDerivedFromCartoPlatformEnvironment`, so this only affects Helm-only installs.

**`AI_SQL_API_URL` and `AI_MAPS_API_URL` both point at `maps-api`** — correct here, not a copy-paste slip: `maps-api` serves both surfaces in Self-Hosted. Called out in a comment since it reads like a bug otherwise.

The in-cluster URLs are portless, matching the existing `AI_SQL_API_URL` and the dominant convention in this chart (22 portless vs 1 with an explicit port). Verified all four target Services listen on `80`.

## Verification

`helm lint` clean. Rendered three ways:

- **domains set** — all 5 vars present; in-cluster URLs resolve to `carto-{workspace,maps,import}-api.<ns>.svc.cluster.local`, confirmed against the rendered Service names and ports
- **domains empty (chart defaults)** — the 3 in-cluster vars present, the 2 external ones correctly absent
- **`--set replicated.enabled=true`** — all 5 present

No `values.yaml` change (so no `chart/README.md` regeneration) and no KOTS change — both domains already flow through `kots-helm.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
