### PR TITLE
chore(chart): dedupe the default image registry via a YAML anchor [sc-562629]

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -547,7 +547,7 @@ accountsWww:
   ## @param accountsWww.image.pullSecrets accounts-www image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: &defaultRegistry us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
     repository: accounts-www
     ## Specify a custom image tag
     tag: ""
@@ -879,7 +879,7 @@ importApi:
   ## @param importApi.image.pullSecrets import-api image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: import-api
     ## Specify a custom image tag
     tag: ""
@@ -1208,7 +1208,7 @@ importWorker:
   ## @param importWorker.image.pullSecrets import-worker image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: import-api
     ## Specify a custom image tag
     tag: ""
@@ -1479,7 +1479,7 @@ ldsApi:
   ## @param ldsApi.image.pullSecrets lds-api image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: lds-api
     ## Specify a custom image tag
     tag: ""
@@ -1808,7 +1808,7 @@ publicEventsApi:
   ## @param publicEventsApi.image.pullSecrets public-events-api image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: public-events-api
     ## Specify a custom image tag
     tag: ""
@@ -2137,7 +2137,7 @@ mapsApi:
   ## @param mapsApi.image.pullSecrets maps-api image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: maps-api
     ## Specify a custom image tag
     tag: ""
@@ -2466,7 +2466,7 @@ sqlWorker:
   ## @param sqlWorker.image.pullSecrets sql-worker image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: maps-api
     ## Specify a custom image tag
     tag: ""
@@ -2728,7 +2728,7 @@ router:
   ## @param router.image.pullSecrets router image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: router/router-http
     ## Specify a custom image tag
     tag: ""
@@ -3179,7 +3179,7 @@ httpCache:
   ## @param httpCache.image.pullSecrets http-cache image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: http-cache
     ## Specify a custom image tag
     tag: ""
@@ -3506,7 +3506,7 @@ notifier:
   ## @param notifier.image.pullSecrets notifier image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: notifier
     ## Specify a custom image tag
     tag: ""
@@ -3831,7 +3831,7 @@ cdnInvalidatorSub:
   ## @param cdnInvalidatorSub.image.pullSecrets cdn-invalidator-sub image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: consumers/cdn-invalidator-sub
     ## Specify a custom image tag
     tag: ""
@@ -4150,7 +4150,7 @@ workspaceApi:
   ## @param workspaceApi.image.pullSecrets workspace-api image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: workspace-api
     ## Specify a custom image tag
     tag: ""
@@ -4480,7 +4480,7 @@ workspaceSubscriber:
   ## @param workspaceSubscriber.image.pullSecrets workspace-subscriber image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: workspace-api
     ## Specify a custom image tag
     tag: ""
@@ -4751,7 +4751,7 @@ workspaceWww:
   ## @param workspaceWww.image.pullSecrets workspace-www image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: workspace-www
     ## Specify a custom image tag
     tag: ""
@@ -5083,7 +5083,7 @@ workspaceMigrations:
   ## @param workspaceMigrations.image.pullSecrets workspace-db image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: workspace-db
     ## Specify a custom image tag
     tag: ""
@@ -5151,7 +5151,7 @@ tenantRequirementsChecker:
   ## @param tenantRequirementsChecker.image.pullSecrets tenant-requirements-checker image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: tenant-requirements-checker
     tag: ""
     pullPolicy: Always
@@ -5221,7 +5221,7 @@ internalRedis:
   ##
   enabled: true
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: valkey
     tag: ""
     pullPolicy: IfNotPresent
@@ -5648,7 +5648,7 @@ upgradeCheck:
   ## @param upgradeCheck.image.pullSecrets upgradeCheck image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: router/router-http
     ## Specify a custom image tag
     tag: ""
@@ -5723,7 +5723,7 @@ routerMetrics:
   ## @param routerMetrics.image.pullSecrets routerMetrics image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: router/router-metrics
     ## Specify a custom image tag
     tag: ""
@@ -5908,7 +5908,7 @@ aiApi:
   ## @param aiApi.image.pullSecrets ai-api image pull secrets
   ##
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: ai-api
     ## Specify a custom image tag
     tag: ""
@@ -6245,7 +6245,7 @@ aiProxy:
   ## @param aiProxy.image.pullPolicy aiProxy image pull policy
   ## @param aiProxy.image.pullSecrets aiProxy image pull secrets
   image:
-    registry: us-docker.pkg.dev/carto-onprem-artifacts/gcr.io
+    registry: *defaultRegistry
     repository: litellm
     ## Specify a custom image tag
     tag: ""


### PR DESCRIPTION
## Summary

gemini-code-assist flagged on #898 that the registry default is repeated across all 21 image blocks in `chart/values.yaml` (https://github.com/CartoDB/carto-selfhosted-helm/pull/898#discussion_r3597783269), so a future default change means editing 21 places instead of one. Anchors the value once, on `accountsWww.image.registry` (the first occurrence), and aliases it into the remaining 20 blocks.

Zero behavioral change: parsed YAML structure is identical to main (`yaml.safe_load` comparison), and a full `helm template` diff (before/after, controlling for release name and Helm's randomly-generated secrets) shows no change to any rendered manifest.

## Story link

[sc-562629](https://app.shortcut.com/cartoteam/story/562629)

## Also considered: consolidating onto `global.imageRegistry`

The chart already has a `global.imageRegistry` override that every component's image helper respects (`carto.images.image` in `_helpers.tpl`), which looked like the more idiomatic fix: give it the real default instead of duplicating it, and have Replicated's `kots-helm.yaml` do the same instead of its own 21 per-component overrides.

Rejected after checking with `helm template`: `global.imageRegistry` is shared across the whole release, including the vendored `postgresql` subchart. Populating it redirects `docker.io/bitnami/postgresql` to `us-docker.pkg.dev/carto-onprem-artifacts/gcr.io/bitnami/postgresql`, which doesn't exist in that registry, breaking the bundled Postgres pull on the default `internalPostgresql.enabled: true` install. That's presumably why it's left `""` today. Leaving this here in case anyone else considers the same move later.

## Validation

- [x] `yaml.safe_load` comparison: parsed `values.yaml` identical to main
- [x] `helm template` diff (before/after): no change to any rendered image reference or other manifest content
- [x] `helm lint`: passes
