### PR TITLE
chore(selfhosted): decouple exports bucket config from storageBucketsBehaviour (RFC) [sc-571305]

### DIFF
--- a/manifests/kots-config.yaml
+++ b/manifests/kots-config.yaml
@@ -587,23 +587,23 @@ spec:
           type: bool
           default: "1"
 
-        # Exports GCP
+        # Exports GCP — warehouse-scoped: BigQuery can only stage exports through
+        # GCS, so this applies on every platform storage provider, not just GCS.
         - name: storageBucketsExportGcp
-          title: Exports Bucket
-          help_text: |- 
-            Bucket name to store exported data. Leave it blank to disable exports.
+          title: GCS exports bucket
+          help_text: |-
+            GCS bucket used to stage BigQuery exports (required for BigQuery exports on any storage provider) and, when GCS is the storage provider, to store exported data. Leave it blank to disable exports.
           type: text
-          when: '{{repl (ConfigOptionEquals "storageBucketsBehaviour" "custom_gcs") }}'
           required: false
           default: repl{{ if ConfigOptionEquals "replicatedLicenseType" "dev"}}repl{{ print (ConfigOption "derivedSelfHostedGCPProjectId") "-export-storage"}}repl{{ end }}
             
 
-        # Exports for AWS
+        # Exports for AWS — warehouse-scoped: Snowflake and Redshift stage exports
+        # through S3, so this applies on every platform storage provider.
         - name: storageBucketsExportAws
           title: AWS exports bucket name
-          help_text: Bucket name to store exported data. Leave it blank to disable exports.
+          help_text: S3 bucket used to stage Snowflake and Redshift exports (on any storage provider) and, when AWS S3 is the storage provider, to store exported data. Leave it blank to disable exports.
           type: text
-          when: '{{repl (ConfigOptionEquals "storageBucketsBehaviour" "custom_aws_s3") }}'
           required: false
         - name: storageBucketsImportExportAwsArnRole
           title: AWS arn bucket role
@@ -611,7 +611,22 @@ spec:
             A AWS arn role must be provided. Check the following instructions for [Redshift](https://docs.carto.com/carto-self-hosted/guides/configure-your-own-buckets#configuration-for-redshift) or [Snowflake](https://docs.carto.com/carto-self-hosted/guides/configure-your-own-buckets#configuration-for-snowflake) 
            
           type: text
-          when: '{{repl (ConfigOptionEquals "storageBucketsBehaviour" "custom_aws_s3") }}'
+          required: false
+
+        # Dedicated credentials for the S3 exports bucket, needed only when the
+        # platform storage provider is not AWS S3 (the platform AccessKey items
+        # are hidden there and can't be reused).
+        - name: storageBucketsExportAwsAccessKeyId
+          title: AccessKey ID for the S3 exports bucket
+          help_text: Only needed when AWS S3 is not the storage provider — otherwise the storage AccessKey is reused.
+          type: text
+          when: '{{repl and (not (ConfigOptionEquals "storageBucketsBehaviour" "custom_aws_s3")) (not (empty (ConfigOption "storageBucketsExportAws"))) }}'
+          required: false
+        - name: storageBucketsExportAwsAccessKeySecret
+          title: AccessKey Secret for the S3 exports bucket
+          help_text: Only needed when AWS S3 is not the storage provider — otherwise the storage AccessKey is reused.
+          type: password
+          when: '{{repl and (not (ConfigOptionEquals "storageBucketsBehaviour" "custom_aws_s3")) (not (empty (ConfigOption "storageBucketsExportAws"))) }}'
           required: false
 
     # Advanced Config

--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -322,15 +322,17 @@ spec:
             value: '{{repl ConfigOption "storageBucketsAwsAccessKeySecret" }}'
         appConfigValues:
           importAwsRoleArn: '{{repl ConfigOption "storageBucketsImportExportAwsArnRole" }}'
-    ## Snowflake and Redshift exports
+    ## Snowflake and Redshift exports. Credentials: the dedicated exports
+    ## AccessKey wins; on custom_aws_s3 it is hidden, so the platform storage
+    ## AccessKey is reused as before.
     - when: '{{repl not (empty (ConfigOption "storageBucketsExportAws")) }}'
       recursiveMerge: true
       values:
         appSecrets:
           exportAwsSecretAccessKey:
-            value: '{{repl ConfigOption "storageBucketsAwsAccessKeySecret" }}'
+            value: '{{repl or (ConfigOption "storageBucketsExportAwsAccessKeySecret") (ConfigOption "storageBucketsAwsAccessKeySecret") }}'
           exportAwsAccessKeyId:
-            value: '{{repl ConfigOption "storageBucketsAwsAccessKeyId" }}'
+            value: '{{repl or (ConfigOption "storageBucketsExportAwsAccessKeyId") (ConfigOption "storageBucketsAwsAccessKeyId") }}'
         appConfigValues:
           exportAwsRoleArn: '{{repl ConfigOption "storageBucketsImportExportAwsArnRole" }}'
           awsExportBucket: '{{repl ConfigOption "storageBucketsExportAws" }}'


### PR DESCRIPTION
> **RFC — draft for discussion, post-September-freeze.** This PR exists so the team can review a concrete proposal; scope and defaults are open questions, not settled decisions.

**Description of the change**

The app resolves export buckets **per warehouse**, coexisting on any platform storage provider: the GCS exports bucket stages BigQuery exports (maps-api/sql-worker read it on every provider) and the AWS exports bucket stages Snowflake/Redshift exports. The KOTS layer contradicts that model by gating each item on `storageBucketsBehaviour`, so a customer can only ever configure the export bucket that matches their platform storage — an Azure or S3 customer cannot enable BigQuery exports, and a GCS customer cannot configure the Snowflake/Redshift staging bucket.

This proposal:

- Removes the `storageBucketsBehaviour` gate from `storageBucketsExportGcp` and `storageBucketsExportAws` (+ `storageBucketsImportExportAwsArnRole`), and rewrites their help texts to say which warehouse path each serves.
- Adds `storageBucketsExportAwsAccessKeyId` / `storageBucketsExportAwsAccessKeySecret`, shown only when the exports bucket is set on a non-S3 platform — the existing platform AccessKey items are hidden there, so the exports bucket had no credential source. The `kots-helm.yaml` mapping coalesces: dedicated exports key first, platform storage key as the existing fallback.
- Deliberately does **not** touch the Azure exports container (#934): `EXPORTS_AZURE_CONTAINER_NAME` is the platform-exports container, read only when the platform provider is Azure Blob — it is platform-scoped, not warehouse-scoped, so `when: custom_azb` remains correct for it.

**Benefits**

- The KOTS UI can express the coexistence the app and chart already support (chart renders all exports vars unconditionally; plain-Helm installs can already set both).
- BigQuery exports become configurable on Azure/S3 platform installs **on the legacy SQL-export-jobs path** (maps-api / sql-worker), which resolves the GCS bucket per warehouse on any platform provider.

**Important scoping caveat — the two export engines differ today.** The new DuckDB engine (import-api `/v3/exports`) stages through the *platform* storage container and, since cloud-native#28017, rejects BigQuery exports outright whenever the platform provider is not GCS (`data-exports/index.ts` guards on `storage.provider !== 'gcp'`, regardless of whether a GCS exports bucket is configured). So this decoupling only fully pays off once the engine gains decoupled GCS staging — the "real work" #28017 explicitly deferred. That app-side change (stage BigQuery through `EXPORTS_GCS_BUCKET_NAME` + the platform SA credentials when the platform provider is not GCS, and only reject when no staging bucket is available) is a prerequisite for the new-engine half of this story.

**Possible drawbacks / open questions (the discussion)**

1. Two more visible items on every install's storage section — is the added surface worth it for how rare cross-provider warehouses are (BigQuery on non-GCP was called "extremely rare")?
2. The exports-credentials coalesce (`or` of dedicated and platform keys) — acceptable, or should the mapping be two explicit conditional blocks?
3. Should the GCS exports item keep its dev-license default now that it is visible on every behaviour (it already fired on every behaviour before)?
4. Docs impact: the SH buckets guide describes exports per provider; decoupling changes that narrative.

**Applicable issues**

- [sc-571305]

**Additional information**

Manifests-only (`kots-config.yaml`, `kots-helm.yaml`); the chart is untouched — it already renders every exports var unconditionally. Validated with `scripts/test-kots-config.sh all` (static; the `accessToCartoModeK8sNotFullySupported` warning is pre-existing on main). Behavioural validation of the KOTS `when:`/default changes needs a `release-changes` install. May need a trivial rebase after #934 (adjacent lines in the same sections).
