### PR TITLE
fix(router): keep the metrics sidecar alive while nginx drains [sc-572315]

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5904,6 +5904,18 @@ routerMetrics:
   ## @param routerMetrics.customStartupProbe Custom startupProbe that overrides the default one
   ##
   customStartupProbe: {}
+  ## @skip routerMetrics.lifecycleHooks [object] for the router-metrics container to automate configuration before or after startup
+  ## @skip routerMetrics.lifecycleHooks.preStop.exec.command
+  ## The sidecar must outlive router-http's preStop (sleep 30 && nginx -s quit): every request nginx
+  ## serves while draining logs a usage line to this container, which only flushes them on SIGTERM.
+  ##
+  lifecycleHooks:
+    preStop:
+      exec:
+        command:
+          - /bin/sh
+          - "-c"
+          - "sleep 60"
 
 gateway:
   ## @param gateway.enabled Enable gateway api.


### PR DESCRIPTION
**Description of the change**

Adds a `preStop` hook to the `router-metrics` sidecar (`routerMetrics.lifecycleHooks`, default `sleep 60`) so it outlives `router-http`'s existing `preStop` (`sleep 30 && nginx -s quit`).

Today the two containers get SIGTERM together but shut down on different clocks. nginx keeps serving for 30 s (the load balancer is still sending it traffic while endpoints drain) and then finishes in-flight requests; the metrics sidecar has no preStop, so it flushes what it holds and exits within a second. Every usage line nginx logs during that drain is sent to a UDP port with no listener and is lost.

Observed on a test tenant during a rolling update: the sidecar logged `process finished` 1.8 s after SIGTERM, and a request served 8 s later returned 200 but never reached the usage table.

**Why a `preStop` sleep, and why 60 s**

When a pod is deleted, the kubelet runs each container's `preStop` and then sends it SIGTERM, for all containers in parallel, with no ordering between them; the pod-wide `terminationGracePeriodSeconds` clock covers hook plus shutdown. The classic pod API has no way to say "this container must outlive that one", so the dependency has to be expressed as time. That is also why `router-http` and `http-cache` already carry a `sleep` in their hooks: the load balancer removes the endpoint asynchronously, and the sleep keeps serving until it has. This change applies the same, established pattern to the container that observes nginx.

Sizing: nginx stops accepting at 30 s and then completes in-flight requests. How long that can take is set per API in the router image, not by nginx's default: `proxy_read_timeout` is 60 s for the Maps API, 180 s for LDS, 300 s for AI, the AI proxy and MCP, and 7 d for the notifier's long-lived connections. nginx writes the usage line when a request completes, so the hook has to outlive the completions it wants to count. A 60 s hook covers the drain plus 30 s of in-flight completion: any request whose upstream answers within 30 s of the quit is counted, whichever API it hits. What it does not cover is the long tail — a Maps API query that takes longer than that, an LDS, AI or MCP request running towards its 180–300 s timeout, and notifier connections. Those complete after the sidecar has exited and their usage lines are lost; they are the residual listed under drawbacks. Going higher would trade another 30 s on every router pod termination for a slice of that tail. The sidecar's own shutdown flush needs at most a further two minutes if Pub/Sub is unreachable, so 60 s plus flush stays well inside the 300 s grace period.

Alternatives considered:

- **Native sidecar containers** (`initContainers` with `restartPolicy: Always`, beta in Kubernetes 1.29, GA in 1.33). The kubelet starts them before the main containers and terminates them only after all main containers have exited. This states the dependency instead of estimating it and is the right end state. It needs the chart's supported Kubernetes minimum to move up and `router-metrics` to move into `initContainers`, where its readiness starts to gate the pod's, so it is a separate, versioned change rather than a fix.
- **A hook that waits for the nginx process** needs `shareProcessNamespace: true` on the pod. Exact, but it widens the boundary between two containers one of which is deliberately locked down (non-root, read-only root filesystem, all capabilities dropped).
- **Polling the nginx listening port** does not work: nginx closes its listeners at the start of `quit`, before in-flight requests finish.
- **Handling it in the sidecar's code** (keep listening after SIGTERM until lines stop arriving) moves pod-lifecycle policy into the application and is still a heuristic. Container ordering belongs in the pod spec.

The hook uses `exec` with `/bin/sh` like the other hooks in the chart; Kubernetes 1.30+ also offers a native `lifecycle.preStop.sleep` action that needs no shell, worth switching to across the chart once that is the minimum.

**Benefits**

- No metered traffic lost on rolling updates, `helm upgrade`, node drains or Spot preemptions. Today each of those drops up to 30 s of a tenant's requests, silently.
- Aligns the sidecar's lifetime with the container it exists to observe, using the pattern the chart already relies on for nginx and Varnish.

**Possible drawbacks**

- Router pod termination takes about 60 s instead of about 30 s. There is no availability impact: the deployment's rolling update brings the new pod to Ready before the old one is signalled, so the extra time only delays the old pod's removal, and a `helm upgrade` converges about 30 s later per router replica.
- Requests that complete more than ~30 s after nginx starts quitting are not covered: a slow Maps API query, LDS (`proxy_read_timeout` 180 s), AI / MCP (300 s) and notifier connections that finish after the sidecar has exited log to a closed port. Before this change nothing in the drain window was covered.
- The value is an estimate by construction; native sidecars (above) are what removes the estimate.

**Applicable issues**

- [sc-572315]
- Companion to CartoDB/cloud-native#28285, which fixes the aggregator's own holding and flush behaviour. The two are independent: this change is worth shipping on today's images, and that PR does not depend on it.

**Additional information**

How nginx gets to drain at all. After a `preStop` returns, the kubelet sends SIGTERM to the container's PID 1, and nginx treats TERM as a fast shutdown, so on its own the sequence `quit` → SIGTERM would drop in-flight requests right at 30 s. It does not, because PID 1 in `router-http` is `/bin/sh`, not nginx: the container `args` are a YAML block scalar (`|`) and end with a newline, which stops busybox `ash` from exec'ing its last command, so the shell stays PID 1 with nginx as a child, and the kernel drops a TERM sent to a PID 1 that has no handler for it. nginx never sees the signal and drains until its in-flight requests finish or the grace period ends. Verified with the release image, the exact rendered `args` and an in-flight 20 s request: with the trailing newline, `quit` then TERM lets the request complete and the container exits 0; without it — or with `exec` in the command — nginx is PID 1 and the same sequence cuts the request immediately. This PR relies on that behaviour and does not change it. Changing `|` to `|-` or adding `exec` to the router command would turn the drain into a fast kill at 30 s and take the sidecar's second 30 s with it.

Validation: `helm template` on both the plain and the `replicated.enabled=true` paths renders the hook on the `router-metrics` container next to the existing one on `router-http`; `helm lint` passes; `chart/README.md` is unchanged because the parameter is `@skip`, matching `router.lifecycleHooks`.

Tested on a test tenant with the same hook applied to the live deployment. A `rollout restart` under a burst of one request every 3 s: the sidecar logged `process finished` 61.8 s after the `Killing` event, its flushed bucket carried the 20 requests served before the signal plus the one nginx served while draining, and the new pod's first regular bucket carried the remaining 39. 60 requests sent, 60 counted. The same restart without the hook, earlier the same day, lost the request served 8 s after the signal.

https://claude.ai/code/session_01SJjm4YGPwkn5GVc1acrFw4
