### PR TITLE
fix(chart): pin aiproxy to one uvicorn worker to stop the boot crash loop [sc-571269]

### DIFF
--- a/chart/templates/aiproxy/configmap.yaml
+++ b/chart/templates/aiproxy/configmap.yaml
@@ -47,6 +47,9 @@ data:
   LITELLM_LOG_LEVEL: {{ ternary "DEBUG" "INFO" (eq .Values.appConfigValues.logLevel "debug") | quote }}
   LITELLM_MIGRATION_DIR: "/app/migrations"
   LITELLM_MODE: "PRODUCTION"
+  # Pin to one worker: the entrypoint derives two from the CPU limit and the pair
+  # crash-loops at boot. Override via aiProxy.extraEnvVars.
+  LITELLM_NUM_WORKERS: "1"
   LITELLM_REDIS_DB: "1"
   LITELLM_REDIS_HOST: {{ include "carto.redis.host" . | quote }}
   LITELLM_REDIS_PORT: {{ include "carto.redis.port" . | quote }}


### PR DESCRIPTION
## Problem

Since the litellm image began deriving its uvicorn worker count from the cgroup CPU limit, the aiproxy default `resources.limits.cpu: 2000m` yields two workers. With two workers the container crash-loops at boot: a child dies ~10-15 ms after each spawn (no traceback, before serving), and is relaunched indefinitely at a ~5.52 s cadence. Those lines go to stderr, so Cloud Logging classifies them as ERROR at a high rate. One pod in four wins the boot and stays healthy with both workers, which points to a two-worker startup race.

This is not install-specific: `chart/templates/aiproxy/deployment.yaml` gates only on `appConfigValues.aiFeaturesEnabled`, and `2000m` is the chart default, so every self-hosted install with AI features enabled and stock resources is exposed.

## Fix

`LITELLM_NUM_WORKERS: "1"`. The image entrypoint honors this env var and skips the CPU-derived count, so a single worker starts and stays up: a lone worker cannot lose a startup race to a sibling.

The managed-deployment investigation (CartoDB/cloud-native#26177, sc-560878) measured worker configs on repeated fresh boots. Both `LITELLM_NUM_WORKERS=1` alone and `PRISMA_HEALTH_WATCHDOG_ENABLED=false` alone scored 0 crashes; that PR names `LITELLM_NUM_WORKERS=1` as the fallback "also 0-crash" lever. Pinning workers therefore covers both candidate mechanisms for this bug (a pure two-worker boot race, and boot-time watchdog/libuv contention between two engines) while keeping the watchdog's proactive DB reconnect for every install.

## Why not disable the watchdog here

That is the managed-deployment fix, but its observed symptom differs: there the Prisma health *engine* is killed producing `ClientNotConnectedError` 5xx (the worker survives), on the watchdog's ~30 s cycle. The self-hosted symptom is the *worker* dying ~10-15 ms after spawn with no 5xx (probes stay 200), which is before the watchdog runs. Disabling the watchdog is the larger, harder-to-reverse lever (it removes a proactive health mechanism for every self-hosted AI install) and would not address a worker-death-at-init race. Pinning workers is the smaller, on-symptom lever that also covers the watchdog case.

The worker-count pin and Prisma-pool cut from CartoDB/cloud-native#26319 are separately not applicable: they addressed Cloud Run boot-boost over-spawn and shared-instance Postgres saturation, neither of which exists self-hosted (stable cgroup read; dedicated DB).

## Caveat: mechanism not yet confirmed against the customer's boot log

The precise mechanism is not proven for this install. The story's `t=0` boot log (requested by Support) would confirm whether the crash is a pure worker race or watchdog contention. The chosen lever holds either way, which is why it is preferred over the mechanism-specific watchdog disable. Applying `LITELLM_NUM_WORKERS=1` via `aiProxy.extraEnvVars` on the affected install and seeing the loop stop is itself the confirmation.

## Placement and override

Hardcoded literal in `chart/templates/aiproxy/configmap.yaml`, matching the existing internal-default convention there (`LITELLM_MODE`, `LITELLM_NON_ROOT`). Not customer-set config, so no `values.yaml` `@param`, no README regeneration, and no KOTS wiring. Consumed via `envFrom`, and a customer's `aiProxy.extraEnvVars` entry renders under container `env:` (which Kubernetes gives precedence over `envFrom`), so an install that boots cleanly with more workers can raise the count (or set an empty value to restore auto-detection) without a chart change.

## Validation

- `helm template` renders the key once in the plain-Helm and `--set replicated.enabled=true` paths.
- `values.yaml` untouched, so the README drift check is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)