### PR TITLE
docs(selfhosted): document minKotsVersion intent and release-note rule

### DIFF
--- a/manifests/kots-app.yaml
+++ b/manifests/kots-app.yaml
@@ -27,6 +27,10 @@ spec:
     - '{{repl if ConfigOptionEquals "aiFeaturesEnabled" "1" }}deployment/carto-ai-api{{repl else}}{{repl end }}'
     - '{{repl if ConfigOptionEquals "aiFeaturesEnabled" "1" }}deployment/carto-aiproxy{{repl else}}{{repl end }}'
     - '{{repl if ConfigOptionEquals "publicEventsApiEnabled" "1" }}deployment/carto-public-events-api{{repl else}}{{repl end }}'
+  # Minimum KOTS Admin Console version customers must run. The Admin Console
+  # blocks a CARTO upgrade when the installed KOTS is below this value.
+  # If you raise it, note the required KOTS upgrade in that release's Self-Hosted
+  # release notes (docs.carto.com/carto-self-hosted/release-notes).
   minKotsVersion: 1.117.3
   additionalImages:
     - gcr.io/carto-onprem-artifacts/tenant-requirements-checker:2025.6.10


### PR DESCRIPTION
## Description

Adds a comment above `minKotsVersion` in `manifests/kots-app.yaml` documenting (1) what it enforces — the KOTS Admin Console blocks a CARTO upgrade when the installed KOTS is below this value — and (2) the process rule: when the value is raised, the required KOTS upgrade must be called out in that release's Self-Hosted release notes.

Puts the reminder at the source, where the change actually happens. `minKotsVersion` moves rarely (~4 times in ~2 years), so a per-release checklist item would be noise; a source comment fires exactly when someone edits the line.

Companion to the docs rework in `gitbook-documentation` that fixes the KOTS Admin Console upgrade section (it previously told users to install a KOTS version from the release notes that was never published).

**Comment only — no value change**, so both Helm and KOTS render paths are unaffected.

## Type of change

- [x] Documentation (comment)

https://claude.ai/code/session_01HsXtv7A3XqmCNFyUpYfVPE