### PR TITLE
fix(ci): WIF auth for release workflows [sc-567936]

### DIFF
--- a/.github/actions/publish-release/action.yaml
+++ b/.github/actions/publish-release/action.yaml
@@ -14,9 +14,12 @@ inputs:
   trigger-action:
     description: "Action that triggered the release"
     required: true
-  gcloud-service-account:
-    description: "Service account key for Google Cloud"
-    required: true
+  workload-identity-provider:
+    description: "Workload Identity Federation provider resource name for Google Cloud auth"
+    default: projects/1086647180948/locations/global/workloadIdentityPools/github-actions-pool/providers/github-carto-selfhosted-helm
+  service-account:
+    description: "Service account email to impersonate via Workload Identity Federation"
+    default: github-actions-artifacts@carto-artifacts.iam.gserviceaccount.com
   replicated-api-token:
     description: "API token for Replicated"
     required: true
@@ -41,7 +44,8 @@ runs:
     - name: Google Cloud Auth
       uses: google-github-actions/auth@v2
       with:
-        credentials_json: ${{ inputs.gcloud-service-account }}
+        workload_identity_provider: ${{ inputs.workload-identity-provider }}
+        service_account: ${{ inputs.service-account }}
         project_id: ${{ inputs.artifacts-gcp-project-id }}
 
     # Step 2: Install Gcloud CLI

--- a/.github/workflows/branch-changes-release.yaml
+++ b/.github/workflows/branch-changes-release.yaml
@@ -16,6 +16,7 @@ jobs:
       id-token: write
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/branch-changes-release.yaml
+++ b/.github/workflows/branch-changes-release.yaml
@@ -12,6 +12,10 @@ jobs:
       )
     timeout-minutes: 3
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,7 +51,6 @@ jobs:
           version: ${{ steps.generate-channel-info.outputs.version }}
           release-notes: "CARTO Self-Hosted dev version generated from branch ${{ steps.generate-channel-info.outputs.channel-name }}"
           trigger-action: "dev"
-          gcloud-service-account: ${{ secrets.CARTO_ARTIFACTS_SERVICE_ACCOUNT }}
           replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}
       
       - name: Comment on PR

--- a/.github/workflows/official-release.yaml
+++ b/.github/workflows/official-release.yaml
@@ -7,6 +7,9 @@ jobs:
   helm-package:
     timeout-minutes: 3
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,7 +33,6 @@ jobs:
           version: ${{ steps.release-info.outputs.version }}
           release-notes: "CARTO Self-Hosted ${{ steps.release-info.outputs.version }}"
           trigger-action: ${{ github.event.action }}
-          gcloud-service-account: ${{ secrets.CARTO_ARTIFACTS_SERVICE_ACCOUNT }}
           replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}
 
       - name: Slack notification

--- a/.github/workflows/release-dedicateds-changes.yaml
+++ b/.github/workflows/release-dedicateds-changes.yaml
@@ -8,6 +8,9 @@ jobs:
   release-changes:
     timeout-minutes: 3
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,5 +29,4 @@ jobs:
           version: ${{ steps.get-chart-version.outputs.version }}
           release-notes: "CARTO Self-Hosted version generated from main branch."
           trigger-action: "dev"
-          gcloud-service-account: ${{ secrets.CARTO_ARTIFACTS_SERVICE_ACCOUNT }}
           replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}


### PR DESCRIPTION
## Summary

Release publishing is broken: the `publish-release` composite action authenticates to GCP with the static `CARTO_ARTIFACTS_SERVICE_ACCOUNT` key, which went invalid under SEC-2026-001 (`invalid_grant: Invalid JWT Signature`, [failing run](https://github.com/CartoDB/carto-selfhosted-helm/actions/runs/32031954580)). This switches the action to keyless Workload Identity Federation, impersonating `github-actions-artifacts@carto-artifacts`, and adds `id-token: write` to the three release jobs that use it (`official-release`, `branch-changes-release`, `release-dedicateds-changes`).

The provider name and SA email are defaulted on the composite action, so callers only add the permissions block and drop the secret input. `branch-changes-release` additionally keeps `pull-requests: write` for its PR-comment step, since setting `permissions` scopes the job token.

## Story

[sc-567936](https://app.shortcut.com/cartoteam/story/567936)

## Depends on

Apply these first, or auth will fail because the provider/binding won't exist:
- WIF provider: https://github.com/CartoDB/carto-infrastructure/pull/690
- SA binding: https://github.com/CartoDB/cloud-native/pull/27548

## Validation

Once the two TF PRs are applied, re-run the failed `official-release` (or push a `release-changes`-labeled PR) and confirm the GCP auth + gsutil/Replicated steps succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)