### PR TITLE
[DO NOT MERGE] feat(chart): notifier publish fan-out via headless Service (multi-AZ POC) [sc-568556]

### DIFF
--- a/chart/templates/notifier/service-headless.yaml
+++ b/chart/templates/notifier/service-headless.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "carto.notifier.fullname" . }}-headless
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: notifier
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  # No ClusterIP on purpose: the publish fan-out needs a DNS name that resolves
+  # to every notifier pod so workspace-subscriber can deliver to each replica.
+  clusterIP: None
+  ports:
+    - port: {{ .Values.notifier.service.ports.internal }}
+      targetPort: internal
+      protocol: TCP
+      name: internal
+  selector:
+    {{- if .Values.notifier.service.labelSelectorsOverride }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.notifier.service.labelSelectorsOverride "context" $) | nindent 4 }}
+    {{- else }}
+    {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: notifier
+    {{- end }}

--- a/chart/templates/workspace-subscriber/configmap.yaml
+++ b/chart/templates/workspace-subscriber/configmap.yaml
@@ -74,7 +74,8 @@ data:
   WORKSPACE_PUBSUB_DATA_UPDATES_TOPIC: "projects/{{ .Values.cartoConfigValues.selfHostedGcpProjectId }}/topics/data-updates"
   WORKSPACE_PUBSUB_EVENT_BUS_SUBSCRIPTION: "projects/{{ .Values.cartoConfigValues.selfHostedGcpProjectId }}/subscriptions/event-bus-workspace-sub"
   WORKSPACE_PUBSUB_TENANT_BUS_SUBSCRIPTION: "projects/{{ .Values.cartoConfigValues.selfHostedGcpProjectId }}/subscriptions/tenant-bus-sub"
-  WORKSPACE_NOTIFIER_PUBLISH_URL: "http://{{ include "carto.notifier.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.notifier.service.ports.internal }}/publish/"
+  WORKSPACE_NOTIFIER_PUBLISH_URL: "http://{{ include "carto.notifier.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.notifier.service.ports.internal }}/publish/"
+  WORKSPACE_NOTIFIER_PUBLISH_FANOUT: "true"
   WORKSPACE_PUBSUB_TENANT_BUS_TOPIC: "projects/{{ .Values.cartoConfigValues.selfHostedGcpProjectId }}/topics/tenant-bus"
   WORKSPACE_TENANT_ID: {{ .Values.cartoConfigValues.selfHostedTenantId | quote }}
   WORKSPACE_THUMBNAILS_BUCKET: {{ .Values.appConfigValues.workspaceThumbnailsBucket | quote }}


### PR DESCRIPTION
# Description

Shortcut

- Autolink: [sc-568556]

POC companion to CartoDB/cloud-native#27638 — do not merge while the approach is under
evaluation.

Pushpin instances don't exchange published messages, so with `notifier.replicaCount > 1`
a publish through the ClusterIP Service reaches one replica and clients held by the
other replicas silently miss it. The candidate fix is publisher-side fan-out: this adds
a headless Service over the notifier pods (per-pod DNS on the publish port) and points
workspace-subscriber at it, enabling its flag-gated broadcast
(`WORKSPACE_NOTIFIER_PUBLISH_FANOUT`, added in the companion PR).

Backward compatible by construction: images without the fan-out code ignore the flag,
and resolving the headless name yields one pod per connection — the same one-random-pod
behavior as today's ClusterIP path. No values.yaml or KOTS changes: the flag is not
customer-facing, so the whole change is two chart templates and renders identically in
both the Helm and Replicated paths.

## Type of change

- [ ] Fix
- [x] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Documentation
- [ ] Security
- [ ] Chore

## Acceptance

Please describe how to validate the feature or fix

1. `helm template chart --show-only templates/notifier/service-headless.yaml` — renders a `clusterIP: None` Service selecting the notifier pods, port `internal` (5561)
2. `helm template chart --show-only templates/workspace-subscriber/configmap.yaml` (plain and `--set replicated.enabled=true`) — `WORKSPACE_NOTIFIER_PUBLISH_URL` targets the `-headless` name and `WORKSPACE_NOTIFIER_PUBLISH_FANOUT: "true"` is present
3. On a cluster with `notifier.replicaCount: 2`: `dig <release>-carto-notifier-headless.<ns>.svc.cluster.local` from any pod returns one A record per notifier pod

## Basic checklist

- [x] Good PR name
- [x] Shortcut link
- [x] Just one issue per PR
- [ ] GitHub labels
- [ ] Proper status & reviewers
- [ ] Tests
- [ ] Documentation
