### PR TITLE
fix(chart): redact API key values in support bundle collection [sc-569079]

### DIFF
--- a/chart/templates/support-bundle-redactor.yaml
+++ b/chart/templates/support-bundle-redactor.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    troubleshoot.sh/kind: support-bundle
+  name: {{ .Release.Name }}-support-bundle-redactor
+  namespace: {{ .Release.Namespace | quote }}
+stringData:
+  # Discovered alongside the support-bundle spec (same label, `redactor-spec` key)
+  # by `kubectl support-bundle --load-cluster-specs` and by KOTS bundle generation.
+  redactor-spec: |
+    apiVersion: troubleshoot.sh/v1beta2
+    kind: Redactor
+    metadata:
+      name: {{ .Release.Name }}-support-bundle-redactor
+    spec:
+      redactors:
+        - name: api-key-values
+          removals:
+            regex:
+              # API keys surface in collected pod logs both as plain JSON and as
+              # escaped JSON embedded in a log line ("apiKey":"…" vs \"apiKey\":\"…\"),
+              # which the default redactors miss. Everything outside the capture
+              # groups is removed, so the prefix stays and the value becomes ***HIDDEN***.
+              - redactor: '(?i)((?:"|\\")api[_-]?key(?:"|\\")\s*:\s*(?:"|\\"))(?P<mask>[^"\\]+)'


### PR DESCRIPTION
## Summary

Support bundles collect pod logs where API keys can surface as plain JSON (`"apiKey":"…"`) or as escaped JSON embedded in a log line (`\"apiKey\":\"…\"`). troubleshoot.sh's default redaction misses both shapes, so a customer-uploaded bundle can carry provider credentials in plaintext. This adds a `Redactor` spec rendered next to the existing support-bundle spec — same `troubleshoot.sh/kind: support-bundle` discovery label, `redactor-spec` data key — masking the key value with `***HIDDEN***` while keeping the surrounding structure readable.

[sc-569079]

## Validation steps

- `helm template chart -s templates/support-bundle-redactor.yaml` renders correctly, both plain and with `--set replicated.enabled=true` (KOTS path discovers cluster specs by the same label).
- The rendered inner `redactor-spec` parses as valid YAML and the regex compiles.
- Regex verified against both leak shapes: escaped-JSON-in-JSON log lines and plain JSON — value masked, surrounding keys left intact; `(?i)` + `api[_-]?key` covers `apiKey`/`api_key` spellings.

## Deployment impact

New Secret in the release namespace; no values changes, no behavior change to collection — only redaction at bundle generation time.

https://claude.ai/code/session_01V5kBKpS6FDCsLUsuFtbpsB