### PR TITLE
docs(chart): document values-placement and config-wiring conventions

### DIFF
--- a/chart/CLAUDE.md
+++ b/chart/CLAUDE.md
@@ -36,6 +36,44 @@ in the shared block anyway.
 app-behavior knobs sitting in a component block anyway — legacy, not
 precedent to copy.
 
+**Corollary — whole-component enablement.** Whether an optional component
+deploys at all follows the same split: customer-facing feature components
+(`httpCache`, `publicEventsApi`, `aiApi`, `aiProxy`, `cdnInvalidatorSub`) are
+gated by an `appConfigValues.*Enabled` boolean plus `not
+cartoConfigValues.onlyRunRouter` — never a self `<component>.enabled` field.
+The exception is infra swap-components choosing between CARTO's bundled
+instance and a customer's own: `internalRedis.enabled`,
+`internalPostgresql.enabled`, and `gateway.enabled` gate themselves, because
+swapping infrastructure backends is that component's own concern, not an
+app-feature decision.
+
+## Feature flags vs `appConfigValues.*Enabled` toggles
+
+Two different mechanisms gate behavior — pick by axis of control, not by
+where the value happens to live:
+
+- **`cartoConfigValues.featureFlagsOverrides`** (LaunchDarkly-backed, see
+  `cartoConfigValues.launchDarklyClientSideId`) is CARTO's staged-rollout
+  mechanism. The test for wiring a new component into it is a fact about that
+  component's *code*, not about `values.yaml`: does its backend actually call
+  the internal `FeatureFlagsClient`? If yes, wire the same four pieces every
+  already-wired component has — the `CARTO_FEATURE_FLAGS_FILE_PATH` env var, a
+  `feature-flags` volume mount, the volume itself, and a
+  `checksum/feature-flags-config` pod annotation — gated on
+  `carto.featureFlags.enabled`. Don't wire infra (`router`, `httpCache`,
+  `gateway`) or third-party images (`aiProxy`/LiteLLM) that don't consume the
+  flag file — an unused mount just adds a spurious restart trigger. The chart
+  can also auto-derive an override from deployment config (an S3-compatible
+  `appConfigValues.s3Endpoint` auto-enables a storage-related flag) — still
+  CARTO's mechanism, just reacting to the customer's config instead of a human
+  toggling LaunchDarkly.
+- **`appConfigValues.*Enabled` booleans** are the customer's permanent,
+  structural choice — does this install have this component/route at all —
+  set once at install, not staged or gradually rolled out.
+
+Wiring a new backend feature and unsure which one: staged rollout across the
+fleet → feature flag; a customer's install-time decision → `appConfigValues`.
+
 ## `_helpers.tpl` invariants
 
 Per-component helpers are uniform (`carto.<component>.fullname`,
@@ -60,6 +98,20 @@ than trusting any list written here.
   is hand-maintained and unvalidated**: a typo in the values path renders an
   empty env var with no error. This is the most common "service starts without
   its credential" bug — changes here deserve a second reviewer.
+- **Three separate secret mechanisms — don't conflate them.** A field's own
+  `.existingSecret.name`/`.key` (nested inside `appSecrets.<field>` /
+  `cartoSecrets.<field>`) only affects that one env var via the
+  `secretAssociation` map above. A *component's* top-level
+  `<component>.existingSecret` is unrelated: it redirects that component's
+  whole generated Secret (`envFrom.secretRef.name`) to a customer-managed one,
+  independent of which individual fields are set — same shape as
+  `<component>.existingConfigMap`. Database credentials
+  (`internalPostgresql`/`externalPostgresql`/`externalRedis`,
+  `cartoSecrets.redisPassword`) sit outside `secretAssociation` entirely, on
+  an older `existingSecret`/`existingSecretPasswordKey` convention — don't
+  expect them in the map. `extraEnvVarsSecret`/`extraEnvVarsCM` is a third,
+  generic escape hatch for arbitrary customer-supplied env vars, unrelated to
+  both.
 - **`nodeOptions` assume `Mi`.** The Node.js `--max-old-space-size` helpers
   parse the memory limit only when its unit is `Mi`; anything else silently
   falls back to the default instead of erroring.

--- a/chart/CLAUDE.md
+++ b/chart/CLAUDE.md
@@ -6,6 +6,36 @@ service, secret) per component. `valkey` is the current cache; `redis` is the
 legacy name kept for backward compatibility — **don't rename it**, it breaks
 existing installs (the `carto.redis.*` helpers resolve to Valkey on purpose).
 
+## Where a new `values.yaml` parameter goes
+
+Placement is by **what the parameter configures**, not by how many templates
+read it — several `appConfigValues`/`cartoConfigValues` keys already have
+exactly one consumer (`ldsGeocodingProvider`, `defaultDoLocation.*`) and stay
+in the shared block anyway.
+
+- **`appConfigValues`** — CARTO application/business behavior the *customer*
+  sets: feature toggles, storage/bucket config, provider selection (LDS/AT/DO
+  defaults), engine tuning for an app-level feature (e.g.
+  `appConfigValues.duckdb.*` for the import/export transfer engine).
+- **`cartoConfigValues`** — the same shape, but for wiring the customer
+  normally never touches (Auth0, CARTO's own GCP project IDs, LaunchDarkly,
+  feature-flag overrides) — changing it can break the install.
+- **A component's own block** (`importWorker:`, `mapsApi:`, …) — only that
+  component's Kubernetes deployment shape: image, resources, probes,
+  replicaCount, security context, affinity/scheduling, service, PDB,
+  sidecars/extraVolumes — or a setting that's conceptually process/pod sizing
+  for *that* pod. `<component>.defaultNodeProcessMaxOldSpace` (Node heap size)
+  is the precedent: it stays local in every one of the 10 components that have
+  it, because it's runtime sizing for that pod, not app behavior — true even
+  where it's no longer literally computed as a percentage of that pod's own
+  `resources.limits.memory` (`importWorker` decoupled the two once DuckDB
+  started allocating memory outside the V8 heap; the heap knob stayed put,
+  only the DuckDB memory/thread/spill knobs moved to `appConfigValues.duckdb`).
+
+`router.nginxConfig.*` and `aiApi.customHeaders` predate this rule and are
+app-behavior knobs sitting in a component block anyway — legacy, not
+precedent to copy.
+
 ## `_helpers.tpl` invariants
 
 Per-component helpers are uniform (`carto.<component>.fullname`,

--- a/manifests/CLAUDE.md
+++ b/manifests/CLAUDE.md
@@ -17,6 +17,28 @@ yourself encoding behavior here that the chart doesn't have, stop.
 `scripts/test-kots-config.sh` renders the KOTS config for `gke|eks|aks|all` —
 the quick local check after touching these files.
 
+## Does a new `appConfigValues` parameter need a KOTS field?
+
+Not a bright line — most `appConfigValues` parameters get a
+`kots-config.yaml` item plus `kots-helm.yaml` wiring, but several legitimately
+don't (a low-traffic EKS-specific auth toggle, a split-horizon URL override,
+disabling the internal cache, a frontend telemetry switch), simply because no
+one's asked to configure them from the Admin Console yet — that's not a rule
+to reason from. Two cases are checkable, though:
+
+- **The option only makes sense if the customer is already hand-authoring
+  Kubernetes objects** (e.g. pointing at a pre-existing ConfigMap/Secret by
+  name) → Helm-only. `trustedCACerts.existingConfigmap` kept its chart value
+  but was deliberately dropped from the KOTS UI for this reason, while the
+  sibling inline-PEM field stayed exposed.
+- **The value is CARTO-managed engine tuning the customer was never meant to
+  set** → not exposed anywhere, and often not even documented as customer
+  config in the first place.
+
+Outside those two, default to wiring both — the whole point of KOTS parity is
+that a customer shouldn't have to hand-edit Helm values for something every
+install has to decide.
+
 ## Secrets — three origins, wired differently
 
 - **Auto-generated** infra secrets: `type: RandomString`, `hidden`, in


### PR DESCRIPTION
## Summary

Documents recurring "where does X go" / "when do you do Y vs Z" conventions for `chart/values.yaml` and the KOTS translation layer, in `chart/CLAUDE.md` and `manifests/CLAUDE.md`. Written up after moving DuckDB transfer-engine tuning to `appConfigValues.duckdb.*` in #918, then extended by systematically checking for other instances of the same kind of decision rather than guessing.

Every rule below was verified against the actual chart (grep + read, not asserted) before being written down; two of them explicitly flag where the evidence doesn't support a clean rule.

**`chart/CLAUDE.md`:**
- **Where a new `values.yaml` parameter goes** — `appConfigValues`/`cartoConfigValues` (app/business behavior) vs. a component's own block (k8s deployment shape or pod/process sizing). Consumer count doesn't decide placement — several shared-block keys already have exactly one consumer. Two pre-existing exceptions (`router.nginxConfig.*`, `aiApi.customHeaders`) flagged as legacy, not precedent.
- **Corollary: whole-component enablement** — customer-facing feature components are gated by an `appConfigValues.*Enabled` boolean, never a self `<component>.enabled`. Exception: `internalRedis`/`internalPostgresql`/`gateway` self-toggle, because swapping infra backends is that component's own concern.
- **Feature flags vs `appConfigValues.*Enabled` toggles** — CARTO's LaunchDarkly-backed staged-rollout mechanism (wired when a component's backend code calls `FeatureFlagsClient`) vs. the customer's permanent install-time structural choice. Different axis of control, easy to conflate.
- **Three separate secret mechanisms** — the `secretAssociation` per-field `existingSecret`, a component's own top-level `existingSecret` (whole-Secret override, unrelated), and the older DB-credential `existingSecret`/`existingSecretPasswordKey` convention. Confusingly similar names, different jobs.

**`manifests/CLAUDE.md`:**
- **Does a new `appConfigValues` parameter need a KOTS field?** — stated honestly as *not* a bright line: two checkable anchors (requires hand-authoring k8s objects → Helm-only; CARTO-managed engine tuning → not customer config at all) plus an acknowledged fuzzy middle where several params just haven't had a KOTS request filed yet.

## Note on sequencing

`appConfigValues.duckdb.*` doesn't exist on `main` yet — it's only on #918 (still open/draft). Not a functional dependency, just reads best if #918 lands first or around the same time.

## Validation

Docs-only change, no chart/values/templates touched.