### PR TITLE
chore(selfhosted): set workspace-www image tag to 2026.7.16-patch1 [sc-571406]

### DIFF
--- a/.github/actions/publish-release/action.yaml
+++ b/.github/actions/publish-release/action.yaml
@@ -14,9 +14,12 @@ inputs:
   trigger-action:
     description: "Action that triggered the release"
     required: true
-  gcloud-service-account:
-    description: "Service account key for Google Cloud"
-    required: true
+  workload-identity-provider:
+    description: "Workload Identity Federation provider resource name for Google Cloud auth"
+    default: projects/1086647180948/locations/global/workloadIdentityPools/github-actions-pool/providers/github-carto-selfhosted-helm
+  service-account:
+    description: "Service account email to impersonate via Workload Identity Federation"
+    default: github-actions-artifacts@carto-artifacts.iam.gserviceaccount.com
   replicated-api-token:
     description: "API token for Replicated"
     required: true
@@ -41,7 +44,8 @@ runs:
     - name: Google Cloud Auth
       uses: google-github-actions/auth@v2
       with:
-        credentials_json: ${{ inputs.gcloud-service-account }}
+        workload_identity_provider: ${{ inputs.workload-identity-provider }}
+        service_account: ${{ inputs.service-account }}
         project_id: ${{ inputs.artifacts-gcp-project-id }}
 
     # Step 2: Install Gcloud CLI

--- a/.github/workflows/branch-changes-release.yaml
+++ b/.github/workflows/branch-changes-release.yaml
@@ -12,6 +12,11 @@ jobs:
       )
     timeout-minutes: 3
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,7 +52,6 @@ jobs:
           version: ${{ steps.generate-channel-info.outputs.version }}
           release-notes: "CARTO Self-Hosted dev version generated from branch ${{ steps.generate-channel-info.outputs.channel-name }}"
           trigger-action: "dev"
-          gcloud-service-account: ${{ secrets.CARTO_ARTIFACTS_SERVICE_ACCOUNT }}
           replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}
       
       - name: Comment on PR

--- a/manifests/kots-helm.yaml
+++ b/manifests/kots-helm.yaml
@@ -198,6 +198,7 @@ spec:
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "registry.self-hosted.carto.com/proxy/carto/gcr.io/carto-onprem-artifacts" }}'
     workspaceWww:
       image:
+        tag: "2026.7.16-patch1"
         registry: '{{repl HasLocalRegistry | ternary LocalRegistryHost "registry.self-hosted.carto.com/proxy/carto/gcr.io/carto-onprem-artifacts" }}'
     workspaceMigrations:
       image:


### PR DESCRIPTION
Between-release patch: pin `workspace-www` to the `2026.7.16-patch1` image (Google Maps `region` fix for locale-correct place names), for delivery via a Replicated patch channel off the 1.280.1 chart.

Branched from tag `1.280.1` (app 2026.7.16), not `main` — this is a patch-channel branch, not to be merged; it's torn down on close. [sc-571406]